### PR TITLE
Redesign admonitions with Lucide icons

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -434,6 +434,113 @@ h1, .markdown h3, .markdown h4 {
   font-weight: bold;
 }
 
+/* Replit-style admonitions: rounded, subtle border, icon inline with text */
+.theme-admonition {
+  border: 1px solid;
+  border-radius: var(--neo-border-radius-m);
+  padding: var(--neo-spacing_2);
+  display: flex;
+  flex-direction: row;
+  gap: var(--neo-spacing_1);
+  align-items: flex-start;
+}
+
+.theme-admonition [class*='admonitionHeading_'] {
+  margin: 0;
+  font-size: 0;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.theme-admonition [class*='admonitionHeading_'] [class*='admonitionIcon_'] {
+  font-size: initial;
+  margin-right: 0;
+  display: inline-flex;
+  align-items: center;
+}
+
+.theme-admonition [class*='admonitionHeading_'] [class*='admonitionIcon_'] svg {
+  fill: none;
+  stroke: currentColor;
+}
+
+.theme-admonition [class*='admonitionContent_'] {
+  flex: 1;
+  color: inherit;
+}
+
+.theme-admonition [class*='admonitionContent_'] > p:first-child {
+  margin-top: 0;
+}
+
+.theme-admonition [class*='admonitionContent_'] > p:last-child {
+  margin-bottom: 0;
+}
+
+/* Per-type colors */
+.theme-admonition-info {
+  background-color: var(--neo-digital-blue-50);
+  border-color: var(--neo-digital-blue-200);
+  color: var(--neo-digital-blue-600);
+}
+
+.theme-admonition-tip {
+  background-color: var(--neo-digital-green-50);
+  border-color: var(--neo-digital-green-300);
+  color: var(--neo-digital-green-800);
+}
+
+.theme-admonition-note {
+  background-color: var(--neo-grey-50);
+  border-color: var(--neo-grey-200);
+  color: var(--neo-grey-800);
+}
+
+.theme-admonition-warning,
+.theme-admonition-caution {
+  background-color: var(--neo-orange-50);
+  border-color: var(--neo-gold-200);
+  color: var(--neo-gold-800);
+}
+
+.theme-admonition-danger {
+  background-color: var(--neo-red-50);
+  border-color: var(--neo-red-200);
+  color: var(--neo-red-700);
+}
+
+/* Dark mode */
+html[data-theme='dark'] .theme-admonition-info {
+  background-color: var(--neo-digital-blue-900);
+  border-color: var(--neo-digital-blue-700);
+  color: var(--neo-digital-blue-100);
+}
+
+html[data-theme='dark'] .theme-admonition-tip {
+  background-color: var(--neo-digital-green-900);
+  border-color: var(--neo-digital-green-700);
+  color: var(--neo-digital-green-100);
+}
+
+html[data-theme='dark'] .theme-admonition-note {
+  background-color: var(--neo-grey-900);
+  border-color: var(--neo-grey-700);
+  color: var(--neo-grey-100);
+}
+
+html[data-theme='dark'] .theme-admonition-warning,
+html[data-theme='dark'] .theme-admonition-caution {
+  background-color: var(--neo-gold-900);
+  border-color: var(--neo-gold-700);
+  color: var(--neo-gold-100);
+}
+
+html[data-theme='dark'] .theme-admonition-danger {
+  background-color: var(--neo-red-900);
+  border-color: var(--neo-red-700);
+  color: var(--neo-red-100);
+}
+
 /* Colorblind-friendly code highlighting */
 :root {
   /* Light theme highlight colors - colorblind accessible */

--- a/src/theme/Admonition/Type/Caution.tsx
+++ b/src/theme/Admonition/Type/Caution.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import type { ReactNode } from 'react';
+import clsx from 'clsx';
+import AdmonitionLayout from '@theme/Admonition/Layout';
+import { TriangleAlert } from 'lucide-react';
+
+const infimaClassName = 'alert alert--warning';
+
+const defaultProps = {
+  icon: <TriangleAlert size={18} strokeWidth={2} />,
+  title: 'caution',
+};
+
+export default function AdmonitionTypeCaution(
+  props: React.ComponentProps<typeof AdmonitionLayout>,
+): ReactNode {
+  return (
+    <AdmonitionLayout
+      {...defaultProps}
+      {...props}
+      className={clsx(infimaClassName, props.className)}>
+      {props.children}
+    </AdmonitionLayout>
+  );
+}

--- a/src/theme/Admonition/Type/Danger.tsx
+++ b/src/theme/Admonition/Type/Danger.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import type { ReactNode } from 'react';
+import clsx from 'clsx';
+import AdmonitionLayout from '@theme/Admonition/Layout';
+import { OctagonAlert } from 'lucide-react';
+
+const infimaClassName = 'alert alert--danger';
+
+const defaultProps = {
+  icon: <OctagonAlert size={18} strokeWidth={2} />,
+  title: 'danger',
+};
+
+export default function AdmonitionTypeDanger(
+  props: React.ComponentProps<typeof AdmonitionLayout>,
+): ReactNode {
+  return (
+    <AdmonitionLayout
+      {...defaultProps}
+      {...props}
+      className={clsx(infimaClassName, props.className)}>
+      {props.children}
+    </AdmonitionLayout>
+  );
+}

--- a/src/theme/Admonition/Type/Info.tsx
+++ b/src/theme/Admonition/Type/Info.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import type { ReactNode } from 'react';
+import clsx from 'clsx';
+import AdmonitionLayout from '@theme/Admonition/Layout';
+import { Info } from 'lucide-react';
+
+const infimaClassName = 'alert alert--info';
+
+const defaultProps = {
+  icon: <Info size={18} strokeWidth={2} />,
+  title: 'info',
+};
+
+export default function AdmonitionTypeInfo(
+  props: React.ComponentProps<typeof AdmonitionLayout>,
+): ReactNode {
+  return (
+    <AdmonitionLayout
+      {...defaultProps}
+      {...props}
+      className={clsx(infimaClassName, props.className)}>
+      {props.children}
+    </AdmonitionLayout>
+  );
+}

--- a/src/theme/Admonition/Type/Note.tsx
+++ b/src/theme/Admonition/Type/Note.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import type { ReactNode } from 'react';
+import clsx from 'clsx';
+import AdmonitionLayout from '@theme/Admonition/Layout';
+import { StickyNote } from 'lucide-react';
+
+const infimaClassName = 'alert alert--secondary';
+
+const defaultProps = {
+  icon: <StickyNote size={18} strokeWidth={2} />,
+  title: 'note',
+};
+
+export default function AdmonitionTypeNote(
+  props: React.ComponentProps<typeof AdmonitionLayout>,
+): ReactNode {
+  return (
+    <AdmonitionLayout
+      {...defaultProps}
+      {...props}
+      className={clsx(infimaClassName, props.className)}>
+      {props.children}
+    </AdmonitionLayout>
+  );
+}

--- a/src/theme/Admonition/Type/Tip.tsx
+++ b/src/theme/Admonition/Type/Tip.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import type { ReactNode } from 'react';
+import clsx from 'clsx';
+import AdmonitionLayout from '@theme/Admonition/Layout';
+import { Lightbulb } from 'lucide-react';
+
+const infimaClassName = 'alert alert--success';
+
+const defaultProps = {
+  icon: <Lightbulb size={18} strokeWidth={2} />,
+  title: 'tip',
+};
+
+export default function AdmonitionTypeTip(
+  props: React.ComponentProps<typeof AdmonitionLayout>,
+): ReactNode {
+  return (
+    <AdmonitionLayout
+      {...defaultProps}
+      {...props}
+      className={clsx(infimaClassName, props.className)}>
+      {props.children}
+    </AdmonitionLayout>
+  );
+}

--- a/src/theme/Admonition/Type/Warning.tsx
+++ b/src/theme/Admonition/Type/Warning.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import type { ReactNode } from 'react';
+import clsx from 'clsx';
+import AdmonitionLayout from '@theme/Admonition/Layout';
+import { TriangleAlert } from 'lucide-react';
+
+const infimaClassName = 'alert alert--warning';
+
+const defaultProps = {
+  icon: <TriangleAlert size={18} strokeWidth={2} />,
+  title: 'warning',
+};
+
+export default function AdmonitionTypeWarning(
+  props: React.ComponentProps<typeof AdmonitionLayout>,
+): ReactNode {
+  return (
+    <AdmonitionLayout
+      {...defaultProps}
+      {...props}
+      className={clsx(infimaClassName, props.className)}>
+      {props.children}
+    </AdmonitionLayout>
+  );
+}


### PR DESCRIPTION
## Summary

Replaces the default Docusaurus admonition (left-accent stripe + bold type-name heading) with a Replit-style box:

* Subtle 1px border on all sides, 12px radius, type-themed background and text
* Icon floated inline at the left of the body via flexbox
* All six types covered: \`info\`, \`tip\`, \`note\`, \`warning\`, \`caution\`, \`danger\`
* Each type has a matching dark-mode variant

Icons are now [Lucide](https://lucide.dev/) (\`lucide-react\` is already a dependency):

| Type | Icon |
|---|---|
| info | \`Info\` |
| tip | \`Lightbulb\` |
| note | \`StickyNote\` |
| warning, caution | \`TriangleAlert\` |
| danger | \`OctagonAlert\` |

## What changed

* \`src/css/custom.css\` — shared \`.theme-admonition\` base rule + per-type color overrides + dark mode + \`fill: none; stroke: currentColor\` so Lucide outlines render correctly (Infima's default \`.alert svg\` would otherwise fill them solid)
* \`src/theme/Admonition/Type/{Info,Tip,Note,Warning,Danger,Caution}.tsx\` — six swizzled wrappers around \`AdmonitionLayout\`, each passing a \`lucide-react\` icon

## Known caveat

The heading-hide trick (\`font-size: 0\`) hides **all** admonition headings, including custom titles passed via \`:::info[Custom title]\` and the existing \`Summary.tsx\` "Session summary" label. If keeping custom titles visible matters, the follow-up is a wrapper that hides only the default type-name label.

## Test plan

- [ ] Run \`yarn start\` and open a page with one of each admonition type — verify the Replit-style rounded box renders with the right Lucide icon and color
- [ ] Toggle dark mode and verify all six variants
- [ ] Confirm no Rspack panics or hot-reload errors after switching pages
- [ ] Decide whether the custom-title caveat above is acceptable for merge or needs a follow-up before unparking the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)