### PR TITLE
Add CLI demo video link to batch changes how-to

### DIFF
--- a/docs/user-documentation/moderne-cli/getting-started/cli-intro.md
+++ b/docs/user-documentation/moderne-cli/getting-started/cli-intro.md
@@ -80,6 +80,7 @@ Commands:
   study                Produces studies from OpenRewrite recipe data tables
                          locally.
   generate-completion  Generate bash/zsh completion script for mod.
+  batch                Add batch changes to the Moderne platform.
 
 MOD SUCCEEDED in (0.01s)
 ```

--- a/docs/user-documentation/moderne-cli/how-to-guides/batch-changes.md
+++ b/docs/user-documentation/moderne-cli/how-to-guides/batch-changes.md
@@ -11,6 +11,11 @@ The `mod batch publish` command allows users to upload repository changes, creat
 mod exec . -- find . -name '*.java' -exec sed -i '' 's/Collections.emptySet()/Set.of()/g' {} ';'
 mod batch publish . --recipe com.acme.CollectionsEmptySetToSetOf --recipe-name "Prefer Set#of over Collections#emptySet" --recipe-description "Migrate uses of java.util.Collections#emptySet to Java 9's java.util.Set#of" --recipe-run ChangeCampaign20250419 -- git diff
 ```
+:::info
+The `mod batch publish` command can run on a single git repository or recursively over a set of repositories.
+:::
+
+<ReactPlayer className="reactPlayer" url='https://www.youtube.com/watch?v=NEEDLINKAFTERITSPOSTED' controls="true" />
 
 After uploading the results, users can navigate to the batch changes activity page by clicking on **Batch Changes** in the Moderne UI's sidebar.
 
@@ -25,3 +30,7 @@ Clicking on a batch change run will display the run's results page. From there, 
   ![](./assets/batch-changes-results-page.png)
   <figcaption>_Batch changes results_</figcaption>
 </figure>
+
+## Additional information
+
+* [Learn how to commit results and issue PRs in Moderne](https://docs.moderne.io/user-documentation/moderne-platform/how-to-guides/track-commits)

--- a/docs/user-documentation/moderne-cli/how-to-guides/batch-changes.md
+++ b/docs/user-documentation/moderne-cli/how-to-guides/batch-changes.md
@@ -3,6 +3,8 @@ sidebar_label: Publishing batch change results
 description: How to publish batch change results to the Moderne platform.
 ---
 
+import ReactPlayer from 'react-player';
+
 # How to publish batch change results to the Moderne platform
 
 The `mod batch publish` command allows users to upload repository changes, created using ad hoc scripts or third-party tools, to the Moderne platform. For example, the following commands first use `mod exec` to run a simple `sed` script across a list of repositories, and then use `mod batch publish` to upload the resulting changes to Moderne:

--- a/docs/user-documentation/moderne-cli/how-to-guides/batch-changes.md
+++ b/docs/user-documentation/moderne-cli/how-to-guides/batch-changes.md
@@ -17,7 +17,7 @@ mod batch publish . --recipe com.acme.CollectionsEmptySetToSetOf --recipe-name "
 The `mod batch publish` command can run on a single git repository or recursively over a set of repositories.
 :::
 
-<ReactPlayer className="reactPlayer" url='https://www.youtube.com/watch?v=NEEDLINKAFTERITSPOSTED' controls="true" />
+<ReactPlayer className="reactPlayer" url='https://www.youtube.com/watch?v=Em-4by2EJO8' controls="true" />
 
 After uploading the results, users can navigate to the batch changes activity page by clicking on **Batch Changes** in the Moderne UI's sidebar.
 


### PR DESCRIPTION
- added link to CLI demo youtube video
- added "Additional information" section
- added info block to inform users command can be run on a single repo or multiple repos
- added missing command in `mod --help` output in `cli-intro.md`