### PR TITLE
Fix sidebar scroll position resetting on navigation

### DIFF
--- a/src/theme/DocSidebar/Desktop/Content/index.tsx
+++ b/src/theme/DocSidebar/Desktop/Content/index.tsx
@@ -48,8 +48,7 @@ const DocSidebarDesktopContent: FunctionComponent<DocSidebarDesktopContentProps>
         styles.menu,
         showAnnouncementBar && styles.menuWithAnnouncementBar,
         className,
-      )}
-      key={path}>
+      )}>
       <ul className={clsx(ThemeClassNames.docs.docSidebarMenu, 'menu__list')}>
         <DocSidebarItems items={sidebar} activePath={path} level={1} />
       </ul>

--- a/src/theme/DocSidebarItems/index.tsx
+++ b/src/theme/DocSidebarItems/index.tsx
@@ -75,7 +75,7 @@ const DocSidebarItemsWrapper: FunctionComponent<Props> = (props) => {
           <PlatformToggle />
         </li>
       )}
-      <DocSidebarItems {...props} items={filteredItems} key={currentPath} />
+      <DocSidebarItems {...props} items={filteredItems} />
     </>
   );
 };


### PR DESCRIPTION
## Summary

* Remove React `key` props on `<nav>` and `<DocSidebarItems>` that forced full DOM remounting on every navigation, destroying scroll position
* Remove auto-collapse behavior for inactive sidebar categories to match [OpenRewrite docs](https://docs.openrewrite.org) behavior and avoid scroll jumping

## Root cause

Two React `key` props were set to the current path, causing React to destroy and recreate the sidebar DOM on every page navigation. This reset scroll position to the top each time.

## Test plan

* Navigate between pages in the sidebar — scroll position should be preserved
* Expand multiple sidebar categories — they should stay open when navigating to other sections
* Manually collapse a category via chevron — it should stay collapsed