### PR TITLE
Revert "Document `MODERNE_CLI_CONFIG_HOME` environment variable"

### DIFF
--- a/docs/user-documentation/moderne-cli/how-to-guides/layer-config-cli.md
+++ b/docs/user-documentation/moderne-cli/how-to-guides/layer-config-cli.md
@@ -45,15 +45,6 @@ mod config build gradle arguments show
 
 Or, you can navigate to the `~/.moderne/cli/moderne.yml` file and see all of your configuration options for all commands there.
 
-:::info
-
-To share the global `moderne.yml` configuration file, you can set the `MODERNE_CLI_CONFIG_HOME` environment variable to point to a network accessible directory containing `moderne.yml`.
-
-```bash
-export MODERNE_CLI_CONFIG_HOME=/net/moderne/cli
-```
-:::
-
 If you want to delete the global arguments, you can run the commands:
 
 ```bash


### PR DESCRIPTION
Reverts moderneinc/moderne-docs#209

This feature will no longer be implemented https://github.com/moderneinc/customer-requests/issues/881#issuecomment-2752424651