### PR TITLE
Fix sidebar scrolling when announcement banner is visible

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -307,20 +307,20 @@ figure figcaption {
 
 /* Offset anchor targets so they land below the fixed navbar */
 html {
-  scroll-padding-top: calc(var(--ifm-navbar-height) + var(--ifm-announcement-bar-height) + var(--neo-spacing_2));
+  scroll-padding-top: calc(var(--ifm-navbar-height) + var(--ifm-secondary-nav-height) + var(--ifm-announcement-bar-height) + var(--neo-spacing_2));
 }
 
 /* Push main content below fixed navbar */
 .main-wrapper {
-  margin-top: calc(var(--ifm-navbar-height) + var(--ifm-announcement-bar-height) + var(--neo-spacing_2));
-  min-height: calc(100vh - var(--ifm-navbar-height) - var(--ifm-announcement-bar-height) - var(--neo-spacing_2));
+  margin-top: calc(var(--ifm-navbar-height) + var(--ifm-secondary-nav-height) + var(--ifm-announcement-bar-height) + var(--neo-spacing_2));
+  min-height: calc(100vh - var(--ifm-navbar-height) - var(--ifm-secondary-nav-height) - var(--ifm-announcement-bar-height) - var(--neo-spacing_2));
 }
 
 /* Ensure sidebar container has correct height calculation */
 .theme-doc-sidebar-container {
   position: sticky;
-  top: var(--neo-spacing_3);
-  height: calc(100vh - var(--ifm-navbar-height) - var(--ifm-announcement-bar-height));
+  top: calc(var(--ifm-navbar-height) + var(--ifm-secondary-nav-height) + var(--ifm-announcement-bar-height));
+  height: calc(100vh - var(--ifm-navbar-height) - var(--ifm-secondary-nav-height) - var(--ifm-announcement-bar-height));
   align-self: flex-start;
 }
 

--- a/src/theme/DocSidebar/Desktop/styles.module.css
+++ b/src/theme/DocSidebar/Desktop/styles.module.css
@@ -10,7 +10,7 @@
     display: flex;
     flex-direction: column;
     height: 100%;
-    padding-top: var(--ifm-navbar-height);
+    padding-top: 0;
     width: var(--doc-sidebar-width);
 
     /* Nested for higher specificity - overrides Logo component defaults.


### PR DESCRIPTION
## Summary

* Fix sidebar scrolling with main content by accounting for the secondary nav height (48px) in all layout offset calculations
* Remove redundant `padding-top: var(--ifm-navbar-height)` on sidebar inner div that double-counted the navbar height alongside the sticky `top` offset
* Add `--ifm-secondary-nav-height` to `scroll-padding-top`, `.main-wrapper` margin/min-height, and `.theme-doc-sidebar-container` sticky top/height

## Test plan

- [ ] Navigate to a docs page with sidebar (e.g., `/user-documentation/moderne-platform/getting-started/running-your-first-recipe`)
- [ ] Scroll down on main content — sidebar should stay fixed in place, not scroll
- [ ] Dismiss the announcement banner (click X) and reload — sidebar should adjust position correctly
- [ ] Check a page with long sidebar content — sidebar should scroll independently within its container
- [ ] Test dark mode toggle — no visual regressions