### PR TITLE
Add info block for default ssh alternate url

### DIFF
--- a/docs/administrator-documentation/moderne-dx/how-to-guides/configure-dx-with-on-prem-scm.md
+++ b/docs/administrator-documentation/moderne-dx/how-to-guides/configure-dx-with-on-prem-scm.md
@@ -61,5 +61,12 @@ java -jar moderne-dx-{version}.jar \
 </Tabs>
 
 :::info
-If the base url uses http(s) protocol and no alternate URLs are specified, we assume the default ssh url for the scm service. 
+If you provide a base URL that uses the HTTP(S) protocol **and** you do not provide any alternate URLs, then we will create an SSH URL for your SCM service based on your base URL.
+
+For example, if you only provide the following:
+```
+java -jar moderne-dx-{version}.jar \
+--moderne.dx.scm[0].baseUrl=https://bitbucket.example.com/stash
+```
+Then we will assume the SSH URL for your SCM service is `ssh://bitbucket.example.com:7999`.
 :::

--- a/docs/administrator-documentation/moderne-dx/how-to-guides/configure-dx-with-on-prem-scm.md
+++ b/docs/administrator-documentation/moderne-dx/how-to-guides/configure-dx-with-on-prem-scm.md
@@ -59,3 +59,7 @@ java -jar moderne-dx-{version}.jar \
 ```
 </TabItem>
 </Tabs>
+
+:::info
+If the base url uses http(s) protocol and no alternate URLs are specified, we assume the default ssh url for the scm service. 
+:::


### PR DESCRIPTION
This adds a note that by default we do assume a default ssh url in DX when only an http(s) url is provided.