### PR TITLE
fixing wording

### DIFF
--- a/docs/administrator-documentation/moderne-platform/how-to-guides/agent-configuration/configure-agent-files-service.md
+++ b/docs/administrator-documentation/moderne-platform/how-to-guides/agent-configuration/configure-agent-files-service.md
@@ -49,7 +49,7 @@ To generate this `repos.csv` file, we recommend using "[repo fetchers](https://g
 
 ### `commitOptions.txt` (optional)
 
-This is an optional file which allows you to configure custom commit options for individual repositories. By commit options, we mean the various ways that code can be committed such as only allowing pull requests for code changes –– or allowing people to commit directly to main.
+This is an optional file which allows you to configure custom commit options for individual organizations. By commit options, we mean the various ways that code can be committed such as only allowing pull requests for code changes –– or allowing people to commit directly to main.
 
 If you don't provide this file, we'll fall back to the default commit options [you specified in your agent configuration](./agent-variables.md#all-agent-configuration-variables) (if you configured that). If you didn't configure that, then we will assume that you want all commit options available to every repository. 
 


### PR DESCRIPTION
I was reread this for the nth time and I realized that the commit Options as specified at the organization level not the repository level

They are applied to every repository but the configuration is at the organization level