### PR TITLE
Remove outdated DX license lease and microservice references

### DIFF
--- a/docs/user-documentation/moderne-cli/getting-started/moderne-cli-license.md
+++ b/docs/user-documentation/moderne-cli/getting-started/moderne-cli-license.md
@@ -17,25 +17,9 @@ If you are a Moderne DX or multi-tenant Moderne customer, you may contact [suppo
 
 If you are not a Moderne customer, but still want to use the Moderne IDE plugin, please fill out our [try the Moderne IDE plugin signup form](https://www.moderne.io/moderne-ide-plugin-signup) and we will coordinate with you.
 
-## License leases
-
-Beginning with CLI and DX v3.30.0, license keys no longer need to be installed directly in the CLI. Instead, license leases are requested from a DX or single-tenant Moderne instance prior to running a recipe. To generate leases, DX instances must be configured with a valid license key. Leases are valid for 3 days which allows for the running of recipes when not connected to DX or Moderne.
-
 ## How to configure a license key
 
-### Moderne DX customers
-
-:::info
-To service license leases, a valid license must be installed on the DX instance.
-:::
-
-A license lease will be automatically fetched by the CLI prior to running a recipe. To explicitly refresh a license lease, run the following CLI command:
-
-```bash
-mod config license moderne sync
-```
-
-### Multi-tenant Moderne customers
+### Moderne DX and multi-tenant customers
 
 Please run the following CLI command:
 

--- a/docs/user-documentation/moderne-cli/references/cli-3-44-0-changes.md
+++ b/docs/user-documentation/moderne-cli/references/cli-3-44-0-changes.md
@@ -82,7 +82,7 @@ If you then add organization structure to that CSV and sync again, the directory
 
 ### `mod git sync moderne`
 
-`mod git sync` works similarly but starts with a request to an endpoint in either the Moderne SaaS or DX microservice to fetch the effective `repos.csv` for an organization. It saves that `repos.csv` to the `.moderne` directory and then delegates to `mod git sync csv`.
+`mod git sync` works similarly but starts with a request to the Moderne SaaS to fetch the effective `repos.csv` for an organization. It saves that `repos.csv` to the `.moderne` directory and then delegates to `mod git sync csv`.
 
 <figure>
   <Zoom>


### PR DESCRIPTION
## Summary

* Removed the "License leases" section from the CLI license docs as it is no longer relevant
* Removed the "Moderne DX customers" subsection from "How to configure a license key" and renamed the remaining section to "Moderne DX and multi-tenant customers"
* Updated `cli-3-44-0-changes.md` to reference only the Moderne SaaS instead of the DX microservice for `mod git sync moderne`

## Test plan

* [ ] Verify the license docs page renders correctly
* [ ] Verify the CLI 3.44.0 changes page renders correctly
* [ ] Confirm no broken links from the removed sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)