### PR TITLE
fix: Prevent right TOC from clipping at bottom of viewport

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -410,6 +410,8 @@ html[data-theme='dark'] [class^=docMainContainer_] .card {
 /* TOC position - below full navbar wrapper */
 [class*="tableOfContents"] {
   top: calc(var(--ifm-navbar-height) + var(--ifm-announcement-bar-height) + var(--neo-spacing_7));
+  max-height: calc(100vh - var(--ifm-navbar-height) - var(--ifm-announcement-bar-height) - 128px);
+  overflow-y: auto;
 }
 
 @media(min-width: 997px) {


### PR DESCRIPTION
## Summary

* Adds `max-height` and `overflow-y: auto` to the right-side table of contents so it stays within the viewport and scrolls independently on pages with many headings (e.g., proof of value).
* Previously, the last TOC items were clipped and unreachable without scrolling the entire page.

- Closes #488

## Test plan

* [ ] Navigate to a page with many headings (e.g., proof of value) — confirm all TOC items are reachable by scrolling the TOC
* [ ] Dismiss the announcement bar — verify TOC recalculates correctly
* [ ] Check a page with a short TOC — no unnecessary scrollbar