### PR TITLE
fix: exclude recipe pages from Algolia search results

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -179,7 +179,10 @@ const config: Config = {
     algolia: {
       appId: "MEFFK0HGO6",
       apiKey: "15eb9c9f6f3147b1cf82b1b7f93cace8",
-      indexName: "moderne"
+      indexName: "moderne",
+      searchParameters: {
+        filters: "NOT category:recipes",
+      },
     },
     // announcementBar: {
     //   id: "code_remix",


### PR DESCRIPTION
## Summary

* Switches Algolia search parameter from `facetFilters: ["-category:recipes"]` to `filters: "NOT category:recipes"` to correctly exclude recipe catalog pages from search results
* The `facetFilters` negation syntax excludes records that lack the `category` attribute entirely, which caused zero results since only recipe pages have this attribute
* The `filters` `NOT` syntax correctly returns all records except those explicitly tagged with `category:recipes`

## Test plan

- [x] Verified via direct Algolia API query that `filters: "NOT category:recipes"` returns non-recipe results (24 hits)
- [x] Tested in local Docusaurus dev server — search for "migrate to java 17" returns documentation and training results, no recipe catalog pages