### PR TITLE
Update architecture doc for saasv2

### DIFF
--- a/docs/administrator-documentation/moderne-platform/references/architecture.md
+++ b/docs/administrator-documentation/moderne-platform/references/architecture.md
@@ -183,7 +183,7 @@ As configuring identity providers between services can be quite complex, the set
 
 The organization management services maintain the hierarchy of repositories that your team has onboarded into Moderne. Organizations provide a logical grouping of repositories that scopes visibility, permissions, and recipe execution targets.
 
-An indexer processes organization data from external sources (such as your Connector or CSV uploads) while a reader serves that data to the rest of the platform. When you run a recipe, you select an organization to run it against — this determines which repositories are included.
+The indexer works with the [Connector](#moderne-connector) to scan your configured artifact sources for updates and pull LST artifacts and recipe JARs into Moderne's internal data store. These artifacts are encrypted in transit and at rest. A reader serves organization and repository data to the rest of the platform. When you run a recipe, you select an organization to run it against — this determines which repositories are included.
 
 **Setup requirements**
 


### PR DESCRIPTION
* Replaces the existing architecture doc with an updated version reflecting the SaaS v2 platform
* Uses "Connector" terminology (instead of "agent") throughout this doc — a docs-wide rename of other pages is a separate effort
* Replaces the static PNG architecture diagram with a simplified Mermaid diagram showing the v2 service topology
* Adds new sections for Changelog, Moddy, DevCenter, and Moderne Trigrep with links to detailed docs
* Replaces superseded sections (Netflix Eureka, generic worker/recipe execution/SCM/tokens services) with v2 microservice descriptions (Organization Management, Recipe Marketplace + Worker, Changeset Services, Authorization Service, Audit Service)
* Preserves the encryption/security narrative and all setup requirements unchanged
* Updates the API gateway section to describe Apollo Router federation

This is largely based on AI documentation created by @scuba10steve 

Open questions I have:
* Did the artifact storage model change at all? I just left it the same but it's not clear to me if that's accurate.
* Likewise, did the encryption model change at all? I left it as is (customer-held symmetric key, decrypt-on-use, revocable by shutting off Connector) - but unsure if that's accurate.