### PR TITLE
Fix docs content hidden behind navbar with announcement bar

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -61,8 +61,9 @@
   --ifm-navbar-padding-vertical: 0;
   --ifm-navbar-padding-horizontal: 32px;
   --ifm-navbar-item-padding-horizontal: 1.4rem;
-  --ifm-navbar-height: 37px;
+  --ifm-navbar-height: calc(37px + var(--ifm-announcement-bar-height));
   --ifm-secondary-nav-height: 48px;
+  --ifm-announcement-bar-height: 30px;
 
   /* Neo-Design: Typography family and weights */
   --ifm-font-family-base: var(--neo-font-family-body), sans-serif;
@@ -102,6 +103,11 @@
 
   /* Hover overlay for light mode */
   --ifm-hover-overlay: rgba(0, 0, 0, 0.05);
+}
+
+/* Zero out announcement bar height when dismissed */
+html[data-announcement-bar-initially-dismissed='true'] {
+  --ifm-announcement-bar-height: 0px;
 }
 
 /* Use selector for specificity */
@@ -409,7 +415,7 @@ html[data-theme='dark'] [class^=docMainContainer_] .card {
 @media(min-width: 997px) {
   /* On desktop, account for secondary nav in total navbar height */
   :root {
-    --ifm-navbar-height: calc(37px + var(--ifm-secondary-nav-height));
+    --ifm-navbar-height: calc(37px + var(--ifm-secondary-nav-height) + var(--ifm-announcement-bar-height));
   }
 
   .theme-doc-sidebar-container {


### PR DESCRIPTION
## Summary

* Adds `--ifm-announcement-bar-height` CSS variable (30px) and includes it in `--ifm-navbar-height` calculation
* Zeros out the variable when the bar is dismissed via `html[data-announcement-bar-initially-dismissed]`
* Fixes both mobile (base) and desktop (with secondary nav) navbar height calculations

The announcement bar was moved inside the fixed navbar wrapper in b9e6eff but `--ifm-navbar-height` was never updated to account for the extra height, causing `.main-wrapper` margin-top to be too small and content to render behind the navbar.