### PR TITLE
Restyle inline code as a borderless light-grey pill

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -434,6 +434,23 @@ h1, .markdown h3, .markdown h4 {
   font-weight: bold;
 }
 
+/* Inline code: borderless pill with light grey background */
+.markdown :not(pre) > code {
+  background-color: var(--neo-code-background);
+  border: none;
+  border-radius: var(--neo-border-radius-x-s);
+  color: var(--neo-typography-code-primary);
+  font-family: var(--neo-font-family-code), monospace;
+  font-size: var(--neo-font-size-code);
+  padding: 2px 6px;
+  vertical-align: baseline;
+}
+
+html[data-theme='dark'] .markdown :not(pre) > code {
+  background-color: var(--neo-grey-800);
+  color: var(--neo-grey-100);
+}
+
 /* Colorblind-friendly code highlighting */
 :root {
   /* Light theme highlight colors - colorblind accessible */


### PR DESCRIPTION
## Summary

* Inline \`code\` now renders as a borderless pill on a \`--neo-code-background\` (light grey) fill with \`--neo-border-radius-x-s\` (4px) corners
* Font drops to JetBrains Mono at \`--neo-font-size-code\` (14px) with 2px/6px padding
* Dark mode swaps to \`--neo-grey-800\` background with \`--neo-grey-100\` text

## Why

The previous Docusaurus default rendered inline code with a 1px border at 95% font-size, which read as cluttered next to body copy. The new pill is quieter and matches the design system tokens (\`--neo-code-background\`, \`--neo-typography-code-primary\`).

## Test plan

- [ ] Run \`yarn start\` and verify any page with inline code (e.g. \`docs/user-documentation/\`) renders the new pill
- [ ] Confirm code blocks (\`pre code\`) are unaffected — only \`:not(pre) > code\` is targeted
- [ ] Toggle dark mode and verify contrast

🤖 Generated with [Claude Code](https://claude.com/claude-code)