### PR TITLE
Updating devCenter Json to include the version

### DIFF
--- a/docs/administrator-documentation/moderne-dx/how-to-guides/devcenter-yaml.md
+++ b/docs/administrator-documentation/moderne-dx/how-to-guides/devcenter-yaml.md
@@ -130,6 +130,7 @@ devCenterConfiguration:
 
 1. **name**: The name of your Organization. (String)
 2. **devCenterConfiguration**: Contains the configuration options for the DevCenter.
+    * version: An integer referencing the version of the DevCenter which is being used, should be set to `1` 
     * [upgradesAndMigrations](#upgradesandmigations): A list that defines what update and migration cards should exist for this DevCenter (e.g., Spring Boot 3 upgrade or Java 21 upgrade).
     * [security](#security): If provided, will add a security section to the DevCenter that allows you to track security issues that haven't been resolved (e.g., remediating OWASP failures).
 

--- a/docs/administrator-documentation/moderne-platform/how-to-guides/dev-center.md
+++ b/docs/administrator-documentation/moderne-platform/how-to-guides/dev-center.md
@@ -97,7 +97,8 @@ You must ensure that the measure recipes return disjointed results (i.e., the sa
 For example, if you were tracking Java versions, you may have a repository that contains some code that uses Java 8, 11, and 17. However, you should ensure that your measure recipes only return this repository once.
 :::
 
-Each card can have up to **three measures**. These measures should be returned in a specific order; with the most urgent being returned first and the least urgent being returned last. In the `Spring Boot 3.2` example, you might have: `Major`, `Minor`, and `Patch` returned in that specific order.
+Each card can have up to **three measures**. These measures should be returned in a specific order; with the most urgent being returned first and the least urgent being returned last. 
+In the `Spring Boot 3.2` example, you might have: `Major`, `Minor` and `Completed` returned in that specific order.
 
 :::warning
 If you change any part of any measure on a card (such as the name of the measure or what recipe it should run), you will lose all results for the card until the next rebuild of the DevCenter.
@@ -113,6 +114,7 @@ If you change any part of any measure on a card (such as the name of the measure
 [
   {
     "devCenter": {
+      "version": 1,
       "upgradesAndMigrations": [
         {
           "title": "Spring boot 3.2",
@@ -158,7 +160,7 @@ If you change any part of any measure on a card (such as the name of the measure
               }
             },
             {
-              "name": "Patch",
+              "name": "Completed",
               "recipe": {
                 "recipeId": "org.openrewrite.java.dependencies.DependencyInsight",
                 "options": [
@@ -220,6 +222,18 @@ If you change any part of any measure on a card (such as the name of the measure
                   }
                 ]
               }
+            },
+            {
+              "name": "Completed",
+              "recipe": {
+                "recipeId": "org.openrewrite.java.search.HasJavaVersion",
+                "options": [
+                  {
+                    "name": "version",
+                    "value": "21-100"
+                  }
+                ]
+              }
             }
           ],
           "fix": {
@@ -237,6 +251,18 @@ If you change any part of any measure on a card (such as the name of the measure
                   {
                     "name": "annotationPattern",
                     "value": "@org.junit.Test"
+                  }
+                ]
+              }
+            },
+            {
+              "name": "Completed",
+              "recipe": {
+                "recipeId": "org.openrewrite.java.search.FindAnnotations",
+                "options": [
+                  {
+                    "name": "annotationPattern",
+                    "value": "@org.junit.jupiter.api.Test"
                   }
                 ]
               }

--- a/docs/user-documentation/moderne-cli/getting-started/cli-dev-center.md
+++ b/docs/user-documentation/moderne-cli/getting-started/cli-dev-center.md
@@ -59,6 +59,7 @@ For simplicity, we'll provide an example DevCenter file for you to copy below. H
 ```yaml
 name: Default
 devCenterConfiguration:
+  version: 1
   upgradesAndMigrations:
     - title: Spring Boot 3
       measures:


### PR DESCRIPTION
We don't require a version to be provided in the DevCenter Json but, we might want to encourage people to provide it as it will give them access to the "N/A" feature