### PR TITLE
Improve Spring Boot migration workshop for Spring I/O

### DIFF
--- a/docs/hands-on-learning/spring-boot-migration/module-1-migration-assessment.md
+++ b/docs/hands-on-learning/spring-boot-migration/module-1-migration-assessment.md
@@ -15,8 +15,8 @@ In this module, you will run the Spring Boot 4 migration recipe in the Moderne P
 
 ### Steps
 
-1. Ensure `Moderne - Training` is still selected in the org dropdown.
-2. Click **DevCenter** in the left nav.
+1. Navigate to [app.moderne.io](https://app.moderne.io/) and sign in. Select **Moderne - Training** from the organization dropdown.
+2. Click **DevCenter** in the left nav. DevCenter is a dashboard that shows the upgrade status of your repositories at a glance — Java versions, Spring Boot versions, security issues, and more.
 3. Note the current status of Java and Spring Boot versions.
 4. Keep this page handy so you can compare after upgrading each group of repositories.
 
@@ -36,8 +36,8 @@ In this module, you will run the Spring Boot 4 migration recipe in the Moderne P
 
 #### Step 1: Open the Moderne Platform
 
-1. Navigate to [app.moderne.io](https://app.moderne.io/) and sign in.
-2. Select **Moderne - Training** from the organization dropdown.
+1. If you haven't already, navigate to [app.moderne.io](https://app.moderne.io/) and sign in.
+2. Confirm that **Moderne - Training** is selected in the organization dropdown.
 
 <figure>
   ![Organization dropdown with Moderne - Training selected](./assets/moderne-training-org.png)
@@ -53,7 +53,7 @@ In this module, you will run the Spring Boot 4 migration recipe in the Moderne P
   <figcaption>_Builder link_</figcaption>
 </figure>
 
-2. Click `+ New recipe` at the bottom of the "Manage my recipes" screen. If the builder already has a recipe open, click the recipe name in the upper left and select `New`.
+2. Click **+ New recipe** at the bottom of the "Manage my recipes" screen. If the builder already has a recipe open, click the recipe name in the upper left and select **New**.
 
 <figure>
   ![Recipe builder welcome modal with New recipe button highlighted](../../user-documentation/moderne-platform/how-to-guides/assets/recipe-welcome-modal.png)
@@ -79,7 +79,6 @@ In this module, you will run the Spring Boot 4 migration recipe in the Moderne P
   <figcaption>_Add recipes from the recipe list_</figcaption>
 </figure>
 
-
 5. Search for `Migrate to Spring Boot 4.0` ([`io.moderne.java.spring.boot4.UpgradeSpringBoot_4_0`](https://docs.openrewrite.org/recipes/java/spring/boot4/upgradespringboot_4_0-moderne-edition)) and select it.
 6. Click **Add recipe**.
 
@@ -97,7 +96,7 @@ In this module, you will run the Spring Boot 4 migration recipe in the Moderne P
 
 #### Step 3: Run the recipe and review the migration
 
-1. Run the recipe against the organization by clicking the `Dry Run` button above the recipe list.
+1. Run the recipe against the organization by clicking the **Dry Run** button above the recipe list. A dry run executes the recipe across all repositories in the selected organization and shows you what changes it would make, without actually modifying any code.
 2. Open the change tree and click into a few files to review. Look for failures highlighted in the diffs by yellow squiggly lines.
 3. Take a few minutes to review the failures and note missing or incompatible classes and dependencies. 
 
@@ -137,9 +136,9 @@ A migration dry run plus the `Verify compilation` recipe ([`io.moderne.compiled.
 
 #### Step 1: Understand your Java adoption
 
-1. From the Marketplace, search for and select `Plan a Java version migration` ([`org.openrewrite.java.migrate.search.PlanJavaMigration`](https://docs.openrewrite.org/recipes/java/migrate/search/planjavamigration)).
-2. Make sure `Moderne - Training` is still selected and click `Dry run` to run the recipe against the org.
-3. After the recipe run, click on the `Data tables` tab. Then download and open the `Java version migration plan` data table as a CSV or Excel file.
+1. Click **Marketplace** in the left navigation to browse available recipes. Search for and select `Plan a Java version migration` ([`org.openrewrite.java.migrate.search.PlanJavaMigration`](https://docs.openrewrite.org/recipes/java/migrate/search/planjavamigration)).
+2. Make sure **Moderne - Training** is still selected and click **Dry run** to run the recipe against the org.
+3. After the recipe run, click on the **Data tables** tab. Some recipes do not modify code — instead they analyze it and produce structured output called "data tables." Download and open the `Java version migration plan` data table as a CSV or Excel file.
 
 <figure>
   ![Data tables tab with Java version migration plan available for download](./assets/java-version-migration-plan-data-table.png)
@@ -147,7 +146,7 @@ A migration dry run plus the `Verify compilation` recipe ([`io.moderne.compiled.
 </figure>
 
 :::note
-You won't see any diff results when running this recipe. It only generates data tables that you can access from the `Data tables` tab.
+You won't see any diff results when running this recipe. It only generates data tables that you can access from the **Data tables** tab.
 :::
 
 This helps you confirm the baseline Java versions and build tooling in use so you know what you are starting from. For this example, you're using Java 8 and Maven across the board. 
@@ -156,11 +155,11 @@ This helps you confirm the baseline Java versions and build tooling in use so yo
 
 1. From the Marketplace, search for and select `Dependency insight for Gradle and Maven` ([`org.openrewrite.java.dependencies.DependencyInsight`](https://docs.openrewrite.org/recipes/java/dependencies/dependencyinsight)).
 2. Configure the options:
-   - **Group pattern:** `org.springframework.boot`
-   - **Artifact pattern:** `*`
-   - **Scope:** `runtime`
+   * **Group pattern:** `org.springframework.boot`
+   * **Artifact pattern:** `*`
+   * **Scope:** `runtime`
 3. Click **Dry run** and wait for the recipe run to complete. Now open the `Dependencies in use` data table and download the CSV.
-4. On the `Visualizations` tab, run the `Dependency usage visualization`.
+4. On the **Visualizations** tab, run the `Dependency usage visualization`. Visualizations offer interactive views of the data produced by the recipe run.
 
 <figure>
   ![Dependency usage visualization with Run visualization button](./assets/dependency-usage-visualization.png)
@@ -175,7 +174,7 @@ While you can run libraries compiled with an older version of Java in newer vers
 
 1. From the Marketplace, search for and select `Find types` ([`org.openrewrite.java.search.FindTypes`](https://docs.openrewrite.org/recipes/java/search/findtypes)).
 2. Configure the option:
-   - **Fully qualified type name:** `javax..*`
+   * **Fully qualified type name:** `javax..*`
 3. Click **Dry run**.
 4. Open the `Type uses` data table and note the top usage hotspots.
 
@@ -187,8 +186,8 @@ Code generators like QueryDSL are often the hardest blockers because they can em
 
 1. From the Marketplace, search for and select `Find Maven plugins` ([`org.openrewrite.maven.search.FindPlugin`](https://docs.openrewrite.org/recipes/maven/search/findplugin)).
 2. Configure the options:
-   - **Group ID:** `com.mysema.maven`
-   - **Artifact ID:** `apt-maven-plugin`
+   * **Group ID:** `com.mysema.maven`
+   * **Artifact ID:** `apt-maven-plugin`
 3. Click **Dry run**.
 4. Open the `SearchResults` data table and note which repos use QueryDSL.
 

--- a/docs/hands-on-learning/spring-boot-migration/module-2-wave-planning.md
+++ b/docs/hands-on-learning/spring-boot-migration/module-2-wave-planning.md
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 
 # Module 2: Wave planning with the Moderne CLI
 
-In this module, you'll move from SaaS-only assessment to CLI-driven analysis so you can map dependencies and pick a safe upgrade order. You will group repositories into “waves” based on those dependencies and upgrade them in order.
+In this module, you'll move from SaaS-only assessment to CLI-driven analysis so you can map dependencies and pick a safe upgrade order. The CLI lets you run recipes against local clones, apply changes directly to your working tree, and integrate with your existing build and release tooling — capabilities you will need for the build-test-release cycle in later modules. You will group repositories into “waves” based on their dependencies and upgrade them in order.
 
 For this workshop, each repository is treated as independently released. That constraint mirrors how large organizations manage shared libraries and it forces you to think about sequencing instead of upgrading everything at once. Dependencies matter because downstream repos can only move once their upstream libraries are upgraded and released. 
 
@@ -57,7 +57,6 @@ cd $WORKSPACE
 ```bash
 mod git sync moderne $WORKSPACE --organization "Moderne - Training" --with-sources
 ```
-
 
 <details>
 <summary>Reference output</summary>
@@ -280,6 +279,10 @@ mod study $WORKSPACE --last-recipe-run --data-table org.openrewrite.maven.table.
 
 #### Step 3: Generate the wave map
 
+:::note
+If you don't have a Python environment or would prefer to skip this step, you can jump ahead to Exercise 2-3 and use the pre-built wave list provided there.
+:::
+
 1. To run the Jupyter notebook, you will need Python and a small virtual environment setup. It is recommended to use `uv`, a [fast Python package manager and virtual environment tool](https://github.com/astral-sh/uv). If you do not have it installed, follow the install steps in the [uv documentation](https://docs.astral.sh/uv/#installation).
 
 Run these commands once to create the virtual environment and install the notebook dependencies:
@@ -291,18 +294,18 @@ source .venv/bin/activate
 uv sync
 ```
 
-2. You can run the notebook using the command line tool `papermill` CLI tool, or use a Jupyter notebook UI. Choose one of these two options:
+2. You can run the notebook using the `papermill` CLI tool or a Jupyter notebook UI. Choose one of these two options:
 
 <Tabs groupId="wave-map">
 <TabItem value="cli" label="CLI (papermill)" default>
 
-This is the easiest option if you want to run the notebook end-to-end from the CLI. _Make sure you replace `<recipe_run_id>` with the ID you retrieved in the previous step._
+This is the easiest option if you want to run the notebook end-to-end from the CLI. _Make sure you replace `RECIPE_RUN_ID` with the ID you retrieved in the previous step (e.g., `20260114165424-VXLMR`)._
 
 ```bash
 papermill $PROJECTS/Release-Train-Metro-Plan/src/main/python/ArchitecturalAnalysis.ipynb \
   $PROJECTS/Release-Train-Metro-Plan/src/main/python/ArchitecturalAnalysis_out.ipynb \
   -p workspace $WORKSPACE \
-  -p recipe_run <recipe_run_id> \
+  -p recipe_run RECIPE_RUN_ID \
   --progress-bar \
   --inject-paths
 ```
@@ -320,14 +323,10 @@ Open the notebook in Jupyter (or a Jupyter editor like VS Code), then update the
 </TabItem>
 </Tabs>
 
-:::note
-If neither option works for you or you don't have a Python environment, don't worry. You can skip the rest of this exercise and still continue with the workshop using the wave list shown in the next exercise.
-:::
-
 3. Open the generated output HTML file to view the wave diagram and note the repository order:
 
 ```bash
-open $PROJECTS/Release-Train-Metro-Plan/src/main/static/metro-plan.html
+open $PROJECTS/Release-Train-Metro-Plan/src/main/static/metro-plan.html  # macOS; use xdg-open on Linux
 ```
 
 4. Now that you have a wave plan, you need a way to target a specific wave with recipe runs and releases. Instead of syncing with the organization in the platform as you did before, you will now use the `repos.csv` method to group repositories by wave. There are a few ways you could do that:

--- a/docs/hands-on-learning/spring-boot-migration/module-3-establish-baseline.md
+++ b/docs/hands-on-learning/spring-boot-migration/module-3-establish-baseline.md
@@ -29,22 +29,22 @@ You saw from the analysis earlier that these projects all use a variety of Sprin
 </figure>
 
 3. Add the following recipes in order:
-   - **`Apache Maven best practices`** ([`org.openrewrite.maven.BestPractices`](https://docs.openrewrite.org/recipes/maven/bestpractices))
-   - **`Migrate to Java 8`** ([`org.openrewrite.java.migrate.UpgradeToJava8`](https://docs.openrewrite.org/recipes/java/migrate/upgradetojava8))
-   - **`Migrate to Spring Boot 2.7`** ([`org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_7`](https://docs.openrewrite.org/recipes/java/spring/boot2/upgradespringboot_2_7))
-   - **`Change Maven dependency`** ([`org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId`](https://docs.openrewrite.org/recipes/maven/changedependencygroupidandartifactid))
+   * **`Apache Maven best practices`** ([`org.openrewrite.maven.BestPractices`](https://docs.openrewrite.org/recipes/maven/bestpractices))
+   * **`Migrate to Java 8`** ([`org.openrewrite.java.migrate.UpgradeToJava8`](https://docs.openrewrite.org/recipes/java/migrate/upgradetojava8))
+   * **`Migrate to Spring Boot 2.7`** ([`org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_7`](https://docs.openrewrite.org/recipes/java/spring/boot2/upgradespringboot_2_7))
+   * **`Change Maven dependency`** ([`org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId`](https://docs.openrewrite.org/recipes/maven/changedependencygroupidandartifactid))
 4. Configure the dependency change:
-   - **Old groupId:** `org.springframework.cloud`
-   - **Old artifactId:** `spring-cloud-starter-zipkin`
-   - **New groupId:** `org.springframework.cloud`
-   - **New artifactId:** `spring-cloud-sleuth-zipkin`
+   * **Old groupId:** `org.springframework.cloud`
+   * **Old artifactId:** `spring-cloud-starter-zipkin`
+   * **New groupId:** `org.springframework.cloud`
+   * **New artifactId:** `spring-cloud-sleuth-zipkin`
 
 <figure>
   ![Baseline recipe list with Maven best practices, Java 8, Spring Boot 2.7, and dependency change](./assets/migration-baseline-recipe.png)
   <figcaption>_Your custom migration baseline recipe_</figcaption>
 </figure>
 
-5. Open the recipe dropdown (top left) and choose `Download YAML`.
+5. Open the recipe dropdown (top left) and choose **Download YAML**.
 
 <figure>
   ![Recipe dropdown menu with Download YAML option highlighted](./assets/download-yaml.png)
@@ -63,17 +63,16 @@ You saw from the analysis earlier that these projects all use a variety of Sprin
 
 #### Step 1: Save and install the recipe
 
-Copy the recipe to your `$WORKSHOP` directory and install it locally:
+Copy the downloaded YAML file to your `$WORKSHOP` directory and install it locally. The filename may vary depending on your browser — look for the most recently downloaded `.yml` file in your Downloads folder:
 
 ```bash
-# If your download location is different, replace with whatever path you used for the YAML file
 cp ~/Downloads/Spring\ Boot\ Migration\ Workshop\ Baseline.yml $WORKSHOP/WorkshopBaseline.yml
 mod config recipes yaml install $WORKSHOP/WorkshopBaseline.yml
 ```
 
 #### Step 2: Build LSTs, then run the recipe and apply changes
 
-1. Since you synced repositories from the wave-specific CSV file instead of the platform, the LSTs aren't available for download, so you'll need to build them before running recipes:
+1. When you re-synced from the wave-aware CSV in Exercise 2-3, the workspace was restructured into wave directories. The LSTs from the original platform sync are no longer in the expected locations, so you need to rebuild them:
 
 ```bash
 mod build $WORKSPACE
@@ -92,7 +91,7 @@ mod git apply $WORKSPACE --last-recipe-run
 
 #### Step 3: Build and release
 
-This repository includes some helper scripts to run commands like building, testing, and releasing. Use the `build.sh` script to build and run tests for all the projects, and the `release.sh` script to release your code for downstream dependencies to consume. To publish a release, the script automatically installs the current non-SNAPSHOT version of each repository into your local Maven cache. It will then bump the project's version to the next available minor SNAPSHOT version, ready for you to make more changes. Both scripts build or release all repositories, but they each accept an argument representing a target wave number. So `build.sh 1` will only build the repositories in Wave 1.
+The `moderne-migration-practice` repository you cloned in Module 2 includes helper scripts in `$WORKSHOP`. Use `build.sh` to build and run tests for all the projects, and `release.sh` to release your code for downstream dependencies to consume. The release script installs the current non-SNAPSHOT version of each repository into your local Maven cache (`~/.m2`), then bumps the project's version to the next minor SNAPSHOT. In a real organization, this step would be handled by your CI/CD pipeline publishing to an artifact repository; for this workshop, a local Maven install simulates that. Both scripts accept an optional wave number argument — for example, `build.sh 1` only builds Wave 1 repositories.
 
 You will be using both of these commands going forward after you make changes to the code to simulate the software development lifecycle of building and releasing new versions of these repositories that would usually be handled by your existing process outside of OpenRewrite and Moderne.
 

--- a/docs/hands-on-learning/spring-boot-migration/module-4-smoke-test.md
+++ b/docs/hands-on-learning/spring-boot-migration/module-4-smoke-test.md
@@ -17,9 +17,9 @@ In this module, you will raise the Java baseline to 17 and run a controlled Spri
 
 ### Steps
 
-1. Back in the [Moderne Platform](https://app.moderne.io), relogin if needed, then click `Activity` in the left navigation.
+1. Back in the [Moderne Platform](https://app.moderne.io), relogin if needed, then click **Activity** in the left navigation. The Activity page shows a history of all recipe runs, including their status and results.
 2. Open the failed run of your custom `Try Spring Boot 4 Upgrade` recipe from Module 1 that included [`io.moderne.java.spring.boot4.UpgradeSpringBoot_4_0`](https://docs.openrewrite.org/recipes/java/spring/boot4/upgradespringboot_4_0) and [`io.moderne.compiled.verification.VerifyCompilation`](https://docs.openrewrite.org/recipes/compiled/verification/verifycompilation).
-3. Click the `Visualizations` tab and run the `Composite recipe results` visualization.
+3. Click the **Visualizations** tab and run the **Composite recipe results** visualization.
 
 <figure>
   ![Visualizations tab showing Composite recipe results Sankey diagram options](./assets/run-composite-recipe-results-visualization.png)
@@ -52,12 +52,13 @@ Spring Boot 2.7 doesn't support Java 25. If you try `UpgradeToJava25` ([`org.ope
 
 #### Step 2: Build and commit
 
-Now that the changes have been applied, confirm the build still works, then commit the code and rebuild your LSTs:
+Now that the changes have been applied, confirm the build still works, then commit the code, release, and rebuild your LSTs. The release step is important because downstream repos in later waves need to resolve the Java 17 versions of their upstream dependencies:
 
 ```bash
 $WORKSHOP/build.sh
 mod git add $WORKSPACE --last-recipe-run
 mod git commit $WORKSPACE -m "Upgrade to Java 17" --last-recipe-run
+$WORKSHOP/release.sh
 mod build $WORKSPACE
 ```
 
@@ -273,7 +274,7 @@ Done (1m 14s)
 Built 11 repositories.
 
 ⏺ What to do next
-    > Run mod run /Users/somebody/workspaces/migration-practice-workspace --recipe=<RecipeName&rt;
+    > Run mod run /Users/somebody/workspaces/migration-practice-workspace --recipe=<RecipeName>
     > Analyze build results with mod trace builds analyze /Users/somebody/workspaces/migration-practice-workspace --last-build
     > Run mod log builds add /Users/somebody/workspaces/migration-practice-workspace logs.zip --last-build to aggregate build logs
 
@@ -304,6 +305,7 @@ First, run the recipe and apply the changes:
 mod run $WORKSPACE --recipe io.moderne.java.spring.boot4.UpgradeSpringBoot_4_0
 mod git apply $WORKSPACE --last-recipe-run
 ```
+
 :::note
 Don't worry if you see warnings about "errors while running the recipe." You'll still be able to move on to the remaining steps.
 :::
@@ -333,7 +335,7 @@ $WORKSHOP/build.sh
 mod build $WORKSPACE
 ```
 
-This restores all uncommitted changes from the smoke test and returns to the Java 17 baseline.
+`MODERNE_BUILD_TOOL_DIR` is a special token that the `mod exec` command expands to the build tool directory (`.`) in each repository. This restores all uncommitted changes from the smoke test and returns to the Java 17 baseline.
 
 ## Takeaways
 

--- a/docs/hands-on-learning/spring-boot-migration/module-5-build-querydsl-recipe.md
+++ b/docs/hands-on-learning/spring-boot-migration/module-5-build-querydsl-recipe.md
@@ -25,7 +25,7 @@ You already saw signs of this in Module 1, Exercise 1-3, where you located code 
 
 #### Step 2: Search for QueryDSL usage
 
-Use `mod search` to find all QueryDSL-related code across the workspace. Trigrep supports file path filters and language filters, so you can target your searches precisely.
+Use `mod search` to find all QueryDSL-related code across the workspace. It supports file path filters (`file:`) and language filters (`lang:`), so you can target your searches precisely.
 
 First, find the Maven plugin declaration in POM files:
 
@@ -97,7 +97,7 @@ The agent will run the same searches you did above, cross-reference them with th
 
 #### Step 1: Set up the recipe project
 
-Create a directory for the recipe project and launch your agent:
+Create a directory for the recipe project and launch your AI coding agent. This exercise uses [Claude Code](https://docs.anthropic.com/en/docs/claude-code) with the Moderne extension, but you can use any AI coding agent or build the recipe manually. If you don't have an agent available, skip to the fallback option in Step 4.
 
 ```bash
 mkdir -p $PROJECTS/rewrite-querydsl && cd $PROJECTS/rewrite-querydsl
@@ -146,11 +146,11 @@ Most of the migration is declarative. The `.list(..)` → `.fetch()` change may 
 
 #### Step 4: Build and install
 
-Once the agent has produced the recipe, build and install it locally:
+Once the agent has produced the recipe, build and install it locally. Use the group, artifact, and version from the generated project's build file (`build.gradle` or `pom.xml`):
 
 ```bash
 ./gradlew build  # or mvn clean install, depending on the scaffold
-mod config recipes jar install <group>:<artifact>:<version>
+mod config recipes jar install <group>:<artifact>:<version>  # e.g., org.openrewrite.recipe:rewrite-querydsl:0.1.0-SNAPSHOT
 ```
 
 :::tip
@@ -189,10 +189,10 @@ This exercise followed an abbreviated version of the plan-build-test workflow fr
 
 #### Step 1: Run the recipe
 
-Run your recipe against the workspace to see what it changes:
+Run your recipe against the workspace to see what it changes. If you used the pre-built fallback, the recipe name is `org.openrewrite.recipe.querydsl.UpgradeToQueryDsl5`:
 
 ```bash
-mod run $WORKSPACE --recipe <your-recipe-name>
+mod run $WORKSPACE --recipe org.openrewrite.recipe.querydsl.UpgradeToQueryDsl5
 ```
 
 Review the diffs using ctrl-click (Windows) or cmd-click (Mac) on the patch links to confirm the changes look correct.

--- a/docs/hands-on-learning/spring-boot-migration/module-6-wave-migration.md
+++ b/docs/hands-on-learning/spring-boot-migration/module-6-wave-migration.md
@@ -15,7 +15,7 @@ In this module, you will build a composite upgrade recipe that includes the Quer
 
 ### Steps
 
-You could try to just run the custom QueryDSL recipe, but there is a chicken-and-egg issue: Spring Boot 4 expects `jakarta.*` APIs, but QueryDSL 3 generates `javax.*`-based code that will not compile. The solution is to upgrade QueryDSL and Spring Boot in a single, repeatable recipe. You can do that using a composite YAML recipe similar to the way you built one in Module 1.
+You could try to just run the custom QueryDSL recipe, but there is a chicken-and-egg issue: Spring Boot 4 expects `jakarta.*` APIs, but QueryDSL 3 generates `javax.*`-based code that will not compile. Applying QueryDSL 5 alone would leave Spring Boot 2.7 (which expects `javax.*`); applying Spring Boot 4 alone would leave QueryDSL 3 (which generates `javax.*`). Neither order works in isolation. The solution is to upgrade QueryDSL and Spring Boot in a single, repeatable recipe. You can do that using a composite YAML recipe similar to the way you built one in Module 1.
 
 Additionally, since you will be upgrading in waves to ensure that custom library dependencies are handled in the proper sequence, you also need to make sure to update the dependency versions in each wave to use the newly released version from the previous wave. So you will need to include this step in the composite recipe as well.
 
@@ -23,10 +23,10 @@ Additionally, since you will be upgrading in waves to ensure that custom library
 This is an example of a migration recipe _freight train_. You will often build a custom recipe that runs the out-of-the-box recipes and then applies some additional ones that are needed in your particular environment. In this workshop, the composite recipe upgrades internal dependencies, applies the Spring Boot 4 recipe, and then runs the QueryDSL upgrade.
 :::
 
-1. Create a local YAML recipe file. This composite recipe is named `org.openrewrite.recipe.querydsl.CustomUpgradeSpringBoot_4_0` and combines [`org.openrewrite.java.dependencies.UpgradeDependencyVersion`](https://docs.openrewrite.org/recipes/java/dependencies/upgradedependencyversion), [`io.moderne.java.spring.boot4.UpgradeSpringBoot_4_0`](https://docs.openrewrite.org/recipes/java/spring/boot4/upgradespringboot_4_0), and `org.openrewrite.recipe.querydsl.UpgradeToQueryDsl5`. If you prefer, you can copy and paste the YAML directly into a new file named `CustomUpgradeSpringBoot_4_0.yml` instead of using the command.
+1. Create a local YAML recipe file in your `$WORKSHOP` directory. This composite recipe is named `org.openrewrite.recipe.querydsl.CustomUpgradeSpringBoot_4_0` and combines [`org.openrewrite.java.dependencies.UpgradeDependencyVersion`](https://docs.openrewrite.org/recipes/java/dependencies/upgradedependencyversion), [`io.moderne.java.spring.boot4.UpgradeSpringBoot_4_0`](https://docs.openrewrite.org/recipes/java/spring/boot4/upgradespringboot_4_0), and `org.openrewrite.recipe.querydsl.UpgradeToQueryDsl5`. If you prefer, you can copy and paste the YAML directly into a new file instead of using the command.
 
 ```bash
-cat <<'EOF' > CustomUpgradeSpringBoot_4_0.yml
+cat <<'EOF' > $WORKSHOP/CustomUpgradeSpringBoot_4_0.yml
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.recipe.querydsl.CustomUpgradeSpringBoot_4_0
@@ -51,7 +51,7 @@ You can't use recipe builder in this case since you are referring to a custom re
 2. Install `org.openrewrite.recipe.querydsl.CustomUpgradeSpringBoot_4_0` locally with the CLI:
 
 ```bash
-mod config recipes yaml install CustomUpgradeSpringBoot_4_0.yml
+mod config recipes yaml install $WORKSHOP/CustomUpgradeSpringBoot_4_0.yml
 ```
 
 ## Exercise 6-2: Upgrade wave 0
@@ -76,9 +76,12 @@ mod git apply $WORKSPACE/Wave0 --last-recipe-run
 Notice you are referencing the `Wave0` directory for each of the `mod` commands. This is taking advantage of the organizational directory structure to target only the wave you want to apply changes to so you can do each wave individually.
 :::
 
-2. Now that the changes have been applied, verify the build and release for the wave:
+2. Now that the changes have been applied, build to verify, commit, and release:
 
 ```bash
+$WORKSHOP/build.sh 0
+mod git add $WORKSPACE/Wave0 --last-recipe-run
+mod git commit $WORKSPACE/Wave0 -m "Upgrade to Spring Boot 4" --last-recipe-run
 $WORKSHOP/release.sh 0
 ```
 
@@ -100,10 +103,12 @@ mod run $WORKSPACE/Wave1 --recipe org.openrewrite.recipe.querydsl.CustomUpgradeS
 mod git apply $WORKSPACE/Wave1 --last-recipe-run
 ```
 
-2. This time, build Wave 1 to make sure there are no errors, then release it:
+2. This time, build Wave 1 to make sure there are no errors, commit, and release:
 
 ```bash
 $WORKSHOP/build.sh 1
+mod git add $WORKSPACE/Wave1 --last-recipe-run
+mod git commit $WORKSPACE/Wave1 -m "Upgrade to Spring Boot 4" --last-recipe-run
 $WORKSHOP/release.sh 1
 ```
 
@@ -258,16 +263,35 @@ MOD SUCCEEDED in 4s
     * Wave 0 and Wave 1 now show Spring Boot 4.0
     * Remaining waves are still pending
 
-5. You can now continue upgrading waves until every repository is on Spring Boot 4. Use the commands as in Exercise 6-3, each time targeting the next wave:
+5. Continue upgrading the remaining waves. Repeat the same pattern for each wave:
 
 ```bash
 mod run $WORKSPACE/Wave2 --recipe org.openrewrite.recipe.querydsl.CustomUpgradeSpringBoot_4_0
 mod git apply $WORKSPACE/Wave2 --last-recipe-run
 $WORKSHOP/build.sh 2
+mod git add $WORKSPACE/Wave2 --last-recipe-run
+mod git commit $WORKSPACE/Wave2 -m "Upgrade to Spring Boot 4" --last-recipe-run
 $WORKSHOP/release.sh 2
-
-# ...and so on
 ```
+
+```bash
+mod run $WORKSPACE/Wave3 --recipe org.openrewrite.recipe.querydsl.CustomUpgradeSpringBoot_4_0
+mod git apply $WORKSPACE/Wave3 --last-recipe-run
+$WORKSHOP/build.sh 3
+mod git add $WORKSPACE/Wave3 --last-recipe-run
+mod git commit $WORKSPACE/Wave3 -m "Upgrade to Spring Boot 4" --last-recipe-run
+$WORKSHOP/release.sh 3
+```
+
+6. After all waves are complete, rebuild LSTs and refresh DevCenter one final time to confirm the migration is done:
+
+```bash
+mod build $WORKSPACE
+mod run $WORKSPACE --recipe io.moderne.devcenter.DevCenterStarter
+mod devcenter $WORKSPACE --last-recipe-run
+```
+
+The final dashboard should show all 11 repositories on Spring Boot 4.0 and Java 17.
 
 ## Takeaways
 

--- a/docs/hands-on-learning/spring-boot-migration/workshop-overview.md
+++ b/docs/hands-on-learning/spring-boot-migration/workshop-overview.md
@@ -22,14 +22,17 @@ Throughout the workshop, you will see screenshot placeholders and collapsible **
 
 To get the most out of this workshop, you should:
 
-* Have basic Java knowledge
-* Know how to work with Maven
+* Have intermediate Java knowledge, including Maven dependency management
+* Be familiar with Spring Boot fundamentals
 * Be comfortable running CLI commands and managing git changes
 
 You will also need:
 
-* [Moderne CLI](../../user-documentation/moderne-cli/getting-started/cli-intro.md) (version 3.55.3 or higher recommended)
+* A [Moderne Platform](https://app.moderne.io) account with access to the **Moderne - Training** organization (your workshop facilitator will provide access)
+* [Moderne CLI](../../user-documentation/moderne-cli/getting-started/cli-intro.md) (version 4.x recommended), authenticated against the Moderne Platform (`mod config moderne edit`)
 * A JDK installed locally (Java 17 or higher recommended)
+* Git installed locally
+* Python 3 and [uv](https://docs.astral.sh/uv/) (optional, for the wave planning notebook in Module 2)
 
 ## Workshop modules
 


### PR DESCRIPTION
## Summary

Simulated two workshop participant personas (Java veteran new to Moderne, junior dev following instructions literally) walking through all 6 modules to surface documentation gaps before Spring I/O.

* **Blockers fixed**: Added missing sign-in steps in Module 1, missing prerequisites (Platform account, CLI auth, Git, Python), missing release step after Java 17 commit in Module 4, resolved unresolved command placeholders in Module 5
* **Confusion points addressed**: Added Marketplace navigation, explained DevCenter/data tables/visualizations on first use, motivated Platform-to-CLI transition, explained `MODERNE_BUILD_TOOL_DIR`, added commit steps before release in Module 6, completed Wave 3 commands and final DevCenter verification
* **Style guide compliance**: Dashes to asterisks (Rule 3), UI elements bold instead of backticks (Rule 20), removed double blank lines (Rule 21), fixed `&rt;` HTML entity typo

## Test plan

* [x] `yarn build` passes with no errors or broken links
* [ ] Visual review of changed pages in browser
* [ ] Walk through Module 1 sign-in flow to confirm ordering makes sense
* [ ] Verify Module 4 release step fits the reference output sequence