### PR TITLE
Update CLI / DX release notes for 3.57.13, 3.57.14

### DIFF
--- a/docs/releases/cli-dx.md
+++ b/docs/releases/cli-dx.md
@@ -13,6 +13,25 @@
 * Replace `StreamingResultPrinter` with RPC-safe offset computation
 * We're suppressing logging of some errors during maven java version detection
 
+### CLI / DX v3.57.14 (2026-03-05)
+
+#### What's Changed
+* Includes OpenRewrite v8.75.1
+* Add custom file-extension-to-parser mappings (build.parsers)
+* Add multi-version Node.js auto-discovery, PATH isolation, and devEngines detection
+
+### CLI / DX v3.57.13 (2026-03-04)
+
+#### What's Changed
+* Fix YAML recipe deletion and :null display in listing
+* Add `mod config build javascript nodeoptions` commands
+* Python fixes
+* Add `mod git rm` subcommand
+* Fix node config installation edit not persisting for list
+* Include sibling branches in repo-level repos-lock.csv
+* GPG commit signing
+* Fix delete to handle installed YAML recipes where paths are not normalized
+
 ### CLI / DX v4.0.3 (2026-03-02)
 
 #### What's Changed


### PR DESCRIPTION
**What**:
Added release notes for CLI / DX versions 3.57.14 and 3.57.13.

**Why**:
They were missing after the respective releases, most likely due to changes in the workflow definitions. Catching up.

