### PR TITLE
feat: update DX docs show that they can run Devcenter on newer versions of the CLI

### DIFF
--- a/docs/administrator-documentation/moderne-dx/how-to-guides/configure-dx-organizations.md
+++ b/docs/administrator-documentation/moderne-dx/how-to-guides/configure-dx-organizations.md
@@ -25,8 +25,8 @@ This guide assumes that:
 The simplest way to achieve the organization structure is to supply a `repos.csv` file directly in DX.
 
 That being said, there are a few downsides of file based organization structure:
-- You cannot configure any [DevCenter](../../moderne-platform/how-to-guides/dev-center.md)
 - Organization based access control is not available
+- If you are on version 3.36.1 or earlier of the CLI, you cannot configure any [DevCenter](../../moderne-platform/how-to-guides/dev-center.md)
 
 ## Generating repos.csv
 


### PR DESCRIPTION
[This change to the CLI](https://github.com/moderneinc/moderne-cli/commit/a33e339278a3e1bd1d0344a67db296c944cda200) allows DX to run the devCenter when people are using the file system to provide their organization. Updating the document to reflect this.
- https://github.com/moderneinc/customer-requests/issues/1043

This functionality was release in the 3.37.0 version of the CLI 

- [x] Validate this reference change made it into the CLI release 