### PR TITLE
Fixes announcement banner + announces code remix

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -184,10 +184,10 @@ const config: Config = {
       indexName: "moderne",
       // Search filtering is handled by SearchFacetTabs (src/theme/SearchBar)
     },
-    // announcementBar: {
-    //   id: "code_remix",
-    //   content: 'Now announcing the inaugural <a href="https://coderemix.ai/"><strong>Code Remix Summit</strong></a> – in Miami May 12th-14th.',
-    // },
+    announcementBar: {
+      id: "code_remix_26",
+      content: '<strong><a href="https://coderemix.ai/?utm_source=docs&utm_medium=referral&utm_campaign=26_crs_banner">Code Remix Summit is back</a></strong> ✦ May 11–13',
+    },
     colorMode: {
       respectPrefersColorScheme: true,
     },

--- a/src/theme/AnnouncementBar/index.tsx
+++ b/src/theme/AnnouncementBar/index.tsx
@@ -6,7 +6,20 @@ import AnnouncementBarContent from '@theme/AnnouncementBar/Content';
 
 import styles from './styles.module.css';
 
+/**
+ * Renders nothing in the default Layout position.
+ * The announcement bar is rendered inside the fixed NavbarLayout wrapper instead,
+ * so it scrolls together with the navbar.
+ */
 const AnnouncementBar: FunctionComponent = () => {
+  return null;
+};
+
+/**
+ * Internal implementation used by NavbarLayout to render the announcement bar
+ * inside the fixed navbar wrapper.
+ */
+export const AnnouncementBarInline: FunctionComponent = () => {
   const {announcementBar} = useThemeConfig();
   const {isActive, close} = useAnnouncementBar();
   if (!isActive) {

--- a/src/theme/Navbar/Layout/index.tsx
+++ b/src/theme/Navbar/Layout/index.tsx
@@ -17,6 +17,7 @@ import {useHideableNavbar, useNavbarMobileSidebar} from '@docusaurus/theme-commo
 import {translate} from '@docusaurus/Translate';
 import NavbarMobileSidebar from '@theme/Navbar/MobileSidebar';
 import type {Props} from '@theme/Navbar/Layout';
+import {AnnouncementBarInline} from '@theme/AnnouncementBar';
 import { SecondaryNav } from '@site/src/components/SecondaryNav';
 import { products, releasesItems, trainingItems } from '@site/src/config/megaMenuData';
 import styles from './styles.module.css';
@@ -47,6 +48,7 @@ const NavbarLayout: FunctionComponent<NavbarLayoutProps> = ({
 
   return (
     <div className={styles.navbarWrapper}>
+      <AnnouncementBarInline />
       <nav
         ref={navbarRef}
         aria-label={translate({


### PR DESCRIPTION
With our redesign changes, the announcement banner was hidden behind the navbar. This brings the announcement banner into the navbar so that it can be used.

Here's what this looks like:

<img width="1025" height="189" alt="Screen Shot 2026-02-20 at 9 00 58 AM" src="https://github.com/user-attachments/assets/503a2fac-eafd-4255-b90d-e147bf3dbdc4" />

<img width="1032" height="172" alt="Screen Shot 2026-02-20 at 9 01 28 AM" src="https://github.com/user-attachments/assets/5bf8eb71-0239-49a1-8f8f-b81dce3c4acf" />

