### PR TITLE
Update agent GitHub config with missing permissions and installation step

### DIFF
--- a/docs/administrator-documentation/moderne-platform/how-to-guides/agent-configuration/configure-an-agent-with-github.md
+++ b/docs/administrator-documentation/moderne-platform/how-to-guides/agent-configuration/configure-an-agent-with-github.md
@@ -36,7 +36,7 @@ To assist with that, this guide will:
     | Homepage URL                            | `https://<TENANT>.moderne.io`                                                                               |
     | Authorization callback URL              | `https://<TENANT>.moderne.io`                                                                               |
     | Webhook Active                          | Disable                                                                                                     |
-    | Repository Permissions                  | Contents - read/write<br/> Pull Requests - read/write<br/> Workflows - read/write                           |
+    | Repository Permissions                  | Contents - read/write<br/> Pull Requests - read/write<br/> Commit statuses - read-only<br/> Checks - read-only<br/> Workflows - read/write |
     | Account Permissions                     | Email Address - read-only                                                                                   |
     | Where can this GitHub App be installed? | You can choose either option based upon your specific needs:<br/> * Only on this account<br/> * Any account |
 
@@ -46,6 +46,11 @@ To assist with that, this guide will:
      <figcaption></figcaption>
    </figure>
 6. Copy the `Client ID` and `Client secret` from this page; they will be used as [arguments for the Moderne Agent](#configure-the-moderne-agent).
+7. Install the GitHub App in your organization(s). See the [GitHub permissions documentation](../../references/github-permissions.md#installing-a-github-app) for detailed installation instructions.
+
+:::note
+After creating a GitHub App, you must install it in each organization or account where you want Moderne to operate. Without installation, GitHub will reject any attempts to commit changes.
+:::
 
 #### Example values
 


### PR DESCRIPTION
## Problem

The agent configuration guide for GitHub was missing:
- Commit statuses and Checks permissions in the Repository Permissions table
- Any mention of needing to install the GitHub App after creating it

- This was discovered after merging #363, which updated the GitHub permissions reference doc but not this configuration guide.

## Solution

- Add `Commit statuses - read-only` and `Checks - read-only` to the Repository Permissions row
- Add step 7 linking to the installation instructions
- Add a note explaining that installation is required