### PR TITLE
peter-evans/create-pull-request@v7.0.9

### DIFF
--- a/.github/workflows/update-proprietary-release-notes.yml
+++ b/.github/workflows/update-proprietary-release-notes.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.git-check.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v7.0.9
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: Update proprietary recipe release notes


### PR DESCRIPTION
**What**:

Upgrading the GHA dependency of `peter-evans/create-pull-request` to latest `v7.0.9`

**Why**:
- https://moderneinc.slack.com/archives/C09CJKMPKK2/p1764600237330889
- as indicated in https://github.com/peter-evans/create-pull-request/issues/4228 our current version of this dependency was not compatible with `checkout@v6` which we have upgraded to last week as per #357 

Thus the workflow started failing with:
```
/usr/bin/git remote prune origin
  remote: Duplicate header: "Authorization"
  fatal: unable to access 'https://github.com/moderneinc/moderne-docs/': The requested URL returned error: 400
```