### PR TITLE
Exclude recipe catalog from Algolia search

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -3,6 +3,7 @@ import type { Config } from '@docusaurus/types';
 import { themes as prismThemes } from 'prism-react-renderer';
 import remarkTokenReplacer from "./src/plugins/replace-tokens";
 import latestVersions from "./src/plugins/latest-versions";
+import pluginNoIndexRecipes from "./src/plugins/noindex-recipes";
 
 const config: Config = {
   title: 'Moderne Docs',
@@ -165,6 +166,15 @@ const config: Config = {
             title: 'Moderne DX Documentation',
             description: 'On-premise deployment solution',
           },
+        ],
+      },
+    ],
+    [
+      pluginNoIndexRecipes,
+      {
+        noIndexPatterns: [
+          '/user-documentation/recipes/recipe-catalog/',
+          '/user-documentation/recipes/lists/',
         ],
       },
     ],

--- a/src/plugins/noindex-recipes.ts
+++ b/src/plugins/noindex-recipes.ts
@@ -1,0 +1,47 @@
+import type { Plugin } from '@docusaurus/types';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+
+interface PluginOptions {
+  noIndexPatterns: string[];
+}
+
+const META_TAG = '<meta name="robots" content="noindex">';
+
+export default function pluginNoIndexRecipes(
+  _context: unknown,
+  options: PluginOptions,
+): Plugin {
+  return {
+    name: 'docusaurus-plugin-noindex-recipes',
+
+    async postBuild({ routesPaths, outDir }) {
+      const matchingRoutes = routesPaths.filter((routePath) =>
+        options.noIndexPatterns.some((pattern) => routePath.startsWith(pattern)),
+      );
+
+      console.log(
+        `[noindex-recipes] Injecting noindex meta tag into ${matchingRoutes.length} pages...`,
+      );
+
+      await Promise.all(
+        matchingRoutes.map(async (routePath) => {
+          const htmlFilePath = path.join(outDir, routePath, 'index.html');
+
+          try {
+            let html = await fs.readFile(htmlFilePath, 'utf-8');
+
+            if (!html.includes('name="robots"')) {
+              html = html.replace('<head>', `<head>\n    ${META_TAG}`);
+              await fs.writeFile(htmlFilePath, html, 'utf-8');
+            }
+          } catch {
+            // Some routes may not have a corresponding HTML file
+          }
+        }),
+      );
+
+      console.log(`[noindex-recipes] Done.`);
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Add a Docusaurus `postBuild` plugin that injects `<meta name="robots" content="noindex">` into recipe catalog and recipe lists pages. This prevents Algolia from indexing these ~5,800 auto-generated pages that currently dominate search results, while preserving direct access and sidebar navigation.

The recipe pages already have canonical links to docs.openrewrite.org, so excluding them from Moderne search is appropriate and improves discoverability of other documentation.

## Test plan

- Run `yarn build` and verify no errors
- Check `build/user-documentation/recipes/recipe-catalog/*/index.html` contains `<meta name="robots" content="noindex">`
- Verify non-recipe pages like `build/introduction/index.html` do NOT have the tag
- After deployment, Algolia crawler will pick up the noindex directive on next re-index

🤖 Generated with [Claude Code](https://claude.com/claude-code)