### PR TITLE
docs(moddy): add MCP tools reference documentation

### DIFF
--- a/docs/user-documentation/moddy/moddy-mcp-integration.md
+++ b/docs/user-documentation/moddy/moddy-mcp-integration.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: MCP Integration
+sidebar_label: Connecting to Moddy via MCP
 description: Connect Moddy Desktop to MCP-compatible tools.
 ---
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -181,6 +181,7 @@ const sidebars: SidebarsConfig = {
         'user-documentation/moddy/moddy-platform',
         'user-documentation/moddy/moddy-desktop',
         'user-documentation/moddy/moddy-mcp-integration',
+        'user-documentation/moddy/mcp-tools-reference',
         'user-documentation/moddy/moddy-data-privacy',
       ],
     },


### PR DESCRIPTION
Add comprehensive reference documentation for all 8 Moddy Desktop MCP tools available through the Model Context Protocol.