### PR TITLE
docs: Update deprecated mod git sync moderne syntax

### DIFF
--- a/docs/user-documentation/moderne-cli/getting-started/cli-intro.md
+++ b/docs/user-documentation/moderne-cli/getting-started/cli-intro.md
@@ -424,7 +424,7 @@ Moderne CLI 3.57.11
 Once you've decided what organization you want to clone, you can download the LSTs and code to your machine by running the following command:
 
 ```bash
-mod git sync moderne /path/to/your/workspace "<organization-name>" --with-sources
+mod git sync moderne /path/to/your/workspace --organization "<organization-name>" --with-sources
 ```
 
 Make sure to replace the path and organization with the one you want. If you don't want to download the code and just want to download the LSTs, you can remove the `--with-sources` flag.
@@ -496,7 +496,7 @@ Moderne CLI 3.57.11
 Once you've decided what organization you want to clone, you can download the LSTs and code to your machine by running the following command:
 
 ```bash
-mod git sync moderne /path/to/your/workspace "<organization-name>" --with-sources
+mod git sync moderne /path/to/your/workspace --organization "<organization-name>" --with-sources
 ```
 
 Make sure to replace the path and organization with the one you want. If you don't want to download the code and just want to download the LSTs, you can remove the `--with-sources` flag.

--- a/docs/user-documentation/moderne-cli/getting-started/moderne-cli-workshop.md
+++ b/docs/user-documentation/moderne-cli/getting-started/moderne-cli-workshop.md
@@ -50,7 +50,7 @@ The Moderne CLI was not designed to run multiple commands simultaneously. In the
 For this exercise, we've prepared a list of open-source repositories for you to use. These repositories have been added to the Moderne Platform and put inside the `Default` organization. Clone these repositories by running the following command from inside your `workshop` directory:
 
 ```bash
-mod git sync moderne . "Default" --with-sources
+mod git sync moderne . --organization "Default" --with-sources
 ```
 
 <details>

--- a/docs/user-documentation/moderne-cli/how-to-guides/parallelism.md
+++ b/docs/user-documentation/moderne-cli/how-to-guides/parallelism.md
@@ -24,7 +24,7 @@ To help improve this experience, we've introduced a `--parallel` flag on a varie
 The following command will clone all of the repositories in the `Default` org to your local machine using the _number of threads available on your computer_:
 
 ```bash
-mod git sync moderne . "Default" --parallel 0
+mod git sync moderne . --organization "Default" --parallel 0
 ```
 
 The following command will run the `DependencyVulnerabilityCheck` recipe against all of the repositories in your current directory using a thread pool with the number of threads _equal to the number of cores available on your computer minus 1_:


### PR DESCRIPTION
## Summary

* Updated `mod git sync moderne` commands to use the `--organization` flag instead of the deprecated positional argument syntax
* Affected files: `cli-intro.md`, `moderne-cli-workshop.md`, `parallelism.md`

## Test plan

* [ ] Verify the updated command examples match the current CLI reference docs
* [ ] Run `yarn start` to confirm no build errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)