### PR TITLE
DocCard: transparent default, white-fill lift on hover

### DIFF
--- a/src/theme/DocCard/styles.module.css
+++ b/src/theme/DocCard/styles.module.css
@@ -5,30 +5,33 @@
 
   padding: var(--neo-spacing_3);
   border-radius: var(--neo-border-radius-x-s);
-  background-color: var(--neo-surfaces-white);
+  background-color: transparent;
   border: 1px solid var(--neo-border-card);
   box-shadow: none;
   display: flex;
   flex-direction: row;
   gap: var(--neo-spacing_2);
-  transition: background-color var(--ifm-transition-fast) ease;
+  transition: background-color var(--ifm-transition-fast) ease,
+              border-color var(--ifm-transition-fast) ease;
   width: 100%;
   align-items: flex-start;
 }
 
 .cardContainer:hover {
-  background-color: var(--neo-grey-50);
-  box-shadow: none;
+  background-color: var(--neo-surfaces-white);
+  border-color: var(--neo-grey-300);
+  box-shadow: var(--neo-shadow-card);
 }
 
 /* Dark mode styles */
 [data-theme='dark'] .cardContainer {
-  background-color: var(--neo-grey-800);
-  border-color: var(--neo-grey-600);
+  background-color: transparent;
+  border-color: var(--neo-grey-700);
 }
 
 [data-theme='dark'] .cardContainer:hover {
-  background-color: var(--neo-grey-700);
+  background-color: var(--neo-grey-800);
+  border-color: var(--neo-grey-600);
 }
 
 .cardContent {


### PR DESCRIPTION
## Summary

Category index page cards (DocCard) lose their resting white fill — at rest they're a 1px outline on the page lavender. On hover they fill white, deepen the border, and pick up a subtle shadow.

## What changes

* \`.cardContainer\`: \`background-color\` → \`transparent\` (was \`--neo-surfaces-white\`); transition now also animates \`border-color\`
* \`.cardContainer:hover\`: fills with \`--neo-surfaces-white\`, border becomes \`--neo-grey-300\`, gains \`--neo-shadow-card\`
* Dark mode mirrors the pattern with \`--neo-grey-700/800\`

## Why

- The white fill at rest read as heavy on category index pages with many cards. Going transparent makes the page feel lighter and lets the brand background (lavender / midnight) flow through. The hover state still gives a clear interactive affordance — and matches the visual direction we landed on for the redesigned admonitions in #631.

## Test plan

- [ ] Run \`yarn start\` and visit any category index page (e.g. \`/user-documentation/moderne-platform/getting-started/\`) — cards should be outlined, transparent at rest
- [ ] Hover any card — should smoothly fill white, border darkens, subtle shadow appears
- [ ] Toggle dark mode — same pattern, using grey-700 default border / grey-800 hover fill
- [ ] Confirm \`cardIcon\`, \`cardTitle\`, \`cardDescription\` still render correctly with the transparent background

🤖 Generated with [Claude Code](https://claude.com/claude-code)