### PR TITLE
Update repos.csv docs to make on-prem configuration clearer

### DIFF
--- a/docs/user-documentation/moderne-cli/references/repos-csv.md
+++ b/docs/user-documentation/moderne-cli/references/repos-csv.md
@@ -96,7 +96,7 @@ Below you can find examples of what origin/path typically looks like for common 
 | HTTPS    | `https://{host}/{context}/{org}/{repo}` | `{host}` | `{org}/{repo}` |
 | SSH      | `git@{host}:{port}/{org}/{repo}`   | `{host}` | `{org}/{repo}` |
 
-For self-hosted providers such as GitHub Enterprise, Self-Managed GitLab, or Bitbucket Data Center or providers behind a custom domain, you'll need to identify any context root and include that in the `origin` and not the `path`.  Depending on the SCM provider, you may need to alter the host or path in similar ways as noted above to remove provider-specific parts of the URL.
+For self-hosted providers such as GitHub Enterprise, Self-Managed GitLab, or Bitbucket Data Center or providers behind a custom domain, you'll need to identify any context root and include that in the `origin` and not the `path`. Depending on the SCM provider, you may need to alter the host or path in similar ways as noted above to remove provider-specific parts of the URL.
 
 ### Using `alternateCloneUrl` to support multiple protocols
 


### PR DESCRIPTION
This PR adds a new section for On-Prem SCM providers to make the note clearer.  This also updates the language in the `alternateCloneUrl` section to soften it from always recommending the column and to have more context on how to use the column itself.