### PR TITLE
Replace references to curl GraphQL requests with GraphiQL queries

### DIFF
--- a/administrator-documentation/moderne-dx/how-to-guides/configure-dx-org-service.md
+++ b/administrator-documentation/moderne-dx/how-to-guides/configure-dx-org-service.md
@@ -55,7 +55,7 @@ java -jar moderne-dx-{version}.jar \
 
 ## Confirming it works
 
-After starting up Moderne DX again, you can now make a curl call to `https://<moderne-dx-url>/graphiql` with the following query:
+After starting up Moderne DX again, you can now make the following GraphQL query using the embedded GraphiQL IDE found at `https://<moderne-dx-host>:8080/graphiql`:
 
 ```graphql
 query orgs {
@@ -78,13 +78,6 @@ query orgs {
 }
 ```
 
-Here's an example of what this call might look like:
-
-{% code overflow="wrap" %}
-```bash
-curl -X POST -H "Content-Type: application/json" -d '{"query":"query orgs { organizations { id repositoriesPages { count edges { node { origin path branch } } } parent { id } } }"}' https://<moderne-dx-url>/graphql
-```
-{% endcode %}
 
 If you run this immediately after startup, you may get no results. Once your index operation is completed, you will get results similar to the following:
 
@@ -139,7 +132,7 @@ Once you've configured all of the above things, you can use the Moderne CLI (mod
 This command will set your Moderne location to your internally-deployed Moderne DX installation:
 
 ```bash
-mod config moderne edit --token=<token> --api=https://<moderne-dx> http://<moderne-dx>
+mod config moderne edit --token=<token> --api=https://<moderne-dx-host>:8080 http://<moderne-dx-host>:8080
 ```
 
 This command will ask Moderne DX for all repositories inside the organization you selected and clone them to `<path>`:

--- a/administrator-documentation/moderne-dx/how-to-guides/configure-dx-with-artifactory-access.md
+++ b/administrator-documentation/moderne-dx/how-to-guides/configure-dx-with-artifactory-access.md
@@ -74,7 +74,7 @@ java -jar moderne-dx-{version}.jar \
 
 ## Confirming it works
 
-After starting up Moderne DX, it will then ask your artifact repository for LST artifacts. This process can take several minutes. You can test it worked by making a curl command to `https://<moderne-dx-url>/graphql` with the following query:
+After starting up Moderne DX, it will then ask your artifact repository for LST artifacts. This process can take several minutes. You can test it worked by making the following GraphQL query using `https://<moderne-dx-host>:8080/graphiql`:
 
 ```graphql
 query orgs {
@@ -97,13 +97,6 @@ query orgs {
 }
 ```
 
-Here's an example of what this call might look like:
-
-{% code overflow="wrap" %}
-```bash
-curl -X POST -H "Content-Type: application/json" -d '{"query":"query orgs { organizations { id repositoriesPages { count edges { node { origin path branch } } } parent { id } } }"}' https://<moderne-dx-url>/graphql
-```
-{% endcode %}
 
 If you run this immediately after startup, you may get no results. Once your index operation is completed, you will get results similar to the following:
 

--- a/administrator-documentation/moderne-dx/how-to-guides/deploying-recipe-artifacts-in-moderne-dx.md
+++ b/administrator-documentation/moderne-dx/how-to-guides/deploying-recipe-artifacts-in-moderne-dx.md
@@ -1,6 +1,6 @@
 # Deploying recipe artifacts in Moderne DX
 
-To deploy recipe artifacts into Moderne DX, you will make a POST request to `<moderne-dx>/graphql` in the following format:
+To deploy recipe artifacts into Moderne DX, you can make a GraphQL mutation using `https://<moderne-dx-host>:8080/graphiql` similar to the following:
 
 ```graphql
 mutation loadRecipes {
@@ -14,4 +14,7 @@ mutation loadRecipes {
 }
 ```
 
-You will need to set an `Authorization` header of the format `Bearer <token you set up when configuring DX>`.
+In order to execute GraphQL mutations, it is required that an `Authorization` HTTP header be included in the request. You can set the header value in GraphiQL's _Headers_ tab as a JSON object:
+```shell
+{"Authorization": "Bearer <access token used to configure DX>"}
+```


### PR DESCRIPTION
- replaced references to making GraphQL queries using `curl` with `/graphiql`
- replaced referencs to `moderne-dx-url` with more appropriate `moderne-dx-host` as URLs include HTTP schemes
- added port 8080 to example DX URLs as this is the default port DX (netty) listens on