### PR TITLE
Document personal access token max expiry configuration

### DIFF
--- a/docs/administrator-documentation/moderne-platform/how-to-guides/agent-configuration/agent-variables.md
+++ b/docs/administrator-documentation/moderne-platform/how-to-guides/agent-configuration/agent-variables.md
@@ -25,7 +25,8 @@ This document includes all of the variables you can configure the Moderne agent 
 | `MODERNE_AGENT_TOKEN`                        | `true`   |                        | The Moderne SaaS agent connection token, provided by Moderne.                                                                                      |
 | `MODERNE_AGENT_DOWNLOADPARALLELISM`          | `false`  | 2 threads              | How many threads are used to download LSTs.                                                                                                        |
 | `MODERNE_AGENT_ARTIFACTINDEXINTERVALSECONDS` | `false`  | 120 seconds            | How frequently LSTs will be indexed.                                                                                                               |
-| `MODERNE_AGENT_DEFAULTCOMMITOPTIONS_{index}` | `false`  | All options available. | Use to restrict which commit options are available in Moderne. Acceptable values: `Direct`, `Branch`, `Fork`, `PullRequest`, `ForkAndPullRequest`. |
+| `MODERNE_AGENT_DEFAULTCOMMITOPTIONS_{index}`          | `false`  | All options available. | Use to restrict which commit options are available in Moderne. Acceptable values: `Direct`, `Branch`, `Fork`, `PullRequest`, `ForkAndPullRequest`. |
+| `MODERNE_AGENT_PERSONALACCESSTOKENS_MAXEXPIRYDAYS`    | `false`  |                        | The maximum number of days a personal access token can be configured to expire in. When set, users cannot create tokens with an expiry date beyond this limit. |
 
 **Example:**
 
@@ -53,7 +54,8 @@ docker run \
 | `--moderne.agent.token`                         | `true`   |                        | The Moderne SaaS agent connection token, provided by Moderne.                                                                                      |
 | `--moderne.agent.downloadParallelism`           | `false`  | 2 threads              | How many threads are used to download LSTs.                                                                                                        |
 | `--moderne.agent.artifactIndexIntervalSeconds`  | `false`  | 120 seconds            | How frequently LSTs will be indexed.                                                                                                               |
-| `--moderne.agent.defaultCommitOptions[{index}]` | `false`  | All options available. | Use to restrict which commit options are available in Moderne. Acceptable values: `Direct`, `Branch`, `Fork`, `PullRequest`, `ForkAndPullRequest`. |
+| `--moderne.agent.defaultCommitOptions[{index}]`      | `false`  | All options available. | Use to restrict which commit options are available in Moderne. Acceptable values: `Direct`, `Branch`, `Fork`, `PullRequest`, `ForkAndPullRequest`. |
+| `--moderne.agent.personalAccessTokens.maxExpiryDays` | `false`  |                        | The maximum number of days a personal access token can be configured to expire in. When set, users cannot create tokens with an expiry date beyond this limit. |
 
 **Example:**
 

--- a/docs/user-documentation/moderne-platform/how-to-guides/create-api-access-tokens.md
+++ b/docs/user-documentation/moderne-platform/how-to-guides/create-api-access-tokens.md
@@ -44,7 +44,7 @@ In this doc, you can find out:
 
 4. In the text box that says `Enter token name`, enter a descriptive name for your token so that it can easily be distinguished from other tokens.
 
-5. Set when the token should expire by clicking on the date selector next to the token name:
+5. Set when the token should expire by clicking on the date selector next to the token name. Note that your organization's administrator may have configured a maximum expiry limit, which will restrict the available date range.
 
 <figure>
   ![](./assets/access-token-expiration.png)

--- a/docs/user-documentation/moderne-platform/references/moderne-tokens.md
+++ b/docs/user-documentation/moderne-platform/references/moderne-tokens.md
@@ -61,6 +61,10 @@ Personal access tokens share the same permissions as your user. What this means 
 
 You can choose how long a personal access token should last when you create it. By default, the token will last for 30 days.
 
+:::note
+Your organization's administrator may have configured a maximum expiry limit for personal access tokens. If so, you will not be able to select an expiration date beyond this limit.
+:::
+
 <figure>
   ![](./assets/access-token-expiration.png)
 </figure>


### PR DESCRIPTION
## Problem

Users need documentation for the new agent configuration option that allows administrators to set a maximum expiry limit for personal access tokens (MAT tokens).

## Solution

Added documentation for `MODERNE_AGENT_PERSONALACCESSTOKENS_MAXEXPIRYDAYS` in three places:

1. **agent-variables.md** - Added the new variable to the core variables reference table (both OCI Container and Executable JAR formats)
2. **moderne-tokens.md** - Added a note in the Personal Access Tokens expiration section informing users that administrators may have configured a limit
3. **create-api-access-tokens.md** - Added a note in the how-to guide about potential restrictions on the date selector