### PR TITLE
Polish h1 typography and tighten top alignment

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -347,9 +347,9 @@ html {
   }
 }
 
-/* Doc main container padding for breathing room */
+/* Align top of main content with top of sidebar */
 [class*="docMainContainer"] {
-  padding-top: var(--neo-spacing_4);
+  padding-top: 0;
 }
 
 .reactPlayer + p {
@@ -360,16 +360,17 @@ html {
   font-size: var(--neo-font-size-default);
 }
 
-/* Apply flexbox with 32px gap between breadcrumbs and document content */
 [class*="docItemContainer"] article {
   display: flex;
   flex-direction: column;
-  gap: var(--neo-spacing_4);
 }
 
-[class^=docMainContainer_] h1 {
-  font-size: var(--neo-font-size-h1);
-  font-weight: var(--neo-font-weight-medium);
+h1 {
+  font-family: var(--neo-font-family-heading), sans-serif;
+  font-size: 36px !important;
+  font-weight: 700 !important;
+  line-height: 45px;
+  color: var(--brand-midnight);
 }
 
 [class^=docMainContainer_] h2:not(.doc-card-title) {

--- a/src/theme/DocCategoryGeneratedIndexPage/styles.module.css
+++ b/src/theme/DocCategoryGeneratedIndexPage/styles.module.css
@@ -39,13 +39,12 @@
   flex-direction: column;
   gap: var(--neo-spacing_1);
 
-  /* Page header typography - matching Figma design (node 478:5567)
-     Nested for higher specificity to override Docusaurus h1 defaults */
   .title {
-    font-size: var(--neo-font-size-h3);
-    font-weight: var(--neo-font-weight-medium);
-    line-height: 1.4;
-    color: var(--neo-typography-input-default);
+    font-family: var(--neo-font-family-heading), sans-serif;
+    font-size: 36px;
+    font-weight: var(--neo-font-weight-bold);
+    line-height: 45px;
+    color: var(--brand-midnight);
     margin: 0;
   }
 

--- a/src/theme/DocSidebarItems/styles.module.css
+++ b/src/theme/DocSidebarItems/styles.module.css
@@ -4,6 +4,6 @@
 
 .platformToggleRow {
   display: flex;
-  margin-top: var(--neo-spacing_2);
+  margin-top: -4px;
   list-style: none;
 }


### PR DESCRIPTION
## Summary

* Global \`h1\` is now Inter 700 / 36px / 45px line-height / \`--brand-midnight\` (rgb(4, 24, 52))
* \`DocCategoryGeneratedIndexPage\` \`.title\` matches the same spec (was 21px / 500)
* Removed phantom top padding on \`docMainContainer\` and the unused breadcrumb flex-gap so the page heading aligns with the top of the sidebar
* \`PlatformToggle\` row pulled up 20px so the User/Admin pill sits closer to the secondary-nav divider

## Why

The page heading sat noticeably lower than the sidebar's first item. Aligning them and bumping the heading to a real H1 size (the spec called for 36px) gives every doc page a stronger, more consistent visual anchor.

## Test plan

- [ ] Run \`yarn start\` and verify all H1s render at 36px / 700 / Inter
- [ ] Check a category index page (e.g. \`/getting-started/\`) — title should also be 36px
- [ ] Verify the User/Admin toggle aligns roughly with the top of the main content area
- [ ] Dark mode still readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)