### PR TITLE
Add Repositories - Admin permission to Bitbucket OAuth 2 config

### DIFF
--- a/docs/administrator-documentation/moderne-platform/how-to-guides/agent-configuration/configure-bitbucket-to-agent.md
+++ b/docs/administrator-documentation/moderne-platform/how-to-guides/agent-configuration/configure-bitbucket-to-agent.md
@@ -26,12 +26,12 @@ This guide will walk you through everything you need to know to get started with
 6. Click _Continue_
 7. Define a new Incoming Application with the following settings:
 
-    | Field                   | Value                                         |
-    |-------------------------|-----------------------------------------------|
-    | Name                    | `Moderne`                                     |
-    | Redirect URL            | `https://<TENANT>.moderne.io`              |
-    | Application Permissions | Repositories - Read<br/> Repositories - Write |
-    
+    | Field                   | Value                                                                                   |
+    |-------------------------|-----------------------------------------------------------------------------------------|
+    | Name                    | `Moderne`                                                                               |
+    | Redirect URL            | `https://<TENANT>.moderne.io`                                                           |
+    | Application Permissions | Repositories - Read<br/> Repositories - Write<br/> Repositories - Admin |
+
 8. Click _Save_ to complete the Application Link creation
 9. Copy the "Client ID" and "Client Secret" to use in the next step
 


### PR DESCRIPTION
## Problem

Customers using OAuth 2 for Bitbucket Data Center were unable to authenticate because the documented permissions were incomplete. The OAuth authorization flow fails when Moderne requests the Admin scope but it's not configured on the Application Link.

## Solution

Add `Repositories - Admin` to the required Application Permissions for Bitbucket Data Center OAuth 2 configuration.