### PR TITLE
Exclude recipe category from Algolia search results

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -180,6 +180,9 @@ const config: Config = {
       appId: "MEFFK0HGO6",
       apiKey: "15eb9c9f6f3147b1cf82b1b7f93cace8",
       indexName: "moderne",
+      searchParameters: {
+        facetFilters: ["category:-recipe"],
+      },
     },
     // announcementBar: {
     //   id: "code_remix",


### PR DESCRIPTION
## Summary

* Adds `facetFilters` to the Algolia search configuration to exclude results where `category` is `recipe`

## Test plan

* [ ] Verify Algolia search no longer returns recipe-category results
* [ ] Confirm `category` is configured as a facet in the Algolia index settings