### PR TITLE
Fix date comparison logic in proprietary release notes script

### DIFF
--- a/.github/scripts/fetch-proprietary-release-notes.js
+++ b/.github/scripts/fetch-proprietary-release-notes.js
@@ -113,7 +113,8 @@ async function generateChangelog() {
   console.log(`Filtered to ${allReleases.length} releases from the last year`);
 
   // Check if there are any new releases since last update
-  const lastUpdateDateObj = lastUpdateDate ? new Date(lastUpdateDate + 'T00:00:00Z') : new Date(0);
+  // Use end of day (23:59:59) for the last update date to avoid re-processing releases from the same day
+  const lastUpdateDateObj = lastUpdateDate ? new Date(lastUpdateDate + 'T23:59:59Z') : new Date(0);
   const hasNewReleases = allReleases.some(release => {
     const releaseDate = new Date(release.published_at);
     return releaseDate > lastUpdateDateObj;


### PR DESCRIPTION
The script was incorrectly comparing release timestamps to midnight of the "Last updated" date, causing releases from the same day (but after midnight) to be considered "new" on subsequent runs. This resulted in daily PRs that only updated the date without any actual content changes.

Changed the comparison to use end of day (23:59:59) for the last update date to properly exclude releases that were already processed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)