### PR TITLE
Add faceted search tabs to Algolia DocSearch

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -98,6 +98,8 @@ const config: Config = {
             '**/*.stories.ts',
             '**/*.stories.jsx',
             '**/*.stories.js',
+            // DEV ONLY: skip 5,700+ recipe-catalog pages for faster rebuilds
+            ...(process.env.NODE_ENV === 'production' ? [] : ['user-documentation/recipes/recipe-catalog/**']),
           ],
           remarkPlugins: [
             [
@@ -180,9 +182,7 @@ const config: Config = {
       appId: "MEFFK0HGO6",
       apiKey: "15eb9c9f6f3147b1cf82b1b7f93cace8",
       indexName: "moderne",
-      searchParameters: {
-        filters: "NOT category:recipes",
-      },
+      // Search filtering is handled by SearchFacetTabs (src/theme/SearchBar)
     },
     // announcementBar: {
     //   id: "code_remix",

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -115,6 +115,11 @@ html[data-theme=light] {
   --docsearch-muted-color: rgba(4, 24, 52, 0.75);
 }
 
+/* Algolia DocSearch - Reduce dropdown height for facet tabs row */
+.DocSearch-Dropdown {
+  max-height: calc(var(--docsearch-modal-height) - var(--docsearch-spacing) - var(--docsearch-footer-height) - 48px);
+}
+
 /* Algolia DocSearch - Pill Shape Styling */
 .DocSearch-Button {
   width: 232px;

--- a/src/theme/SearchBar/SearchFacetTabs.module.css
+++ b/src/theme/SearchBar/SearchFacetTabs.module.css
@@ -1,0 +1,70 @@
+.tabsContainer {
+  display: flex;
+  gap: var(--neo-spacing_1);
+  padding: var(--neo-spacing_1) var(--neo-spacing_2);
+  border-bottom: 1px solid var(--neo-border-primary);
+}
+
+.tab {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--neo-spacing_3_4) var(--neo-spacing_1_1_2);
+  border-radius: 999px;
+  border: 1px solid var(--neo-border-primary);
+  background: transparent;
+  color: var(--neo-typography-input-default);
+  font-family: var(--neo-font-family-body), sans-serif;
+  font-size: var(--neo-font-size-xs);
+  font-weight: var(--neo-font-weight-medium);
+  cursor: pointer;
+  transition: all 0.15s ease;
+  white-space: nowrap;
+  line-height: 1;
+}
+
+.tab:hover {
+  background: var(--neo-surfaces-list-hover);
+}
+
+.tabActive {
+  background: var(--neo-digital-blue-500);
+  border-color: var(--neo-digital-blue-500);
+  color: var(--neo-surfaces-white);
+}
+
+.tabActive:hover {
+  background: var(--neo-digital-blue-600);
+  border-color: var(--neo-digital-blue-600);
+}
+
+html[data-theme='dark'] .tab {
+  border-color: rgba(255, 255, 255, 0.2);
+  color: rgba(255, 255, 255, 0.9);
+}
+
+html[data-theme='dark'] .tab:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+html[data-theme='dark'] .tabActive {
+  background: var(--neo-digital-blue-400);
+  border-color: var(--neo-digital-blue-400);
+  color: var(--neo-surfaces-white);
+}
+
+html[data-theme='dark'] .tabActive:hover {
+  background: var(--neo-digital-blue-500);
+  border-color: var(--neo-digital-blue-500);
+}
+
+@media (max-width: 768px) {
+  .tabsContainer {
+    padding: var(--neo-spacing_1) var(--neo-spacing_1_1_2);
+    gap: var(--neo-spacing_3_4);
+  }
+
+  .tab {
+    font-size: var(--neo-font-size-xxs);
+    padding: var(--neo-spacing_1_2) var(--neo-spacing_1);
+  }
+}

--- a/src/theme/SearchBar/SearchFacetTabs.tsx
+++ b/src/theme/SearchBar/SearchFacetTabs.tsx
@@ -1,0 +1,43 @@
+import clsx from 'clsx';
+import type {ReactNode} from 'react';
+import styles from './SearchFacetTabs.module.css';
+
+export type SearchTab = 'all' | 'documentation' | 'recipes';
+
+interface SearchFacetTabsProps {
+  activeTab: SearchTab;
+  onTabChange: (tab: SearchTab) => void;
+}
+
+const tabs: {value: SearchTab; label: string}[] = [
+  {value: 'all', label: 'All'},
+  {value: 'documentation', label: 'Documentation'},
+  {value: 'recipes', label: 'Recipes'},
+];
+
+export default function SearchFacetTabs({
+  activeTab,
+  onTabChange,
+}: SearchFacetTabsProps): ReactNode {
+  return (
+    <div
+      className={styles.tabsContainer}
+      role="tablist"
+      aria-label="Search scope">
+      {tabs.map((tab) => (
+        <button
+          key={tab.value}
+          role="tab"
+          aria-selected={activeTab === tab.value}
+          className={clsx(
+            styles.tab,
+            activeTab === tab.value && styles.tabActive,
+          )}
+          onClick={() => onTabChange(tab.value)}
+          type="button">
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/theme/SearchBar/index.tsx
+++ b/src/theme/SearchBar/index.tsx
@@ -1,0 +1,435 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Ejected from @docusaurus/theme-search-algolia (v3.9.2) to add
+ * faceted "Search in" tabs (All / Documentation / Recipes).
+ *
+ * Modifications from upstream:
+ * - Added SearchTab state and SearchFacetTabs component
+ * - Modified useSearchParameters to merge tab-specific facet filters
+ * - Reset activeTab to 'documentation' in closeModal
+ * - Render SearchFacetTabs alongside DocSearchModal in the portal
+ */
+
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import {createPortal} from 'react-dom';
+import {DocSearchButton} from '@docsearch/react/button';
+import {useDocSearchKeyboardEvents} from '@docsearch/react/useDocSearchKeyboardEvents';
+import Head from '@docusaurus/Head';
+import Link from '@docusaurus/Link';
+import {useHistory} from '@docusaurus/router';
+import {
+  isRegexpStringMatch,
+  useSearchLinkCreator,
+} from '@docusaurus/theme-common';
+import {
+  useAlgoliaContextualFacetFilters,
+  useSearchResultUrlProcessor,
+  useAlgoliaAskAi,
+  mergeFacetFilters,
+} from '@docusaurus/theme-search-algolia/client';
+import Translate from '@docusaurus/Translate';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import translations from '@theme/SearchTranslations';
+import SearchFacetTabs, {type SearchTab} from './SearchFacetTabs';
+import type {
+  InternalDocSearchHit,
+  DocSearchModal as DocSearchModalType,
+  DocSearchModalProps,
+  StoredDocSearchHit,
+  DocSearchTransformClient,
+  DocSearchHit,
+  DocSearchTranslations,
+  UseDocSearchKeyboardEventsProps,
+} from '@docsearch/react';
+
+import type {AutocompleteState} from '@algolia/autocomplete-core';
+import type {FacetFilters} from 'algoliasearch/lite';
+import type {ThemeConfigAlgolia} from '@docusaurus/theme-search-algolia';
+
+type DocSearchProps = Omit<
+  DocSearchModalProps,
+  'onClose' | 'initialScrollY'
+> & {
+  contextualSearch?: string;
+  externalUrlRegex?: string;
+  searchPagePath: boolean | string;
+  askAi?: Exclude<
+    (DocSearchModalProps & {askAi: unknown})['askAi'],
+    string | undefined
+  >;
+};
+
+// extend DocSearchProps for v4 features
+// TODO Docusaurus v4: cleanup after we drop support for DocSearch v3
+interface DocSearchV4Props extends DocSearchProps {
+  indexName: string;
+  askAi?: ThemeConfigAlgolia['askAi'];
+  translations?: DocSearchTranslations;
+}
+
+let DocSearchModal: typeof DocSearchModalType | null = null;
+
+function importDocSearchModalIfNeeded() {
+  if (DocSearchModal) {
+    return Promise.resolve();
+  }
+  return Promise.all([
+    import('@docsearch/react/modal'),
+    import('@docsearch/react/style'),
+    import('./styles.css'),
+  ]).then(([{DocSearchModal: Modal}]) => {
+    DocSearchModal = Modal;
+  });
+}
+
+function useNavigator({
+  externalUrlRegex,
+}: Pick<DocSearchProps, 'externalUrlRegex'>) {
+  const history = useHistory();
+  const [navigator] = useState<DocSearchModalProps['navigator']>(() => {
+    return {
+      navigate(params) {
+        // Algolia results could contain URL's from other domains which cannot
+        // be served through history and should navigate with window.location
+        if (isRegexpStringMatch(externalUrlRegex, params.itemUrl)) {
+          window.location.href = params.itemUrl;
+        } else {
+          history.push(params.itemUrl);
+        }
+      },
+    };
+  });
+  return navigator;
+}
+
+function useTransformSearchClient(): DocSearchModalProps['transformSearchClient'] {
+  const {
+    siteMetadata: {docusaurusVersion},
+  } = useDocusaurusContext();
+  return useCallback(
+    (searchClient: DocSearchTransformClient) => {
+      searchClient.addAlgoliaAgent('docusaurus', docusaurusVersion);
+      return searchClient;
+    },
+    [docusaurusVersion],
+  );
+}
+
+function useTransformItems(props: Pick<DocSearchProps, 'transformItems'>) {
+  const processSearchResultUrl = useSearchResultUrlProcessor();
+  const [transformItems] = useState<DocSearchModalProps['transformItems']>(
+    () => {
+      return (items: DocSearchHit[]) =>
+        props.transformItems
+          ? // Custom transformItems
+            props.transformItems(items)
+          : // Default transformItems
+            items.map((item) => ({
+              ...item,
+              url: processSearchResultUrl(item.url),
+            }));
+    },
+  );
+  return transformItems;
+}
+
+function useResultsFooterComponent({
+  closeModal,
+}: {
+  closeModal: () => void;
+}): DocSearchProps['resultsFooterComponent'] {
+  return useMemo(
+    () =>
+      ({state}) =>
+        <ResultsFooter state={state} onClose={closeModal} />,
+    [closeModal],
+  );
+}
+
+function Hit({
+  hit,
+  children,
+}: {
+  hit: InternalDocSearchHit | StoredDocSearchHit;
+  children: ReactNode;
+}) {
+  return <Link to={hit.url}>{children}</Link>;
+}
+
+type ResultsFooterProps = {
+  state: AutocompleteState<InternalDocSearchHit>;
+  onClose: () => void;
+};
+
+function ResultsFooter({state, onClose}: ResultsFooterProps) {
+  const createSearchLink = useSearchLinkCreator();
+
+  return (
+    <Link to={createSearchLink(state.query)} onClick={onClose}>
+      <Translate
+        id="theme.SearchBar.seeAll"
+        values={{count: state.context.nbHits}}>
+        {'See all {count} results'}
+      </Translate>
+    </Link>
+  );
+}
+
+/**
+ * Algolia `filters` string for each search tab.
+ *
+ * Uses `filters` (SQL-like syntax) instead of `facetFilters` because
+ * a negative facetFilter like `-category:recipes` also excludes records
+ * missing the attribute entirely, while `NOT category:recipes` only
+ * excludes records that explicitly have category:recipes.
+ */
+const tabFilters: Record<SearchTab, string> = {
+  all: '',
+  documentation: 'NOT category:recipes',
+  recipes: 'category:recipes',
+};
+
+function useSearchParameters({
+  contextualSearch,
+  activeTab,
+  ...props
+}: DocSearchProps & {activeTab: SearchTab}): DocSearchProps['searchParameters'] {
+  const contextualSearchFacetFilters = useAlgoliaContextualFacetFilters();
+
+  const configFacetFilters: FacetFilters =
+    props.searchParameters?.facetFilters ?? [];
+
+  const facetFilters: FacetFilters = contextualSearch
+    ? // Merge contextual search filters with config filters
+      mergeFacetFilters(contextualSearchFacetFilters, configFacetFilters)
+    : // ... or use config facetFilters
+      configFacetFilters;
+
+  const filterString = tabFilters[activeTab];
+
+  // We let users override default searchParameters if they want to
+  return {
+    ...props.searchParameters,
+    facetFilters,
+    ...(filterString && {filters: filterString}),
+  };
+}
+
+/**
+ * Creates a mount point div inside .DocSearch-Modal (between SearchBar and
+ * Dropdown) and keeps a reference to it. We portal SearchFacetTabs into this
+ * mount point so the tabs live inside the modal's own DOM tree and survive
+ * DocSearch's internal React reconciliation.
+ */
+function useTabsMountPoint(
+  isOpen: boolean,
+  activeTab: SearchTab,
+): HTMLDivElement | null {
+  const [mountPoint, setMountPoint] = useState<HTMLDivElement | null>(null);
+  const mountRef = useRef<HTMLDivElement | null>(null);
+
+  // Re-run when isOpen or activeTab changes (activeTab change causes modal
+  // remount via key prop, which destroys the old mount point)
+  useEffect(() => {
+    if (!isOpen) {
+      mountRef.current?.remove();
+      mountRef.current = null;
+      setMountPoint(null);
+      return;
+    }
+
+    function ensureMountPoint() {
+      // Already created and still in the DOM
+      if (mountRef.current?.isConnected) {
+        return;
+      }
+
+      const modal = document.querySelector('.DocSearch-Modal');
+      const dropdown = document.querySelector('.DocSearch-Dropdown');
+      if (!modal || !dropdown) return;
+
+      // Clean up any stale mount points (e.g. from React Strict Mode double-runs)
+      modal.querySelectorAll('[data-facet-tabs]').forEach((el) => el.remove());
+
+      const div = document.createElement('div');
+      div.setAttribute('data-facet-tabs', '');
+      modal.insertBefore(div, dropdown);
+      mountRef.current = div;
+      setMountPoint(div);
+    }
+
+    // Try immediately (modal may already be rendered)
+    ensureMountPoint();
+
+    // Watch for the modal/dropdown appearing if not yet in the DOM
+    const observer = new MutationObserver(() => ensureMountPoint());
+    observer.observe(document.body, {childList: true, subtree: true});
+
+    return () => {
+      observer.disconnect();
+      mountRef.current?.remove();
+      mountRef.current = null;
+    };
+  }, [isOpen, activeTab]);
+
+  return mountPoint;
+}
+
+function DocSearch({externalUrlRegex, ...props}: DocSearchV4Props) {
+  const navigator = useNavigator({externalUrlRegex});
+  const transformItems = useTransformItems(props);
+  const transformSearchClient = useTransformSearchClient();
+
+  const [activeTab, setActiveTab] = useState<SearchTab>('documentation');
+  const searchParameters = useSearchParameters({...props, activeTab});
+
+  const handleTabChange = useCallback((tab: SearchTab) => {
+    // Capture the current query so it persists across the modal remount
+    const input = document.querySelector<HTMLInputElement>('.DocSearch-Input');
+    if (input?.value) {
+      setInitialQuery(input.value);
+    }
+    setActiveTab(tab);
+  }, []);
+
+  const searchContainer = useRef<HTMLDivElement | null>(null);
+  const searchButtonRef = useRef<HTMLButtonElement | null>(null);
+  const [isOpen, setIsOpen] = useState(false);
+  const [initialQuery, setInitialQuery] = useState<string | undefined>(
+    undefined,
+  );
+
+  const tabsMountPoint = useTabsMountPoint(isOpen, activeTab);
+
+  const {isAskAiActive, currentPlaceholder, onAskAiToggle, extraAskAiProps} =
+    useAlgoliaAskAi(props);
+
+  const prepareSearchContainer = useCallback(() => {
+    if (!searchContainer.current) {
+      const divElement = document.createElement('div');
+      searchContainer.current = divElement;
+      document.body.insertBefore(divElement, document.body.firstChild);
+    }
+  }, []);
+
+  const openModal = useCallback(() => {
+    prepareSearchContainer();
+    importDocSearchModalIfNeeded().then(() => setIsOpen(true));
+  }, [prepareSearchContainer]);
+
+  const closeModal = useCallback(() => {
+    setIsOpen(false);
+    searchButtonRef.current?.focus();
+    setInitialQuery(undefined);
+    setActiveTab('documentation');
+    onAskAiToggle(false);
+  }, [onAskAiToggle]);
+
+  const handleInput = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === 'f' && (event.metaKey || event.ctrlKey)) {
+        // ignore browser's ctrl+f
+        return;
+      }
+      // prevents duplicate key insertion in the modal input
+      event.preventDefault();
+      setInitialQuery(event.key);
+      openModal();
+    },
+    [openModal],
+  );
+
+  const resultsFooterComponent = useResultsFooterComponent({closeModal});
+
+  useDocSearchKeyboardEvents({
+    isOpen,
+    onOpen: openModal,
+    onClose: closeModal,
+    onInput: handleInput,
+    searchButtonRef,
+    isAskAiActive: isAskAiActive ?? false,
+    onAskAiToggle: onAskAiToggle ?? (() => {}),
+  } satisfies UseDocSearchKeyboardEventsProps & {
+    // TODO Docusaurus v4: cleanup after we drop support for DocSearch v3
+    isAskAiActive: boolean;
+    onAskAiToggle: (askAiToggle: boolean) => void;
+  } as UseDocSearchKeyboardEventsProps);
+
+  return (
+    <>
+      <Head>
+        {/* This hints the browser that the website will load data from Algolia,
+        and allows it to preconnect to the DocSearch cluster. It makes the first
+        query faster, especially on mobile. */}
+        <link
+          rel="preconnect"
+          href={`https://${props.appId}-dsn.algolia.net`}
+          crossOrigin="anonymous"
+        />
+      </Head>
+
+      <DocSearchButton
+        onTouchStart={importDocSearchModalIfNeeded}
+        onFocus={importDocSearchModalIfNeeded}
+        onMouseOver={importDocSearchModalIfNeeded}
+        onClick={openModal}
+        ref={searchButtonRef}
+        translations={props.translations?.button ?? translations.button}
+      />
+
+      {isOpen &&
+        DocSearchModal &&
+        searchContainer.current &&
+        createPortal(
+          <DocSearchModal
+            key={activeTab}
+            onClose={closeModal}
+            initialScrollY={window.scrollY}
+            initialQuery={initialQuery}
+            navigator={navigator}
+            transformItems={transformItems}
+            hitComponent={Hit}
+            transformSearchClient={transformSearchClient}
+            {...(props.searchPagePath && {
+              resultsFooterComponent,
+            })}
+            placeholder={currentPlaceholder}
+            {...props}
+            translations={props.translations?.modal ?? translations.modal}
+            searchParameters={searchParameters}
+            {...extraAskAiProps}
+          />,
+          searchContainer.current,
+        )}
+
+      {tabsMountPoint &&
+        createPortal(
+          <SearchFacetTabs
+            activeTab={activeTab}
+            onTabChange={handleTabChange}
+          />,
+          tabsMountPoint,
+        )}
+    </>
+  );
+}
+
+export default function SearchBar(): ReactNode {
+  const {siteConfig} = useDocusaurusContext();
+  return (
+    <DocSearch {...(siteConfig.themeConfig.algolia as DocSearchV4Props)} />
+  );
+}

--- a/src/theme/SearchBar/styles.css
+++ b/src/theme/SearchBar/styles.css
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+:root {
+  --docsearch-primary-color: var(--ifm-color-primary);
+  --docsearch-text-color: var(--ifm-font-color-base);
+}
+
+.DocSearch-Button {
+  margin: 0;
+  transition: all var(--ifm-transition-fast)
+    var(--ifm-transition-timing-default);
+}
+
+.DocSearch-Container {
+  z-index: calc(var(--ifm-z-index-fixed) + 1);
+}
+
+.DocSearch-Button-Key {
+  padding: 0;
+}


### PR DESCRIPTION
## Summary

* Eject SearchBar from `@docusaurus/theme-search-algolia` (v3.9.2) to add faceted All / Documentation / Recipes filter tabs to the DocSearch modal
* Use Algolia `filters` (SQL-like syntax) instead of `facetFilters` so negation correctly handles records missing the `category` attribute
* Default to the Documentation tab on modal open
* Conditionally exclude recipe-catalog pages in dev mode only (`NODE_ENV !== production`) for faster local rebuilds

## Test plan

- [ ] Open search modal and verify Documentation tab is selected by default
- [ ] Switch between All, Documentation, and Recipes tabs and confirm results filter correctly
- [ ] Verify query text persists when switching tabs
- [ ] Check dark mode styling for tabs
- [ ] Run `yarn build` and verify recipe-catalog pages are included in production build
- [ ] Run `yarn start` and verify recipe-catalog pages are excluded in dev mode