### PR TITLE
Use `${user.home}` instead of `~` for agent local repository config

### DIFF
--- a/docs/administrator-documentation/moderne-platform/how-to-guides/agent-configuration/configure-an-agent-with-maven-repository-access.md
+++ b/docs/administrator-documentation/moderne-platform/how-to-guides/agent-configuration/configure-an-agent-with-maven-repository-access.md
@@ -101,7 +101,7 @@ If you want to configure a [Moderne DevCenter](../dev-center.md), you will need 
 docker run \
 # ... Existing variables
 -e MODERNE_AGENT_MAVEN_0_URL=https://myartifactory.example.com/artifactory/libs-releases-local \
--e MODERNE_AGENT_MAVEN_0_LOCALREPOSITORY=~/.moderne-maven \
+-e MODERNE_AGENT_MAVEN_0_LOCALREPOSITORY=${user.home}/.moderne-maven \
 -e MODERNE_AGENT_MAVEN_0_USERNAME=admin \
 -e MODERNE_AGENT_MAVEN_0_PASSWORD=password \
 # ... Additional variables
@@ -115,7 +115,7 @@ docker run \
 | Argument Name                                    | Required                                              | Default            | Description                                                                                                                                                           |
 |--------------------------------------------------|-------------------------------------------------------|--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 |`--moderne.agent.maven[{index}].url`              | `true`                                                |                    | The URL of your Maven repository.                                                                                                                                     |
-| `--moderne.agent.maven[{index}].localRepository` | `true`                                                | `~/.moderne-maven` | The path on disk where LST artifacts and Maven index files will be downloaded to. This is on the disk where the agent is being run and **not** on the Maven instance. <br/><br/> LST artifacts are deleted from this location after they are transmitted to Moderne. Index files will remain behind to be used to detect diffs in the artifacts. <br/><br/> If multiple Maven repositories are configured on the agent, they **must** have different local repositories configured. |
+| `--moderne.agent.maven[{index}].localRepository` | `true`                                                | `${user.home}/.moderne-maven` | The path on disk where LST artifacts and Maven index files will be downloaded to. This is on the disk where the agent is being run and **not** on the Maven instance. <br/><br/> LST artifacts are deleted from this location after they are transmitted to Moderne. Index files will remain behind to be used to detect diffs in the artifacts. <br/><br/> If multiple Maven repositories are configured on the agent, they **must** have different local repositories configured. |
 | `--moderne.agent.maven[{index}].username`        | `false`                                               | `null`             | The username used to resolve artifacts.                                                                                                                               |
 | `--moderne.agent.maven[{index}].password`        | `false`                                               | `null`             | The password used to resolve artifacts.                                                                                                                               |
 | `--moderne.agent.maven[{index}].releases`        | `false`                                               | `true`             | Specifies whether or not this repository should be searched for releases.                                                                                             |
@@ -134,7 +134,7 @@ If you want to configure a [Moderne DevCenter](../dev-center.md), you will need 
 java -jar moderne-agent-{version}.jar \
 # ... Existing arguments
 --moderne.agent.maven[0].url=https://myartifactory.example.com/artifactory/libs-releases-local \
---moderne.agent.maven[0].localRepository=~/.moderne-maven \
+--moderne.agent.maven[0].localRepository=${user.home}/.moderne-maven \
 --moderne.agent.maven[0].username=admin \
 --moderne.agent.maven[0].password=password \
 # ... Additional arguments


### PR DESCRIPTION
`~` doesn't actually work and will cause problems.