### PR TITLE
Add hands-on workshop for Moderne agent tools

### DIFF
--- a/docs/hands-on-learning/agent-tools/module-1-cli-and-lsts.md
+++ b/docs/hands-on-learning/agent-tools/module-1-cli-and-lsts.md
@@ -89,6 +89,9 @@ On corporate networks behind a proxy or with restricted Maven Central access, se
 
 Instead of syncing the entire recipe catalog, install just the JARs you need:
 
+<Tabs groupId="cli-install-os" queryString="os">
+<TabItem value="linux-macos" label="Linux / macOS" default>
+
 ```bash
 mod config recipes jar install \
   org.openrewrite.recipe:rewrite-prethink \
@@ -96,6 +99,20 @@ mod config recipes jar install \
   org.openrewrite.recipe:rewrite-static-analysis \
   org.openrewrite.recipe:rewrite-spring
 ```
+
+</TabItem>
+<TabItem value="windows" label="Windows">
+
+```powershell
+mod config recipes jar install `
+  org.openrewrite.recipe:rewrite-prethink `
+  io.moderne.recipe:rewrite-prethink `
+  org.openrewrite.recipe:rewrite-static-analysis `
+  org.openrewrite.recipe:rewrite-spring
+```
+
+</TabItem>
+</Tabs>
 
 The two `rewrite-prethink` artifacts are the focus of this workshop: the `org.openrewrite.recipe` module is the open-source building blocks, and `io.moderne.recipe:rewrite-prethink` adds pre-configured discovery for Spring, JPA, Kafka, and other common frameworks. See [Recipe modules](../../user-documentation/agent-tools/prethink.md#recipe-modules) for the full breakdown.
 
@@ -113,7 +130,7 @@ Search for one of the Prethink recipes to confirm it resolved:
 mod config recipes search UpdatePrethinkContext
 ```
 
-You should see at least the `io.moderne.prethink.UpdatePrethinkContextNoAiStarter` and `io.moderne.prethink.UpdatePrethinkContextStarter` recipes listed.
+The CLI walks through each matching recipe interactively and asks whether to set it as the active recipe. You should see at least the `io.moderne.prethink.UpdatePrethinkContextNoAiStarter` and `io.moderne.prethink.UpdatePrethinkContextStarter` recipes show up. Press `n` (or just `Enter`) at each prompt to skip — you'll select recipes explicitly with `--recipe` later.
 
 ### Takeaways
 
@@ -159,14 +176,28 @@ The `--with-sources` flag clones the source code in addition to fetching pre-bui
 <details>
 <summary>Reference: what gets synced</summary>
 
-The `Default` organization includes public repositories like `spring-projects/spring-petclinic`, `Netflix/photon`, `finos/messageml-utils`, and a handful of others. The exact list is updated occasionally, but it's always a small enough set to build locally without consuming much disk.
+At the time of writing, the `Default` organization contains 11 public repositories spanning Maven, Gradle, and Spring projects:
+
+* `apache/maven-doxia`
+* `awslabs/aws-saas-boost`
+* `finos/messageml-utils`
+* `finos/spring-bot`
+* `finos/symphony-bdk-java`
+* `finos/symphony-wdk`
+* `Netflix/photon`
+* `Netflix/ribbon`
+* `openrewrite/rewrite-recipe-bom`
+* `spring-projects/spring-data-commons`
+* `spring-projects/spring-petclinic`
+
+The exact list is updated occasionally, but it's always a small enough set to build locally without consuming much disk.
 
 If you want a different mix (for example, only Spring repositories), browse the available organizations with `mod config moderne organizations show` and substitute a different name.
 
 </details>
 
 :::info
-If a few LST downloads fail with HTTP 404 or 401, that's expected for some open-source repos. As long as most synced successfully, you can continue. Repositories without LSTs will be rebuilt locally in Step 3.
+Don't worry if some LST downloads fail (you may see HTTP 404/401 messages, or skipped repos in the progress output). That's expected for a few of these public repos. Anything without an LST will be rebuilt locally in Step 3, and any repo whose build also fails is silently skipped. As long as a handful succeed, you're fine.
 :::
 
 #### Step 3: Build any missing LSTs locally
@@ -189,7 +220,15 @@ If multiple projects fail with the same root cause, run `mod trace builds analyz
 mod list .
 ```
 
-Repositories without LSTs will be marked with a `(no LST)` annotation. As long as a handful of Java/Spring projects show up clean (no annotation), you're ready for the next module.
+Repositories without LSTs are marked with a `(no LST)` annotation, like this:
+
+```text
+  9% (1s)     ▶ awslabs/aws-saas-boost@main (no LST)
+ 18% (1s)     ▶ finos/messageml-utils@main
+ 27% (1s)     ▶ finos/spring-bot@spring-bot-master
+```
+
+As long as a handful of Java/Spring projects show up without that annotation, you're ready for the next module.
 
 ### Takeaways
 

--- a/docs/hands-on-learning/agent-tools/module-1-cli-and-lsts.md
+++ b/docs/hands-on-learning/agent-tools/module-1-cli-and-lsts.md
@@ -1,0 +1,202 @@
+---
+sidebar_label: "Module 1: CLI and LSTs"
+description: Install the Moderne CLI, install the Prethink recipe modules, and build LSTs for a working set of Java and Spring projects.
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Module 1: CLI and LSTs
+
+In this module, you'll set up everything the agent tools depend on: the Moderne CLI, a couple of recipe JARs (including `io.moderne.recipe:rewrite-prethink`), and Lossless Semantic Trees (LSTs) for a small working set of Java and Spring repositories. The later modules build on top of this setup, so don't skip ahead until your LSTs build cleanly.
+
+## Exercise 1-1: Install and configure the Moderne CLI
+
+### Goals for this exercise
+
+* Install the Moderne CLI on your machine
+* Authenticate the CLI against [app.moderne.io](https://app.moderne.io)
+* Confirm the installation by running `mod --version`
+
+### Steps
+
+#### Step 1: Install the CLI
+
+The recommended way to install the Moderne CLI is via the install script:
+
+<Tabs groupId="cli-install-os" queryString="os">
+<TabItem value="linux-macos" label="Linux / macOS" default>
+
+```bash
+curl https://app.moderne.io/cli | bash
+```
+
+</TabItem>
+<TabItem value="windows" label="Windows">
+
+```powershell
+irm https://app.moderne.io/cli/windows | iex
+```
+
+</TabItem>
+</Tabs>
+
+Alternatively, you can install via a package manager:
+
+* **Homebrew** (macOS/Linux): `brew install moderneinc/moderne/mod`
+* **Chocolatey** (Windows): `choco install mod --prerelease`
+
+For more installation options, including Enterprise and Moderne DX setups, see [Getting started with the Moderne CLI](../../user-documentation/moderne-cli/getting-started/cli-intro.md#installation-and-configuration).
+
+Verify the install:
+
+```bash
+mod --version
+```
+
+#### Step 2: Connect the CLI to Moderne
+
+Point the CLI at the public Moderne tenant and log in:
+
+```bash
+mod config moderne edit https://app.moderne.io
+mod config moderne login
+```
+
+The login command opens a browser, asks you to grant the CLI access to your account, and stores a token locally that's valid for 365 days. If you're running on an Enterprise tenant, replace the URL with your tenant's hostname.
+
+:::tip
+On corporate networks behind a proxy or with restricted Maven Central access, see [Using the CLI with internal tools and artifact repositories](../../user-documentation/moderne-cli/getting-started/cli-internal-tools.md) before continuing.
+:::
+
+### Takeaways
+
+* The Moderne CLI is the entry point for everything in this workshop. Skills, the MCP server, Prethink, and Trigrep all run through `mod`.
+* You only need to authenticate once. The CLI caches your token across terminal sessions.
+
+---
+
+## Exercise 1-2: Install the recipe modules
+
+### Goals for this exercise
+
+* Install the recipe JARs needed for Prethink and the rest of this workshop
+* Understand the difference between `mod config recipes jar install` and a full catalog sync
+
+### Steps
+
+#### Step 1: Install the workshop recipe JARs
+
+Instead of syncing the entire recipe catalog, install just the JARs you need:
+
+```bash
+mod config recipes jar install \
+  org.openrewrite.recipe:rewrite-prethink \
+  io.moderne.recipe:rewrite-prethink \
+  org.openrewrite.recipe:rewrite-static-analysis \
+  org.openrewrite.recipe:rewrite-spring
+```
+
+The two `rewrite-prethink` artifacts are the focus of this workshop: the `org.openrewrite.recipe` module is the open-source building blocks, and `io.moderne.recipe:rewrite-prethink` adds pre-configured discovery for Spring, JPA, Kafka, and other common frameworks. See [Recipe modules](../../user-documentation/agent-tools/prethink.md#recipe-modules) for the full breakdown.
+
+The other two JARs are useful warm-up recipes you'll touch later when verifying everything works.
+
+:::tip
+If you'd rather have the entire catalog available, run `mod config recipes moderne sync` instead. That takes a few minutes and downloads every recipe Moderne ships.
+:::
+
+#### Step 2: Confirm the recipes are installed
+
+Search for one of the Prethink recipes to confirm it resolved:
+
+```bash
+mod config recipes search UpdatePrethinkContext
+```
+
+You should see at least the `io.moderne.prethink.UpdatePrethinkContextNoAiStarter` and `io.moderne.prethink.UpdatePrethinkContextStarter` recipes listed.
+
+### Takeaways
+
+* `mod config recipes jar install <coords>` is a fast way to grab a known recipe pack without syncing the full catalog.
+* The Moderne Prethink module depends on the OpenRewrite Prethink module. Installing both is the safe default.
+
+---
+
+## Exercise 1-3: Sync repositories and build LSTs
+
+### Goals for this exercise
+
+* Set up a workspace directory containing a few Java/Spring repositories
+* Build LSTs locally with `mod build` (the prerequisite for everything in the rest of this workshop)
+
+### Key concepts
+
+A [Lossless Semantic Tree (LST)](../../administrator-documentation/moderne-platform/references/lossless-semantic-trees.md) is a type-attributed, format-preserving tree representation of your source code. Recipes, the MCP server's semantic tools, and the Trigrep search index all read from LSTs rather than raw text, which is what gives them type awareness.
+
+You can either **download** pre-built LSTs from the Moderne Platform or **build** them locally with `mod build`. Both options work for the rest of this workshop, but a local build is the more realistic flow for your own repositories. We'll show both paths.
+
+### Steps
+
+#### Step 1: Create a workspace directory
+
+```bash
+mkdir ~/agent-tools-workshop
+cd ~/agent-tools-workshop
+```
+
+This directory will hold the repositories, LSTs, search indexes, and recipe run artifacts for the rest of the workshop.
+
+#### Step 2: Sync a small set of repositories
+
+Use the public `Default` organization, which contains a manageable mix of Java and Spring projects:
+
+```bash
+mod git sync moderne . --organization "Default" --with-sources
+```
+
+The `--with-sources` flag clones the source code in addition to fetching pre-built LSTs. Sources are required for the apply/commit steps in [Module 3](./module-3-prethink.md).
+
+<details>
+<summary>Reference: what gets synced</summary>
+
+The `Default` organization includes public repositories like `spring-projects/spring-petclinic`, `Netflix/photon`, `finos/messageml-utils`, and a handful of others. The exact list is updated occasionally, but it's always a small enough set to build locally without consuming much disk.
+
+If you want a different mix (for example, only Spring repositories), browse the available organizations with `mod config moderne organizations show` and substitute a different name.
+
+</details>
+
+:::info
+If a few LST downloads fail with HTTP 404 or 401, that's expected for some open-source repos. As long as most synced successfully, you can continue. Repositories without LSTs will be rebuilt locally in Step 3.
+:::
+
+#### Step 3: Build any missing LSTs locally
+
+Run `mod build` on the workspace to (re)build LSTs for everything you just cloned:
+
+```bash
+mod build .
+```
+
+This invokes each project's build (Maven, Gradle, etc.) and serializes the LSTs to disk. On a small workspace it usually takes a couple of minutes. If a project fails to build, the CLI keeps going and just skips that one.
+
+:::tip
+If multiple projects fail with the same root cause, run `mod trace builds analyze . --last-build` to see a dashboard of build failures, with logs and per-repo details.
+:::
+
+#### Step 4: Confirm LSTs are available
+
+```bash
+mod list .
+```
+
+Repositories without LSTs will be marked with a `(no LST)` annotation. As long as a handful of Java/Spring projects show up clean (no annotation), you're ready for the next module.
+
+### Takeaways
+
+* The agent tools all build on top of LSTs. Without `mod build` (or downloaded LSTs), the MCP server's semantic tools, Prethink recipes, and Trigrep indexes have nothing to read.
+* You can mix and match: pre-built LSTs for repos available on the Moderne Platform and locally built LSTs for repos that aren't.
+* Build failures are normal in any heterogeneous set of repositories. Don't try to fix every failure right now. Move on as long as enough repos succeed.
+
+## Next up
+
+In [Module 2](./module-2-install-agent-tools.md), you'll install the Moderne skills and MCP server into your AI coding agent and see what new capabilities show up.

--- a/docs/hands-on-learning/agent-tools/module-1-cli-and-lsts.md
+++ b/docs/hands-on-learning/agent-tools/module-1-cli-and-lsts.md
@@ -65,8 +65,14 @@ mod config moderne login
 
 The login command opens a browser, asks you to grant the CLI access to your account, and stores a token locally that's valid for 365 days. If you're running on an Enterprise tenant, replace the URL with your tenant's hostname.
 
-:::tip
-On corporate networks behind a proxy or with restricted Maven Central access, see [Using the CLI with internal tools and artifact repositories](../../user-documentation/moderne-cli/getting-started/cli-internal-tools.md) before continuing.
+:::tip Restrictive networks
+On corporate networks with proxies or limited Maven Central / Moderne SaaS access, see [Using the CLI with internal tools and artifact repositories](../../user-documentation/moderne-cli/getting-started/cli-internal-tools.md) before continuing. Symptoms you might hit later in this workshop:
+
+* `mod git sync moderne` reports `PARTIAL SUCCESS` because a few LSTs sit on hosts your network can't reach
+* `mod config recipes jar install` fails to resolve a JAR — point it at your internal Artifactory/Nexus first via `mod config recipes artifacts`
+* `mod build` can't download Maven/Gradle plugins — set up your build tool's mirror and proxy as you normally would, then re-run
+
+For the workshop you only need a handful of repos to succeed. Don't try to fix every failure up front.
 :::
 
 ### Takeaways
@@ -156,10 +162,24 @@ You can either **download** pre-built LSTs from the Moderne Platform or **build*
 
 #### Step 1: Create a workspace directory
 
+<Tabs groupId="cli-install-os" queryString="os">
+<TabItem value="linux-macos" label="Linux / macOS" default>
+
 ```bash
 mkdir ~/agent-tools-workshop
 cd ~/agent-tools-workshop
 ```
+
+</TabItem>
+<TabItem value="windows" label="Windows">
+
+```powershell
+New-Item -ItemType Directory -Path "$HOME\agent-tools-workshop"
+cd $HOME\agent-tools-workshop
+```
+
+</TabItem>
+</Tabs>
 
 This directory will hold the repositories, LSTs, search indexes, and recipe run artifacts for the rest of the workshop.
 
@@ -172,6 +192,31 @@ mod git sync moderne . --organization "Default" --with-sources
 ```
 
 The `--with-sources` flag clones the source code in addition to fetching pre-built LSTs. Sources are required for the apply/commit steps in [Module 3](./module-3-prethink.md).
+
+<details>
+<summary>Sample sync output</summary>
+
+```text
+● Synchronizing organization directory structure
+Found 1 organization containing 11 repositories
+
+● Downloading LSTs for repositories
+  0% (1s)     ▶ awslabs/aws-saas-boost@main
+  0% (1s)         ✗ Failed to download LST from http://artifactory.moderne.internal/...
+  9% (1s)     ▶ apache/maven-doxia@master
+  9% (1s)         ✓ Downloaded LST from https://artifactory.moderne.ninja/...
+  ... (other repos)
+100% (12s)    Done
+
+Synced 11 repositories.
+
+PARTIAL SUCCESS: mod partially succeeded with an exception
+1 repository failed to sync. The exception for the failure on awslabs/aws-saas-boost@main is shown above.
+```
+
+A `PARTIAL SUCCESS` message is normal here — at the time of writing, one of the LSTs in the `Default` org is hosted on a Moderne-internal artifactory and isn't reachable from public networks. The 10 repos that did sync are enough for the workshop.
+
+</details>
 
 <details>
 <summary>Reference: what gets synced</summary>

--- a/docs/hands-on-learning/agent-tools/module-1-cli-and-lsts.md
+++ b/docs/hands-on-learning/agent-tools/module-1-cli-and-lsts.md
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 
 # Module 1: CLI and LSTs
 
-In this module, you'll set up everything the agent tools depend on: the Moderne CLI, a couple of recipe JARs (including `io.moderne.recipe:rewrite-prethink`), and Lossless Semantic Trees (LSTs) for a small working set of Java and Spring repositories. The later modules build on top of this setup, so don't skip ahead until your LSTs build cleanly.
+In this module, you'll set up everything the agent tools depend on: the Moderne CLI, a couple of recipe JARs (including `io.moderne.recipe:rewrite-prethink`), and [Lossless Semantic Trees (LSTs)](../../administrator-documentation/moderne-platform/references/lossless-semantic-trees.md) for a small working set of Java and Spring repositories. The later modules build on top of this setup, so don't skip ahead until your LSTs build cleanly.
 
 ## Exercise 1-1: Install and configure the Moderne CLI
 
@@ -66,18 +66,18 @@ mod config moderne login
 The login command opens a browser, asks you to grant the CLI access to your account, and stores a token locally that's valid for 365 days. If you're running on an Enterprise tenant, replace the URL with your tenant's hostname.
 
 :::tip Restrictive networks
-On corporate networks with proxies or limited Maven Central / Moderne SaaS access, see [Using the CLI with internal tools and artifact repositories](../../user-documentation/moderne-cli/getting-started/cli-internal-tools.md) before continuing. Symptoms you might hit later in this workshop:
+On corporate networks with proxies or limited Maven Central / Moderne SaaS access, see [Using the CLI with internal tools and artifact repositories](../../user-documentation/moderne-cli/getting-started/cli-internal-tools.md) before continuing. Without a properly configured setup, you'll commonly see:
 
 * `mod git sync moderne` reports `PARTIAL SUCCESS` because a few LSTs sit on hosts your network can't reach
 * `mod config recipes jar install` fails to resolve a JAR — point it at your internal Artifactory/Nexus first via `mod config recipes artifacts`
 * `mod build` can't download Maven/Gradle plugins — set up your build tool's mirror and proxy as you normally would, then re-run
 
-For the workshop you only need a handful of repos to succeed. Don't try to fix every failure up front.
+For the workshop you only need a handful of repos to succeed. **Don't try to fix every failure up front**.
 :::
 
 ### Takeaways
 
-* The Moderne CLI is the entry point for everything in this workshop. Skills, the MCP server, Prethink, and Trigrep all run through `mod`.
+* The Moderne CLI is the entry point for everything in this workshop. Every command you'll run starts with `mod`.
 * You only need to authenticate once. The CLI caches your token across terminal sessions.
 
 ---
@@ -100,7 +100,6 @@ Instead of syncing the entire recipe catalog, install just the JARs you need:
 
 ```bash
 mod config recipes jar install \
-  org.openrewrite.recipe:rewrite-prethink \
   io.moderne.recipe:rewrite-prethink \
   org.openrewrite.recipe:rewrite-static-analysis \
   org.openrewrite.recipe:rewrite-spring
@@ -111,7 +110,6 @@ mod config recipes jar install \
 
 ```powershell
 mod config recipes jar install `
-  org.openrewrite.recipe:rewrite-prethink `
   io.moderne.recipe:rewrite-prethink `
   org.openrewrite.recipe:rewrite-static-analysis `
   org.openrewrite.recipe:rewrite-spring
@@ -120,7 +118,7 @@ mod config recipes jar install `
 </TabItem>
 </Tabs>
 
-The two `rewrite-prethink` artifacts are the focus of this workshop: the `org.openrewrite.recipe` module is the open-source building blocks, and `io.moderne.recipe:rewrite-prethink` adds pre-configured discovery for Spring, JPA, Kafka, and other common frameworks. See [Recipe modules](../../user-documentation/agent-tools/prethink.md#recipe-modules) for the full breakdown.
+The `rewrite-prethink` artifact is the focus of this workshop: it uses an open-source `org.openrewrite.recipe` module for building blocks, while `io.moderne.recipe:rewrite-prethink` adds pre-configured discovery for Spring, JPA, Kafka, and other common frameworks. See [Recipe modules](../../user-documentation/agent-tools/prethink.md#recipe-modules) for the full breakdown.
 
 The other two JARs are useful warm-up recipes you'll touch later when verifying everything works.
 

--- a/docs/hands-on-learning/agent-tools/module-2-install-agent-tools.md
+++ b/docs/hands-on-learning/agent-tools/module-2-install-agent-tools.md
@@ -1,0 +1,178 @@
+---
+sidebar_label: "Module 2: Install agent tools"
+description: Install Moderne skills and the MCP server with mod config agent-tools install, scope to specific agents, and verify what your AI agent now exposes.
+---
+
+# Module 2: Install agent tools
+
+In this module, you'll install the Moderne skills and the Moderne MCP server into your AI coding agent. You'll learn how to install everything at once, how to scope to a single agent like GitHub Copilot, and how to confirm the new capabilities are actually available.
+
+## Exercise 2-1: Install agent tools for every detected agent
+
+### Goals for this exercise
+
+* Run `mod config agent-tools install` and understand what it changes
+* Confirm the new skills appear in your agent
+* Know how to roll back with `uninstall`
+
+### Key concepts
+
+The Moderne CLI bundles two complementary kinds of agent tooling:
+
+| Component       | What it provides                                                                                              |
+|-----------------|---------------------------------------------------------------------------------------------------------------|
+| **Skills**      | Procedural instructions that teach an agent how to create recipes, run them, and analyze impact               |
+| **MCP server**  | A live process that exposes tools for semantic search, navigation, refactoring, and recipe execution          |
+
+The install command auto-detects which coding agents are present on your machine and installs both components for each one. See [Skills for AI coding agents](../../user-documentation/agent-tools/skills.md) and the [MCP overview](../../user-documentation/agent-tools/mcp/overview.md) for full reference docs.
+
+### Steps
+
+#### Step 1: Install agent tools for every detected agent
+
+```bash
+mod config agent-tools install
+```
+
+The CLI scans for installed coding agents (Claude Code, Cursor, GitHub Copilot, Windsurf, Sourcegraph Amp, OpenAI Codex), then installs skills and registers the MCP server for each one it finds. If no agents are detected, the CLI prints a message listing the supported agents and where it looked.
+
+To remove everything later, run:
+
+```bash
+mod config agent-tools uninstall
+```
+
+#### Step 2: See where the skills landed
+
+The skills are installed as plain markdown files. Their exact location depends on the agent. A few examples:
+
+| Agent          | Install location                                                  |
+|----------------|-------------------------------------------------------------------|
+| Claude Code    | `~/.claude/marketplaces/moderne/moderne/skills/<skill>/SKILL.md`  |
+| Cursor         | `.cursor/rules/moderne-<skill>.mdc` (per project)                 |
+| GitHub Copilot | `.github/instructions/moderne-<skill>.instructions.md` (per project) |
+| Windsurf       | `~/.codeium/windsurf/skills/<skill>/SKILL.md`                     |
+
+For the full list see [Supported agents](../../user-documentation/agent-tools/skills.md#supported-agents).
+
+:::note
+Cursor and GitHub Copilot install skills *per project* (into `.cursor/rules/` or `.github/instructions/`) rather than globally. If you want those skills available in another project, run the install command from that project's root too.
+:::
+
+#### Step 3: Verify the skills are available
+
+How you check depends on your agent.
+
+**Claude Code** - Open Claude Code in your workshop directory and type `/`. You should see entries like `/moderne:create-recipe`, `/moderne:run-recipe`, `/moderne:create-organization`, and `/moderne:analyze-impact`.
+
+**Cursor / GitHub Copilot** - Skills are loaded automatically as rules/instructions. Open the project in your editor and check that `.cursor/rules/moderne-*.mdc` or `.github/instructions/moderne-*.instructions.md` exist.
+
+**Windsurf, Amp, Codex** - Skills are referenced by name in your prompt (for example, "Using the run-recipe skill, ..."). See [Invoking skills](../../user-documentation/agent-tools/skills.md#invoking-skills) for the agent-specific syntax.
+
+### Takeaways
+
+* A single command (`mod config agent-tools install`) wires up every detected agent.
+* Skills are just markdown. You can `cat` them to see exactly what your agent has been taught.
+* The CLI updates these files when you upgrade. Re-run the install command after each CLI update.
+
+---
+
+## Exercise 2-2: Scope the install to a single agent
+
+### Goals for this exercise
+
+* Use a per-agent install command to scope to one agent
+* Recognize when per-agent installation is the right choice
+
+### Steps
+
+#### Step 1: Install for a single agent
+
+If you only want agent tools for one specific agent, use a per-agent subcommand. For example:
+
+```bash
+mod config agent-tools copilot install
+```
+
+Other supported subcommands are `claude`, `cursor`, `windsurf`, `amp`, and `codex`. Each one installs both skills and the MCP server for that agent only. If the agent isn't detected on your system, the command prints a message and exits without making changes.
+
+This is the right call when:
+
+* You only use one agent and don't want files written for the others
+* Cursor or Copilot is the agent you care about and you're inside the project where you want those instructions installed
+* You're scripting the install in CI/CD for a specific agent
+
+#### Step 2 (optional): Install only skills, not the MCP server
+
+If you want the procedural guidance but not the live MCP server (for example, on a machine where you can't run a long-lived process), install just the skills:
+
+```bash
+mod config agent-tools skills install
+```
+
+This installs skills for every detected agent but leaves the MCP server unconfigured. You can pair this with [Module 4](./module-4-trigrep.md) (Trigrep) to get fast search via the CLI without needing the MCP server.
+
+### Takeaways
+
+* Per-agent install is useful for project-scoped agents like Cursor and Copilot, where the skills get written into the working directory.
+* `skills install` is a lighter-weight option when you don't want the MCP server.
+
+---
+
+## Exercise 2-3: Inspect a skill to understand what your agent now knows
+
+### Goals for this exercise
+
+* Open one of the installed skills and read its content
+* See for yourself how skills shape the agent's behavior
+
+### Steps
+
+#### Step 1: Read a skill end-to-end
+
+Open one of the skill files using the path that matches your agent. For Claude Code on macOS:
+
+```bash
+cat ~/.claude/marketplaces/moderne/moderne/skills/create-recipe/SKILL.md
+```
+
+For Cursor, look at `.cursor/rules/moderne-create-recipe.mdc` in the current project. For Copilot, look at `.github/instructions/moderne-create-recipe.instructions.md`.
+
+The file is plain markdown describing the recipe development workflow: when to choose declarative YAML vs Refaster vs imperative recipes, how to scaffold a project, how to write tests with `RewriteTest`, and how to handle imports correctly. This is what the agent reads before responding.
+
+The four skills you now have available are:
+
+| Skill                     | What it does                                                                              |
+|---------------------------|-------------------------------------------------------------------------------------------|
+| **create-organization**   | Helps the agent assemble a curated set of repositories to test recipes against            |
+| **create-recipe**         | Guides the agent through recipe type selection, scaffolding, and writing tests            |
+| **run-recipe**            | Handles compiling, running, and diagnosing recipes against real repositories              |
+| **analyze-impact**        | Turns recipe run data into reports and visualizations                                     |
+
+See [Available skills](../../user-documentation/agent-tools/skills.md#available-skills) for the longer descriptions.
+
+#### Step 2 (optional): Try a skill with a throwaway prompt
+
+In Claude Code, invoke `/moderne:create-recipe` and give it a simple, throwaway request:
+
+```
+/moderne:create-recipe
+
+I want to create an OpenRewrite recipe that renames the method getItems() to items() on com.example.ShoppingCart.
+```
+
+For other agents, see [Invoking skills](../../user-documentation/agent-tools/skills.md#invoking-skills) for the right invocation syntax.
+
+Notice how the skill shapes the agent's approach: it picks a recipe type *before* writing code, scaffolds a project layout, and writes tests with the `RewriteTest` framework. Without the skill, you'd typically get a single YAML or Java file with no tests.
+
+You don't need to keep the output. Stop the agent once you've seen it work.
+
+### Takeaways
+
+* Skills are just procedural markdown your agent reads before answering. There's no magic.
+* Reading a skill once is the fastest way to understand what behaviors your agent will fall back to.
+* When the agent goes off the rails, you can compare its actions to the skill and see where it deviated.
+
+## Next up
+
+In [Module 3](./module-3-prethink.md), you'll run Prethink against the workspace you set up in Module 1 and see what kind of pre-resolved context gets generated for your agent.

--- a/docs/hands-on-learning/agent-tools/module-2-install-agent-tools.md
+++ b/docs/hands-on-learning/agent-tools/module-2-install-agent-tools.md
@@ -61,7 +61,7 @@ Cursor and GitHub Copilot install skills *per project* (into `.cursor/rules/` or
 
 #### Step 3: Verify the skills are available
 
-How you check depends on your agent.
+How you check depends on your agent. Restart the agent first if it was already running — most agents pick up new skills/MCP servers at startup.
 
 **Claude Code** - Open Claude Code in your workshop directory and type `/`. You should see entries like `/moderne:create-recipe`, `/moderne:run-recipe`, `/moderne:create-organization`, and `/moderne:analyze-impact`.
 

--- a/docs/hands-on-learning/agent-tools/module-3-prethink.md
+++ b/docs/hands-on-learning/agent-tools/module-3-prethink.md
@@ -1,0 +1,193 @@
+---
+sidebar_label: "Module 3: Prethink"
+description: Run Prethink on a working set, apply the changes, and ask your agent to visualize the generated code quality metrics.
+---
+
+# Module 3: Prethink
+
+In this module, you'll run Moderne Prethink on the workspace you set up in [Module 1](./module-1-cli-and-lsts.md), apply the generated context to your repositories, and inspect what shows up: service endpoints, messaging connections, dependencies, and per-method/class/package code quality metrics. Then you'll ask your agent to read the metrics and propose a refactoring plan.
+
+For the deep reference on what Prethink is, see [Moderne Prethink recipes](../../user-documentation/agent-tools/prethink.md). This module focuses on running it and using the output.
+
+## Exercise 3-1: Run Prethink and apply the changes
+
+### Goals for this exercise
+
+* Run the `UpdatePrethinkContextNoAiStarter` recipe across the workspace
+* Apply the generated `.moderne/context/` files into your repositories
+* Understand what each phase of the recipe contributed
+
+### Key concepts
+
+Prethink is delivered as an OpenRewrite [composite recipe](https://docs.openrewrite.org/concepts-and-explanations/recipes#composite-recipes) that runs many smaller recipes in phases. Each phase produces data tables, and a final phase exports those tables as CSV and Markdown into `.moderne/context/` inside each repository. Your AI agent reads those files instead of inferring everything from the source code.
+
+You'll run the **No AI** starter in this workshop, which doesn't require an LLM provider. If you have an OpenAI/Gemini/Poolside key handy, you can swap to `UpdatePrethinkContextStarter` later to also get AI-generated method/class summaries. See [Available recipes](../../user-documentation/agent-tools/prethink.md#available-recipes) for the parameters.
+
+### Steps
+
+#### Step 1: Run Prethink across the workspace
+
+From your `~/agent-tools-workshop` directory:
+
+```bash
+mod run . --recipe io.moderne.prethink.UpdatePrethinkContextNoAiStarter
+```
+
+This will take a few minutes. The recipe runs through architectural discovery, code quality analysis, test coverage mapping, dependency inventory, and CALM architecture diagram generation. The CLI will report `Fix results` per repository as it completes.
+
+:::tip
+If you're impatient, target a single repository first to see the output faster:
+
+```bash
+mod run ./spring-projects/spring-petclinic --recipe io.moderne.prethink.UpdatePrethinkContextNoAiStarter
+```
+
+Then re-run on the full workspace once you've seen what gets produced.
+:::
+
+#### Step 2: Apply the changes to your working tree
+
+Until you apply the run, the output exists only as patches. Make the files real:
+
+```bash
+mod git apply . --last-recipe-run
+```
+
+After this, each repository has a `.moderne/context/` directory and updated agent configuration files (`AGENTS.md`, `CLAUDE.md`, `.cursorrules`, or `.github/copilot-instructions.md`, depending on which agents you're targeting).
+
+#### Step 3 (optional): Examine a recipe run summary
+
+Before moving on, you can ask the CLI for a detailed run summary:
+
+```bash
+mod run-history list .
+```
+
+This shows what Prethink touched per repository. It's useful if you want to share context with someone or pick a specific repo to dig into.
+
+### Takeaways
+
+* Prethink is a recipe like any other. `mod run` and `mod git apply` are the same commands you'd use for any migration recipe.
+* The output is structured data on disk, not a runtime service. Your agent reads it like any other file.
+
+---
+
+## Exercise 3-2: Inspect the generated context
+
+### Goals for this exercise
+
+* See exactly what files Prethink wrote
+* Understand the difference between CSV (data) and Markdown (schema) files
+* Locate the architectural and quality artifacts you'll use later
+
+### Steps
+
+#### Step 1: Look at what Prethink generated
+
+Pick one of the Spring repositories (for example, `spring-petclinic`) and list the context directory:
+
+```bash
+ls spring-projects/spring-petclinic/.moderne/context/
+```
+
+You should see CSVs and matching Markdown files for each context type. For the full list, see [What Prethink generates](../../user-documentation/agent-tools/prethink.md#what-prethink-generates). The most interesting ones for this exercise:
+
+| File                              | What it captures                                                                                          |
+|-----------------------------------|-----------------------------------------------------------------------------------------------------------|
+| `service-endpoints.csv`           | REST/HTTP endpoints with HTTP methods, paths, and the framework that exposed them                         |
+| `database-connections.csv`        | JPA entities, repositories, and JDBC connection points                                                    |
+| `dependencies.csv`                | Resolved dependency graph including transitive dependencies                                               |
+| `method-quality-metrics.csv`      | Per-method cyclomatic complexity, cognitive complexity, ABC, Halstead measures                            |
+| `class-quality-metrics.csv`       | Per-class WMC, LCOM4, TCC, CBO, Maintainability Index                                                     |
+| `package-quality-metrics.csv`     | Per-package coupling, instability, abstractness, dependency cycles                                        |
+| `code-smells.csv`                 | God Class, Feature Envy, Data Class detections with severity and metric evidence                          |
+| `test-gaps.csv`                   | Untested public methods ranked by risk score (complexity x architectural centrality)                      |
+| `architecture-diagram.md`         | Mermaid architecture diagram you can render directly in GitHub or your IDE                                |
+
+The corresponding `.md` files describe the schema and meaning of each CSV. They're written for humans **and** agents, so opening them is the fastest way to understand a column.
+
+#### Step 2: Open the architecture diagram
+
+Open `architecture-diagram.md` in your editor or a Mermaid renderer (GitHub, GitLab, and most IDEs support Mermaid out of the box). For a Spring web app you'll see services, controllers, databases, and messaging components and the relationships between them.
+
+#### Step 3: Skim the updated agent config
+
+Open the `CLAUDE.md` (or `AGENTS.md`, `.cursorrules`, etc.) at the root of one of the repositories. Prethink added a section pointing to the generated context files with one-line descriptions. This is what enables [progressive discovery](../../user-documentation/agent-tools/prethink.md#how-agents-discover-prethink-context): the agent doesn't load every CSV up-front, it sees the index first and reads only the files it needs.
+
+### Takeaways
+
+* Each context type has a CSV (data) and a Markdown file (schema). The agent uses both.
+* Architectural context (endpoints, messaging, databases) lets the agent reason about cross-service behavior without reading every controller.
+* The updated agent config file is the entry point. Without it, the agent wouldn't know the context directory exists.
+
+---
+
+## Exercise 3-3: Visualize code quality metrics with your agent
+
+### Goals for this exercise
+
+* Use the per-method, per-class, and per-package quality metrics as input for the agent
+* Get the agent to produce a visualization and a remediation plan
+* Practice steering the agent toward concrete, prioritized work
+
+### Steps
+
+#### Step 1: Pick a target repository
+
+Pick one repository with rich quality data (Spring PetClinic and Spring Data Commons are good choices). `cd` into it and start your agent from there. For Claude Code:
+
+```bash
+cd spring-projects/spring-petclinic
+claude
+```
+
+#### Step 2: Ask the agent to visualize the metrics
+
+Point the agent at the quality CSVs and ask it to surface what's worst. A few tips for the prompt:
+
+* **Give it the file paths.** The agent already has the CSV references via `CLAUDE.md`, but naming them explicitly speeds it up.
+* **Ask for a chart, not a table.** The interesting signal is the *shape* of the distribution, not individual rows.
+* **Constrain the output.** "Top 10 by risk" is more useful than "everything sorted by complexity."
+
+<details>
+<summary>Suggested prompt</summary>
+
+> Read `.moderne/context/method-quality-metrics.csv`, `.moderne/context/class-quality-metrics.csv`, and `.moderne/context/code-smells.csv`. Produce a single visualization that highlights the methods and classes most in need of refactoring, weighted by complexity and code smells. Render it as a Mermaid diagram or an HTML file I can open in a browser. Cap it to the top 10 methods and top 10 classes.
+
+</details>
+
+Most agents will write a small HTML file with a chart, or a Markdown file with a Mermaid diagram. Either is fine. The point is to see the distribution.
+
+#### Step 3: Ask for a remediation plan
+
+Once the visualization is in place, ask the agent to use the same data to propose a phased plan:
+
+<details>
+<summary>Suggested prompt</summary>
+
+> Based on the same files, propose a phased refactoring plan targeting the most in-need areas. For each phase, list:
+> 
+> * The class or method to refactor
+> * The specific code smell or metric that flagged it (cite the column and value)
+> * A one-sentence approach (extract method, split class, introduce delegate, etc.)
+> * Whether the existing test coverage is sufficient (cross-reference `.moderne/context/test-gaps.csv`)
+> 
+> Don't write any code yet. I want to review the plan first.
+
+</details>
+
+The point of the cross-reference with `test-gaps.csv` is to make sure the agent doesn't refactor untested methods without flagging the testing gap. This is the kind of reasoning that becomes possible once the context is structured.
+
+:::tip
+The Moderne Platform has built-in [Prethink code quality visualizations](../../user-documentation/moderne-platform/getting-started/visualizations.md#prethink-code-quality-visualizations) — executive dashboards, coupling/cohesion matrices, and method risk radar charts — that work on the same data. If you have access to the Platform, compare what your agent produced to the canned visualizations.
+:::
+
+### Takeaways
+
+* The quality metrics are most useful as agent feedback, not as a dashboard for humans. Pair them with `test-gaps.csv` so the agent considers test coverage when proposing changes.
+* Asking the agent to visualize first, then plan, helps it ground its reasoning in the data rather than its priors.
+* Once the agent writes any code, you can re-run Prethink to see whether the metrics actually improved. See [Incremental Prethink via MCP](../../user-documentation/agent-tools/prethink.md#incremental-prethink-via-mcp) for the feedback loop.
+
+## Next up
+
+In [Module 4](./module-4-trigrep.md), you'll build a trigram search index across the same workspace and explore what makes Trigrep faster and more structurally aware than `grep`.

--- a/docs/hands-on-learning/agent-tools/module-3-prethink.md
+++ b/docs/hands-on-learning/agent-tools/module-3-prethink.md
@@ -35,6 +35,31 @@ mod run . --recipe io.moderne.prethink.UpdatePrethinkContextNoAiStarter
 
 This will take a few minutes. The recipe runs through architectural discovery, code quality analysis, test coverage mapping, dependency inventory, and CALM architecture diagram generation. The CLI will report `Fix results` per repository as it completes.
 
+<details>
+<summary>Sample tail of the run output</summary>
+
+```text
+        Fix results at file:///.../.moderne/run/.../fix.patch
+        ✓ Recipe run complete
+   Done
+
+3m 18s saved by using previously built LSTs
+3h 30m saved by using recipes
+
+Produced results for 1 repository.
+
+● What to do next
+    > Run mod study . --last-recipe-run --data-table ClassQualityMetrics
+    > Run mod study . --last-recipe-run --data-table CodeSmells
+    > Run mod study . --last-recipe-run --data-table MethodQualityMetrics
+    ... (more data tables)
+    > Run mod git apply . --last-recipe-run to apply the changes
+```
+
+The "What to do next" footer suggests `mod study` commands for inspecting each generated data table — handy for spot-checking what the recipe found.
+
+</details>
+
 :::tip
 If you're impatient, target a single repository first to see the output faster:
 
@@ -53,7 +78,22 @@ Until you apply the run, the output exists only as patches. Make the files real:
 mod git apply . --last-recipe-run
 ```
 
-After this, each repository has a `.moderne/context/` directory and updated agent configuration files (`AGENTS.md`, `CLAUDE.md`, `.cursorrules`, or `.github/copilot-instructions.md`, depending on which agents you're targeting).
+After this, each repository has a `.moderne/context/` directory and an updated agent-configuration file. Prethink writes only the files for the agents Prethink was configured to target — most commonly `CLAUDE.md`, but it can also be `AGENTS.md`, `.cursorrules`, or `.github/copilot-instructions.md`.
+
+<details>
+<summary>Sample <code>mod git apply</code> output</summary>
+
+```text
+● Executing git apply
+
+  0% (1s)     ▶ spring-projects/spring-petclinic@main
+  0% (1s)         ✓ Applied file:///.../spring-petclinic/.moderne/run/.../fix.patch
+100% (1s)     Done
+
+Applied patches to 1 repository.
+```
+
+</details>
 
 #### Step 3 (optional): Examine a recipe run summary
 
@@ -96,19 +136,87 @@ You should see CSVs and matching Markdown files for each context type. For the f
 |-----------------------------------|-----------------------------------------------------------------------------------------------------------|
 | `service-endpoints.csv`           | REST/HTTP endpoints with HTTP methods, paths, and the framework that exposed them                         |
 | `database-connections.csv`        | JPA entities, repositories, and JDBC connection points                                                    |
-| `dependencies.csv`                | Resolved dependency graph including transitive dependencies                                               |
+| `dependency-list-report.csv`      | Resolved dependency graph including transitive dependencies                                               |
 | `method-quality-metrics.csv`      | Per-method cyclomatic complexity, cognitive complexity, ABC, Halstead measures                            |
 | `class-quality-metrics.csv`       | Per-class WMC, LCOM4, TCC, CBO, Maintainability Index                                                     |
 | `package-quality-metrics.csv`     | Per-package coupling, instability, abstractness, dependency cycles                                        |
 | `code-smells.csv`                 | God Class, Feature Envy, Data Class detections with severity and metric evidence                          |
 | `test-gaps.csv`                   | Untested public methods ranked by risk score (complexity x architectural centrality)                      |
-| `architecture-diagram.md`         | Mermaid architecture diagram you can render directly in GitHub or your IDE                                |
+| `architecture.md`                 | Mermaid architecture diagram you can render directly in GitHub or your IDE                                |
+
+<details>
+<summary>Sample <code>ls .moderne/context/</code> output</summary>
+
+```text
+architecture.md
+calm-architecture.json
+class-quality-metrics.csv
+class-quality-metrics.md
+code-smells.csv
+code-smells.md
+coding-conventions.csv
+coding-conventions.md
+data-assets.csv
+database-connections.csv
+dependencies.md
+dependency-list-report.csv
+dependency-usage.csv
+deployment-artifacts.csv
+error-handling-patterns.csv
+error-handling.md
+external-service-calls.csv
+library-usage.md
+method-descriptions.csv
+method-quality-metrics.csv
+method-quality-metrics.md
+package-quality-metrics.csv
+package-quality-metrics.md
+project-identity.md
+project-metadata.csv
+server-configuration.csv
+service-endpoints.csv
+test-coverage.md
+test-gaps.csv
+test-gaps.md
+test-mapping.csv
+test-quality-issues.csv
+test-quality.md
+token-estimates.md
+```
+
+</details>
 
 The corresponding `.md` files describe the schema and meaning of each CSV. They're written for humans **and** agents, so opening them is the fastest way to understand a column.
 
 #### Step 2: Open the architecture diagram
 
-Open `architecture-diagram.md` in your editor or a Mermaid renderer (GitHub, GitLab, and most IDEs support Mermaid out of the box). For a Spring web app you'll see services, controllers, databases, and messaging components and the relationships between them.
+Open `architecture.md` in your editor or a Mermaid renderer (GitHub, GitLab, and most IDEs support Mermaid out of the box). For a Spring web app you'll see services, controllers, databases, and messaging components and the relationships between them.
+
+<details>
+<summary>Sample diagram excerpt for spring-petclinic</summary>
+
+```mermaid
+flowchart LR
+  subgraph spring-petclinic["petclinic"]
+    owner-controller["Owner Controller"]
+    pet-controller["Pet Controller"]
+    visit-controller["Visit Controller"]
+    crash-controller["Crash Controller"]
+    welcome-controller["Welcome Controller"]
+    vet-controller["Vet Controller"]
+  end
+
+  owner-db[("Owner")]
+  pet-type-db[("PetType")]
+  vet-db[("Vet")]
+  ...
+
+  owner-controller -->|JDBC| owner-db
+  owner-controller -->|JDBC| pet-type-db
+  ...
+```
+
+</details>
 
 #### Step 3: Skim the updated agent config
 
@@ -157,6 +265,8 @@ Point the agent at the quality CSVs and ask it to surface what's worst. A few ti
 > Read `.moderne/context/method-quality-metrics.csv`, `.moderne/context/class-quality-metrics.csv`, and `.moderne/context/code-smells.csv`. Produce a single visualization that highlights the methods and classes most in need of refactoring, weighted by complexity and code smells. Render it as a Mermaid diagram or an HTML file I can open in a browser. Cap it to the top 10 methods and top 10 classes.
 
 </details>
+
+Each CSV has a matching `.md` file (e.g., `method-quality-metrics.md`) that documents every column. If the agent's first chart looks confused about what a column means, tell it to read the `.md` first.
 
 Most agents will write a small HTML file with a chart, or a Markdown file with a Mermaid diagram. Either is fine. The point is to see the distribution.
 

--- a/docs/hands-on-learning/agent-tools/module-3-prethink.md
+++ b/docs/hands-on-learning/agent-tools/module-3-prethink.md
@@ -60,10 +60,10 @@ After this, each repository has a `.moderne/context/` directory and updated agen
 Before moving on, you can ask the CLI for a detailed run summary:
 
 ```bash
-mod run-history list .
+mod run-history .
 ```
 
-This shows what Prethink touched per repository. It's useful if you want to share context with someone or pick a specific repo to dig into.
+This shows what Prethink touched per repository. It's useful if you want to share context with someone or pick a specific repo to dig into. Add `--most-recent` to limit the output to one entry per recipe.
 
 ### Takeaways
 
@@ -140,6 +140,8 @@ Pick one repository with rich quality data (Spring PetClinic and Spring Data Com
 cd spring-projects/spring-petclinic
 claude
 ```
+
+For Cursor, run `cursor .`. For Windsurf, run `windsurf .`. For other agents, open the directory the way you normally would.
 
 #### Step 2: Ask the agent to visualize the metrics
 

--- a/docs/hands-on-learning/agent-tools/module-3-prethink.md
+++ b/docs/hands-on-learning/agent-tools/module-3-prethink.md
@@ -7,7 +7,7 @@ description: Run Prethink on a working set, apply the changes, and ask your agen
 
 In this module, you'll run Moderne Prethink on the workspace you set up in [Module 1](./module-1-cli-and-lsts.md), apply the generated context to your repositories, and inspect what shows up: service endpoints, messaging connections, dependencies, and per-method/class/package code quality metrics. Then you'll ask your agent to read the metrics and propose a refactoring plan.
 
-For the deep reference on what Prethink is, see [Moderne Prethink recipes](../../user-documentation/agent-tools/prethink.md). This module focuses on running it and using the output.
+For the deep reference on what Prethink is, see the [Moderne Prethink doc](../../user-documentation/agent-tools/prethink.md). This module focuses on running it and using the output.
 
 ## Exercise 3-1: Run Prethink and apply the changes
 

--- a/docs/hands-on-learning/agent-tools/module-4-trigrep.md
+++ b/docs/hands-on-learning/agent-tools/module-4-trigrep.md
@@ -28,6 +28,29 @@ mod postbuild search index .
 
 The CLI walks every repository with an LST and produces a trigram index per repo. Indexes live in `.moderne/mcp/search/` inside each repository and use the `.zoekt` extension. Index size is roughly 10-20% of the source size.
 
+<details>
+<summary>Sample output</summary>
+
+```text
+● Generating search indexes
+  ...
+  9% (3s)     ▶ awslabs/aws-saas-boost@main (no LST)
+  9% (3s)         Skipped: no LST artifact
+ 18% (3s)     ▶ finos/messageml-utils@main
+ 18% (3s)         ✓ Indexed
+ ...
+100% (4s)     Done
+
+Generated search indexes: 10 indexed, 1 skipped, 0 failed
+
+● What to do next
+    > 1 repository have no LST artifact. Run mod build first.
+```
+
+The `1 skipped` count corresponds to the same `awslabs/aws-saas-boost` repo whose LST failed to download in [Module 1](./module-1-cli-and-lsts.md). Without an LST, there's nothing to index.
+
+</details>
+
 :::tip
 Re-run the same command after significant code changes (or after a fresh `mod build`). Add `--force` if you want to regenerate even when the index already exists.
 :::
@@ -37,18 +60,48 @@ Re-run the same command after significant code changes (or after a fresh `mod bu
 Pick a term you'd expect in a Spring workspace:
 
 ```bash
+mod search . "@RestController"
+```
+
+You should get sub-second results showing every file that mentions `@RestController`, with line numbers and a snippet. Try a few more:
+
+```bash
+mod search . "spring.datasource"
+mod search . "System.out.println"
 mod search . "KafkaTemplate"
 ```
 
-You should get sub-second results showing every file that mentions `KafkaTemplate`, with line numbers and a snippet. Try a few more:
+Notice how each search returns in well under a second, even though the workspace contains thousands of files. The index does the work.
 
-```bash
-mod search . "@RestController"
-mod search . "spring.datasource"
-mod search . "System.out.println"
+<details>
+<summary>Sample output for <code>mod search . "@RestController"</code></summary>
+
+```text
+● Searching for: @RestController
+  0% (1s)     ▶ apache/maven-doxia@master
+  0% (1s)         ✓ No matches
+  9% (1s)     ▶ awslabs/aws-saas-boost@main
+  9% (1s)         No search index
+  ...
+ 27% (1s)     ▶ finos/spring-bot@spring-bot-master
+ 27% (1s)         ● File(libs/.../BotController.java)
+ 27% (1s)              36   @RestController
+ 27% (1s)              37   public class BotController {
+ 27% (1s)         ✓ 1 matches in 1 files
+  ...
+Found 12 matches in 12 files across 10 repositories.
+
+● What to do next
+    > 1 repository has no search index. Run mod postbuild search index to generate indexes from existing LSTs.
 ```
 
-Notice how each search returns in well under a second, even though the workspace contains thousands of files. The index does the work.
+The `No search index` line for `awslabs/aws-saas-boost` is expected — that repo's LST didn't sync (see [Module 1 Step 2](./module-1-cli-and-lsts.md)), so the index couldn't be built. The other 10 repos searched fine.
+
+</details>
+
+:::tip
+Some queries return zero matches in the `Default` org because nothing in those repos uses the keyword. For example `KafkaTemplate` returns 0 matches across the `Default` org. That's not a bug — it just means none of these public repos use Spring Kafka.
+:::
 
 ### Takeaways
 
@@ -116,15 +169,33 @@ The hole syntax includes typed variants like `:[name:e]` (balanced expression), 
 Trigrep extends Sourcegraph's filter syntax with Java-specific filters that read from LST metadata. These are the queries `grep` simply can't answer:
 
 ```bash
-# All public methods that return a List
-mod search . 'visibility:public returns:List'
+# All public methods that return a List (pass each filter as a separate arg)
+mod search . visibility:public returns:List
 
 # Classes that extend a Spring base class
-mod search . 'extends:WebSecurityConfigurerAdapter'
+mod search . extends:WebSecurityConfigurerAdapter
 
 # Methods that throw a checked exception
-mod search . 'throws:IOException'
+mod search . throws:IOException
 ```
+
+:::warning Quoting
+Don't wrap multiple filters in a single pair of quotes (e.g. `'visibility:public returns:List'`). With one shell-arg, the CLI parses the whole string as a single filter value and prints `Search failed: Unknown visibility: public returns:List`. Pass each filter as its own arg, or quote each individually: `"visibility:public" "returns:List"`.
+:::
+
+<details>
+<summary>Sample output for <code>mod search . throws:IOException</code></summary>
+
+```text
+● Searching for: throws:IOException
+  0% (1s)     ▶ apache/maven-doxia@master
+  0% (1s)         doxia-sink-api/src/main/java/.../SinkFactory.java
+  0% (1s)           L41: Sink createSink(File outputDir, String outputName) throws IOException;
+  0% (1s)           L54: Sink createSink(File outputDir, String outputName, String encoding) throws IOException;
+  ...
+```
+
+</details>
 
 ### Takeaways
 

--- a/docs/hands-on-learning/agent-tools/module-4-trigrep.md
+++ b/docs/hands-on-learning/agent-tools/module-4-trigrep.md
@@ -121,20 +121,35 @@ Some queries return zero matches in the `Default` org because nothing in those r
 
 #### Step 1: Literal queries with boolean operators
 
-Literal search supports implicit AND, explicit OR, and negation with `-`:
+Literal search supports implicit AND, explicit OR, and negation with `-`. Pass each token as its own argument so the CLI parses the query as Sourcegraph syntax instead of a literal phrase (see the warning below):
 
 ```bash
-mod search . "@Service getUserById"
-mod search . "@Service or @Controller"
-mod search . "KafkaTemplate -test"
+mod search . @Service getUserById
+mod search . @Service or @Controller
+mod search . KafkaTemplate -test
 ```
 
 Combine with [filters](../../user-documentation/agent-tools/trigrep.md#filters) to narrow by file path, language, or symbol type:
 
 ```bash
-mod search . 'lang:java visibility:public @RestController'
-mod search . 'file:**/*Test.java @Mock'
+mod search . lang:java visibility:public @RestController
+mod search . "file:**/*Test.java" @Mock
 ```
+
+:::warning Quoting
+Don't wrap a multi-token query in a single pair of shell quotes. The CLI treats a single-arg query as a literal phrase and re-emits it quoted in the `Searching for:` line — so `"@Service or @Controller"` looks for the phrase `@Service or @Controller` (which appears nowhere) and returns 0 matches. The same trap applies to `"visibility:public returns:List"`, which fails with `Unknown visibility: public returns:List`. Either pass each token as its own argument, or quote each one individually:
+
+```bash
+# Works
+mod search . @Service or @Controller
+mod search . "@Service" or "@Controller"
+
+# Fails (literal phrase)
+mod search . "@Service or @Controller"
+```
+
+Quoting a single token (e.g. `"file:**/*Test.java"` to keep the shell from expanding the glob) is fine.
+:::
 
 #### Step 2: Regex queries
 
@@ -169,7 +184,7 @@ The hole syntax includes typed variants like `:[name:e]` (balanced expression), 
 Trigrep extends Sourcegraph's filter syntax with Java-specific filters that read from LST metadata. These are the queries `grep` simply can't answer:
 
 ```bash
-# All public methods that return a List (pass each filter as a separate arg)
+# All public methods that return a List
 mod search . visibility:public returns:List
 
 # Classes that extend a Spring base class
@@ -178,10 +193,6 @@ mod search . extends:WebSecurityConfigurerAdapter
 # Methods that throw a checked exception
 mod search . throws:IOException
 ```
-
-:::warning Quoting
-Don't wrap multiple filters in a single pair of quotes (e.g. `'visibility:public returns:List'`). With one shell-arg, the CLI parses the whole string as a single filter value and prints `Search failed: Unknown visibility: public returns:List`. Pass each filter as its own arg, or quote each individually: `"visibility:public" "returns:List"`.
-:::
 
 <details>
 <summary>Sample output for <code>mod search . throws:IOException</code></summary>

--- a/docs/hands-on-learning/agent-tools/module-4-trigrep.md
+++ b/docs/hands-on-learning/agent-tools/module-4-trigrep.md
@@ -26,7 +26,7 @@ From your workspace root:
 mod postbuild search index .
 ```
 
-The CLI walks every repository with an LST and produces a trigram index per repo. Indexes live in `.moderne/search/` inside each repository and use the `.zoekt` extension. Index size is roughly 10-20% of the source size.
+The CLI walks every repository with an LST and produces a trigram index per repo. Indexes live in `.moderne/mcp/search/` inside each repository and use the `.zoekt` extension. Index size is roughly 10-20% of the source size.
 
 :::tip
 Re-run the same command after significant code changes (or after a fresh `mod build`). Add `--force` if you want to regenerate even when the index already exists.

--- a/docs/hands-on-learning/agent-tools/module-4-trigrep.md
+++ b/docs/hands-on-learning/agent-tools/module-4-trigrep.md
@@ -136,7 +136,7 @@ Sourcegraph's negation operator is also written as `-test`, but `mod` parses lea
 Combine with [filters](../../user-documentation/agent-tools/trigrep.md#filters) to narrow by file path, language, or symbol type:
 
 ```bash
-mod search . lang:java visibility:public @RestController
+mod search . visibility:public @RestController
 mod search . "file:**/*Test.java" @Mock
 ```
 
@@ -177,9 +177,8 @@ mod search . struct:'repository.findById(:[id:e])'
 # String concatenation inside log calls (a known performance smell)
 mod search . struct:'logger.:[level](:[msg] + :[rest])'
 
-# Catch blocks that only print stack traces (illustrative — 0 matches in
-# the Default org, but try it on your own codebase)
-mod search . struct:'catch (:[ex:e] :[var:id]) { :[_].printStackTrace()'
+# Optional.ofNullable(x).orElse(y) — superseded by Objects.requireNonNullElse since Java 9
+mod search . struct:'Optional.ofNullable(:[x:e]).orElse(:[y:e])'
 ```
 
 The hole syntax includes typed variants like `:[name:e]` (balanced expression), `:[name:id]` (identifier), `:[name:block]` (balanced braces), and `:[name:g]` (generics). See [Structural holes](../../user-documentation/agent-tools/trigrep.md#structural-holes) for the full reference.
@@ -192,8 +191,8 @@ Trigrep extends Sourcegraph's filter syntax with Java-specific filters that read
 # All public methods that return a List
 mod search . visibility:public returns:List
 
-# Classes that extend a Spring base class
-mod search . extends:WebSecurityConfigurerAdapter
+# Custom exception classes that extend RuntimeException
+mod search . extends:RuntimeException
 
 # Methods that throw a checked exception
 mod search . throws:IOException

--- a/docs/hands-on-learning/agent-tools/module-4-trigrep.md
+++ b/docs/hands-on-learning/agent-tools/module-4-trigrep.md
@@ -68,7 +68,7 @@ You should get sub-second results showing every file that mentions `@RestControl
 ```bash
 mod search . "spring.datasource"
 mod search . "System.out.println"
-mod search . "KafkaTemplate"
+mod search . "@Autowired"
 ```
 
 Notice how each search returns in well under a second, even though the workspace contains thousands of files. The index does the work.
@@ -100,7 +100,7 @@ The `No search index` line for `awslabs/aws-saas-boost` is expected — that rep
 </details>
 
 :::tip
-Some queries return zero matches in the `Default` org because nothing in those repos uses the keyword. For example `KafkaTemplate` returns 0 matches across the `Default` org. That's not a bug — it just means none of these public repos use Spring Kafka.
+Zero matches just means none of these repos use the keyword — for example, the `Default` org has no Spring Kafka, no JMS, and no `@KafkaListener` annotations. Try a Spring annotation that the petclinic and spring-data-commons repos definitely use (`@Repository`, `@Transactional`, `findById`) to see plenty of hits.
 :::
 
 ### Takeaways
@@ -121,13 +121,17 @@ Some queries return zero matches in the `Default` org because nothing in those r
 
 #### Step 1: Literal queries with boolean operators
 
-Literal search supports implicit AND, explicit OR, and negation with `-`. Pass each token as its own argument so the CLI parses the query as Sourcegraph syntax instead of a literal phrase (see the warning below):
+Literal search supports implicit AND, explicit OR, and negation. Pass each token as its own argument so the CLI parses the query as Sourcegraph syntax instead of a literal phrase (see the warning below):
 
 ```bash
-mod search . @Service getUserById
-mod search . @Service or @Controller
-mod search . KafkaTemplate -test
+mod search . @Repository findById        # implicit AND
+mod search . @Service or @Controller     # explicit OR
+mod search . @Autowired not test         # negation
 ```
+
+:::note
+Sourcegraph's negation operator is also written as `-test`, but `mod` parses leading-dash arguments as CLI flags and rejects them. Use `not` (or `NOT`) instead, or pass the rest of the query after a `--` separator.
+:::
 
 Combine with [filters](../../user-documentation/agent-tools/trigrep.md#filters) to narrow by file path, language, or symbol type:
 
@@ -167,14 +171,15 @@ Use regex when literal search isn't expressive enough but you don't need to resp
 Prefix a query with `struct:` to switch into [structural matching](../../user-documentation/agent-tools/trigrep.md#structural-pattern-matching). Holes (`:[name]`) match content while respecting balanced delimiters, which lets you express things regex can't:
 
 ```bash
-# Find Kafka send calls regardless of argument shape
-mod search . struct:'kafkaTemplate.send(:[topic:e], :[payload:e])'
-
-# Catch blocks that only print stack traces
-mod search . struct:'catch (:[ex:e] :[var:id]) { :[_].printStackTrace()'
+# Find findById calls regardless of receiver expression
+mod search . struct:'repository.findById(:[id:e])'
 
 # String concatenation inside log calls (a known performance smell)
 mod search . struct:'logger.:[level](:[msg] + :[rest])'
+
+# Catch blocks that only print stack traces (illustrative — 0 matches in
+# the Default org, but try it on your own codebase)
+mod search . struct:'catch (:[ex:e] :[var:id]) { :[_].printStackTrace()'
 ```
 
 The hole syntax includes typed variants like `:[name:e]` (balanced expression), `:[name:id]` (identifier), `:[name:block]` (balanced braces), and `:[name:g]` (generics). See [Structural holes](../../user-documentation/agent-tools/trigrep.md#structural-holes) for the full reference.
@@ -228,13 +233,13 @@ mod search . throws:IOException
 
 #### Step 1: Search for the targets
 
-Suppose you want to migrate a Kafka-using subset of your workspace. Find them first:
+Suppose you want to run a static-analysis pass only over the transactional-persistence repos in your workspace. Find them first:
 
 ```bash
-mod search . "KafkaTemplate or @KafkaListener or @SendTo"
+mod search . @Transactional
 ```
 
-This finishes in under a second and tells you exactly which repositories contain Kafka producer or consumer patterns.
+In the `Default` org, this matches 3 of the 10 indexed repos (`finos/symphony-wdk`, `spring-projects/spring-data-commons`, `spring-projects/spring-petclinic`). The search finishes in under a second.
 
 #### Step 2: Run a recipe scoped to the matched repos
 
@@ -244,7 +249,7 @@ Use `--last-search` to make the next `mod run` only process repositories the sea
 mod run . --recipe org.openrewrite.staticanalysis.CommonStaticAnalysis --last-search
 ```
 
-If the search matched 3 of 11 repositories, the recipe processes 3 instead of 11. On larger workspaces (think thousands of repos) this is the difference between a coffee break and overnight.
+If the search matched 3 of 10 repositories, the recipe processes 3 instead of 10. On larger workspaces (think thousands of repos) this is the difference between a coffee break and overnight.
 
 See [Using search as a prefilter for recipes](../../user-documentation/agent-tools/trigrep.md#using-search-as-a-prefilter-for-recipes) for more on this pattern.
 

--- a/docs/hands-on-learning/agent-tools/module-4-trigrep.md
+++ b/docs/hands-on-learning/agent-tools/module-4-trigrep.md
@@ -1,0 +1,200 @@
+---
+sidebar_label: "Module 4: Trigrep"
+description: Build a trigram search index with mod postbuild search index, then explore literal, regex, and structural queries across your workspace.
+---
+
+# Module 4: Trigrep
+
+In this module, you'll build a trigram search index across the workspace from [Module 1](./module-1-cli-and-lsts.md) and explore what indexed search makes possible. You'll run literal queries, regex, and Comby-style structural patterns, and you'll see how Trigrep's Java-aware filters (`visibility:`, `extends:`, `returns:`, etc.) push beyond what `grep` can do.
+
+For the deep reference on syntax and semantics, see [Moderne Trigrep](../../user-documentation/agent-tools/trigrep.md). This module is hands-on practice.
+
+## Exercise 4-1: Build the search index
+
+### Goals for this exercise
+
+* Generate a trigram index over every repository in your workspace
+* Understand what `mod postbuild search index` produces and where it's stored
+
+### Steps
+
+#### Step 1: Build the index
+
+From your workspace root:
+
+```bash
+mod postbuild search index .
+```
+
+The CLI walks every repository with an LST and produces a trigram index per repo. Indexes live in `.moderne/search/` inside each repository and use the `.zoekt` extension. Index size is roughly 10-20% of the source size.
+
+:::tip
+Re-run the same command after significant code changes (or after a fresh `mod build`). Add `--force` if you want to regenerate even when the index already exists.
+:::
+
+#### Step 2: Run a sanity-check search
+
+Pick a term you'd expect in a Spring workspace:
+
+```bash
+mod search . "KafkaTemplate"
+```
+
+You should get sub-second results showing every file that mentions `KafkaTemplate`, with line numbers and a snippet. Try a few more:
+
+```bash
+mod search . "@RestController"
+mod search . "spring.datasource"
+mod search . "System.out.println"
+```
+
+Notice how each search returns in well under a second, even though the workspace contains thousands of files. The index does the work.
+
+### Takeaways
+
+* `mod postbuild search index` is a one-time setup step per workspace (run again after big code changes).
+* Indexes are local — there's no server to manage.
+
+---
+
+## Exercise 4-2: Explore Trigrep's three query paradigms
+
+### Goals for this exercise
+
+* Use literal, regex, and structural queries on the same workspace
+* Recognize when each paradigm is the right tool
+
+### Steps
+
+#### Step 1: Literal queries with boolean operators
+
+Literal search supports implicit AND, explicit OR, and negation with `-`:
+
+```bash
+mod search . "@Service getUserById"
+mod search . "@Service or @Controller"
+mod search . "KafkaTemplate -test"
+```
+
+Combine with [filters](../../user-documentation/agent-tools/trigrep.md#filters) to narrow by file path, language, or symbol type:
+
+```bash
+mod search . 'lang:java visibility:public @RestController'
+mod search . 'file:**/*Test.java @Mock'
+```
+
+#### Step 2: Regex queries
+
+Wrap a pattern in `/.../` to switch into regex mode. Trigrep extracts literal fragments to keep the search fast:
+
+```bash
+mod search . '/log\.(info|debug|warn|error)\(/'
+mod search . '/@(Get|Post|Put|Delete|Patch)Mapping/'
+```
+
+Use regex when literal search isn't expressive enough but you don't need to respect language structure (parens, braces, etc.).
+
+#### Step 3: Structural queries with Comby holes
+
+Prefix a query with `struct:` to switch into [structural matching](../../user-documentation/agent-tools/trigrep.md#structural-pattern-matching). Holes (`:[name]`) match content while respecting balanced delimiters, which lets you express things regex can't:
+
+```bash
+# Find Kafka send calls regardless of argument shape
+mod search . struct:'kafkaTemplate.send(:[topic:e], :[payload:e])'
+
+# Catch blocks that only print stack traces
+mod search . struct:'catch (:[ex:e] :[var:id]) { :[_].printStackTrace()'
+
+# String concatenation inside log calls (a known performance smell)
+mod search . struct:'logger.:[level](:[msg] + :[rest])'
+```
+
+The hole syntax includes typed variants like `:[name:e]` (balanced expression), `:[name:id]` (identifier), `:[name:block]` (balanced braces), and `:[name:g]` (generics). See [Structural holes](../../user-documentation/agent-tools/trigrep.md#structural-holes) for the full reference.
+
+#### Step 4: Java-specific semantic filters
+
+Trigrep extends Sourcegraph's filter syntax with Java-specific filters that read from LST metadata. These are the queries `grep` simply can't answer:
+
+```bash
+# All public methods that return a List
+mod search . 'visibility:public returns:List'
+
+# Classes that extend a Spring base class
+mod search . 'extends:WebSecurityConfigurerAdapter'
+
+# Methods that throw a checked exception
+mod search . 'throws:IOException'
+```
+
+### Takeaways
+
+* Literal queries are fast and obvious. Reach for them first.
+* Regex covers patterns literal search can't, and Trigrep optimizes them by extracting literal fragments.
+* Structural queries respect language structure (parens, braces, generics), which makes them reliable on patterns regex would miss or false-match.
+* Semantic filters (`visibility:`, `extends:`, `returns:`, `throws:`) are unique to Trigrep and rely on LST metadata.
+
+---
+
+## Exercise 4-3: Use search as a recipe prefilter
+
+### Goals for this exercise
+
+* See how Trigrep narrows the scope of an expensive recipe run
+* Understand the `--last-search` integration with `mod run`
+
+### Steps
+
+#### Step 1: Search for the targets
+
+Suppose you want to migrate a Kafka-using subset of your workspace. Find them first:
+
+```bash
+mod search . "KafkaTemplate or @KafkaListener or @SendTo"
+```
+
+This finishes in under a second and tells you exactly which repositories contain Kafka producer or consumer patterns.
+
+#### Step 2: Run a recipe scoped to the matched repos
+
+Use `--last-search` to make the next `mod run` only process repositories the search hit:
+
+```bash
+mod run . --recipe org.openrewrite.staticanalysis.CommonStaticAnalysis --last-search
+```
+
+If the search matched 3 of 11 repositories, the recipe processes 3 instead of 11. On larger workspaces (think thousands of repos) this is the difference between a coffee break and overnight.
+
+See [Using search as a prefilter for recipes](../../user-documentation/agent-tools/trigrep.md#using-search-as-a-prefilter-for-recipes) for more on this pattern.
+
+### Takeaways
+
+* Search-as-prefilter is one of the highest-leverage uses of Trigrep, especially at scale.
+* The same `--last-search` flag works for any recipe, not just the static analysis one above.
+
+---
+
+## Exercise 4-4 (optional): Use plain output for agents
+
+### Goals for this exercise
+
+* See how `--output plain` produces minimal, agent-friendly output
+* Recognize when to use it
+
+### Steps
+
+Run any search with `--output plain`:
+
+```bash
+mod search . "@Deprecated" --output plain
+```
+
+The output drops the colorized formatting and truncates each match to a single line of file:line:snippet. This is the format AI agents prefer when invoking `mod search` from a tool call (it parses cleanly and uses fewer tokens). The MCP server's `trigrep_search` tool uses the same plain format under the hood — you'll see this in [Module 5](./module-5-mcp.md).
+
+### Takeaways
+
+* Default rich output is for humans. Plain output is for agents.
+* The MCP server is the more typical way an agent will use Trigrep, but `--output plain` is a useful escape hatch when you want to script it directly.
+
+## Next up
+
+In [Module 5](./module-5-mcp.md), you'll see how the Moderne MCP server exposes the Trigrep search you just learned (plus semantic navigation and refactoring) directly to your AI coding agent.

--- a/docs/hands-on-learning/agent-tools/module-5-mcp.md
+++ b/docs/hands-on-learning/agent-tools/module-5-mcp.md
@@ -43,6 +43,19 @@ claude mcp list
 
 You should see `moderne` (or similar) listed. For Cursor, open `~/.cursor/mcp.json` and confirm a `moderne` entry exists.
 
+<details>
+<summary>Sample <code>claude mcp list</code> output</summary>
+
+```text
+Checking MCP server health...
+
+moderne: bash -c if [ -x '/opt/homebrew/bin/mod' ]; then exec '/opt/homebrew/bin/mod' mcp; else exec mod mcp; fi - ✓ Connected
+```
+
+The exact path to `mod` depends on how you installed the CLI (Homebrew lands at `/opt/homebrew/bin/mod` on Apple Silicon, the install script lands at `~/.moderne/cli/mod` on Linux/macOS, and `%LOCALAPPDATA%\Programs\moderne\mod.exe` on Windows). The wrapper is the same on every platform.
+
+</details>
+
 #### Step 2: Open the project and confirm tools are exposed
 
 Start your agent inside the workspace from Module 1:

--- a/docs/hands-on-learning/agent-tools/module-5-mcp.md
+++ b/docs/hands-on-learning/agent-tools/module-5-mcp.md
@@ -112,9 +112,9 @@ Ask your agent:
 
 #### Step 2: Find method invocations by AspectJ pattern
 
-> Use `find_methods` to list every call to `org.springframework.kafka.core.KafkaTemplate send(..)`. Show me the file and line for each call.
+> Use `find_methods` to list every call to `org.springframework.data.repository.CrudRepository findById(..)`. Show me the file and line for each call.
 
-`find_methods` resolves the type at every call site, so it finds `kafkaTemplate.send(...)` even when `kafkaTemplate` is declared in a parent class or injected via Spring. Grep would miss the indirect cases.
+`find_methods` resolves the type at every call site, so it finds `repository.findById(...)` even when `repository` is declared in a parent class or injected via Spring. Grep would miss the indirect cases — and would also match unrelated `findById` methods on classes that aren't repositories.
 
 #### Step 3: Find annotation usages
 

--- a/docs/hands-on-learning/agent-tools/module-5-mcp.md
+++ b/docs/hands-on-learning/agent-tools/module-5-mcp.md
@@ -1,0 +1,240 @@
+---
+sidebar_label: "Module 5: MCP server"
+description: Explore the Moderne MCP server and the semantic search, navigation, and refactoring tools it exposes to your AI coding agent.
+---
+
+# Module 5: MCP server
+
+In this final module, you'll see how the Moderne MCP server gives your AI coding agent direct access to indexed search, semantic navigation, codebase-wide refactoring, and recipe execution. You already installed it in [Module 2](./module-2-install-agent-tools.md) (it ships alongside skills via `mod config agent-tools install`). Now you'll exercise the tools.
+
+For the full tool catalog and architecture details, see the [MCP server overview](../../user-documentation/agent-tools/mcp/overview.md). This module is hands-on practice.
+
+## Exercise 5-1: Confirm the MCP server is wired up
+
+### Goals for this exercise
+
+* See where each agent stores its MCP server configuration
+* Confirm the MCP tools show up in your agent
+
+### Key concepts
+
+The MCP server is a process the CLI starts when your agent opens a project. The agent talks to it over the [Model Context Protocol](https://modelcontextprotocol.io/), which is what makes the Moderne tools (e.g. `trigrep_search`, `find_methods`, `change_type`, `run_recipe`) appear as callable tools in the agent's tool list.
+
+Each agent has its own configuration mechanism. The CLI handles the differences for you. For example, it runs `claude mcp add` for Claude Code and writes to `~/.cursor/mcp.json` for Cursor.
+
+### Steps
+
+#### Step 1: Find the MCP configuration for your agent
+
+| Agent           | MCP configuration                                   |
+|-----------------|-----------------------------------------------------|
+| Claude Code     | Registered via `claude mcp add`                     |
+| Windsurf        | `~/.codeium/windsurf/mcp_config.json`               |
+| Cursor          | `~/.cursor/mcp.json`                                |
+| GitHub Copilot  | `.vscode/mcp.json` and `~/.copilot/mcp-config.json` |
+| Sourcegraph Amp | Registered via `amp mcp add`                        |
+| OpenAI Codex    | Registered via `codex mcp add`                      |
+
+For Claude Code, list registered MCP servers:
+
+```bash
+claude mcp list
+```
+
+You should see `moderne` (or similar) listed. For Cursor, open `~/.cursor/mcp.json` and confirm a `moderne` entry exists.
+
+#### Step 2: Open the project and confirm tools are exposed
+
+Start your agent inside the workspace from Module 1:
+
+```bash
+cd ~/agent-tools-workshop
+claude
+```
+
+In Claude Code, the MCP tools appear as `mcp__moderne__*` and are listed when the agent shows its available tools. In Cursor, they appear as MCP tool calls in the agent's chat. In each case, the names match the table in [Available tools](../../user-documentation/agent-tools/mcp/overview.md#available-tools).
+
+:::warning
+The MCP server **must be started from within a git repository**. If your working directory isn't a git repo, the server exits immediately and none of the tools become available. The `mod git sync` from [Module 1](./module-1-cli-and-lsts.md) takes care of this — every cloned repo is its own git directory.
+:::
+
+#### Step 3: Watch the build progress
+
+When the MCP server starts, it builds two things in the background: the trigram search index (powering `trigrep_search` and `trigrep_structural_search`) and LSTs (powering the semantic tools). Tools become available progressively as each build completes.
+
+You can ask the agent to check the status itself:
+
+> Use the `lst_status` and `build_status` tools to tell me which Moderne tools are ready right now.
+
+Or, if you enabled the [tool browser](../../user-documentation/agent-tools/mcp/tool-browser.md), open it from your system tray to see live build progress and per-project status cards.
+
+### Takeaways
+
+* The CLI handles the MCP wiring per agent. You usually don't need to edit configuration files by hand.
+* The MCP server runs in the background while the agent is open and shuts down when the agent closes.
+* `lst_status` and `build_status` are the agent's way of asking "are the tools ready yet?" Use them when results look incomplete.
+
+---
+
+## Exercise 5-2: Use semantic tools that grep can't replicate
+
+### Goals for this exercise
+
+* See the difference between text search and semantic search
+* Use `find_types`, `find_methods`, `find_annotations`, and `find_implementations` from your agent
+
+### Steps
+
+Pick a Spring repository in your workspace (Spring PetClinic works well) and open your agent there.
+
+#### Step 1: Find every reference to a type
+
+Ask your agent:
+
+> Use `find_types` to list every reference to `org.springframework.web.bind.annotation.RestController` in this repository. Group by file.
+
+`find_types` finds imports, field types, parameters, return types, casts, generics, and annotation usages — the same things an IDE finds when you do a "find usages" on a class. Grep can't do this because it can't tell `RestController` (the annotation) from `RestController` (a hypothetical local class with the same name).
+
+#### Step 2: Find method invocations by AspectJ pattern
+
+> Use `find_methods` to list every call to `org.springframework.kafka.core.KafkaTemplate send(..)`. Show me the file and line for each call.
+
+`find_methods` resolves the type at every call site, so it finds `kafkaTemplate.send(...)` even when `kafkaTemplate` is declared in a parent class or injected via Spring. Grep would miss the indirect cases.
+
+#### Step 3: Find annotation usages
+
+> Use `find_annotations` to find every place `@Transactional` is used in this repo, including on classes, methods, and parameters.
+
+#### Step 4: Find all implementations of an interface
+
+> Use `find_implementations` to list every class that implements `org.springframework.data.repository.Repository`, including indirect implementations through subinterfaces.
+
+This walks the full type hierarchy, which is exactly the kind of question Trigrep's `implements:` filter can only answer at one level. The MCP version goes deep.
+
+### Takeaways
+
+* Semantic tools answer questions about *types*, not *text*. Use them when you care about correctness.
+* Each tool corresponds to a refactoring you'd do with an IDE; the MCP version works across the entire workspace at once.
+
+---
+
+## Exercise 5-3: Use codebase-wide refactoring tools
+
+### Goals for this exercise
+
+* See an MCP-driven rename or refactor in action
+* Understand the difference between `change_type`, `change_method_name`, and `pattern_replace`
+
+### Steps
+
+#### Step 1: Pick a low-stakes target
+
+Pick a class or method in one of the workspace repositories that has obvious renames (a typo, an outdated name, a method whose better name has been on a TODO for a while). For learning purposes, you can also undo the change at the end.
+
+#### Step 2: Ask the agent to use `change_method_name`
+
+> Use the `change_method_name` tool to rename `getOwners` to `findOwners` on `org.springframework.samples.petclinic.owner.OwnerRepository`. Then show me the diff for every file that changed.
+
+`change_method_name` updates the declaration and **every call site** atomically, just like an IDE rename across the whole workspace. Compare that to a regex find-and-replace that would also touch comments, string literals, and unrelated methods of the same name.
+
+#### Step 3 (optional): Try `pattern_replace` for a Refaster-style change
+
+`pattern_replace` runs a Refaster template across the codebase. Provide a Java class with `@BeforeTemplate` and `@AfterTemplate` methods, and the agent applies it everywhere the pattern matches. This is the right tool when you have a mechanical pattern that's identical across many call sites (for example, replacing `Optional.ofNullable(x).orElse(y)` with `x != null ? x : y`).
+
+See the [Refaster template documentation](https://docs.openrewrite.org/concepts-and-explanations/recipes#refaster-template-recipes) for how the templates are structured. Most agents can write the template for you if you describe the change in plain English.
+
+#### Step 4: Revert if needed
+
+If you used the changes only to learn the tool, you can revert with git:
+
+```bash
+cd <repo>
+git restore .
+```
+
+### Takeaways
+
+* MCP refactoring tools update **every reference** atomically. They are not text replacements.
+* Use `change_type`/`change_method_name` for clean renames. Use `pattern_replace` (Refaster) when the change is structural and repeated across call sites.
+* For more complex changes, run an existing recipe (`run_recipe`) instead — see Exercise 5-4.
+
+---
+
+## Exercise 5-4: Run a recipe through the MCP server
+
+### Goals for this exercise
+
+* See the agent invoke `search_recipes`, `learn_recipe`, and `run_recipe`
+* Connect what you've learned in earlier modules: the agent uses Prethink + Trigrep + recipes to drive a fix
+
+### Steps
+
+#### Step 1: Ask the agent to find a relevant recipe
+
+> Use `search_recipes` to find an OpenRewrite recipe that upgrades dependencies with known vulnerabilities. Show me the top 3 results.
+
+The `search_recipes` tool returns a paginated list of matching recipes ranked by relevance. The agent picks one and uses `learn_recipe` to retrieve its description, options, and data table schemas before deciding to run it.
+
+#### Step 2: Run the recipe
+
+> Use `run_recipe` to run `org.openrewrite.java.dependencies.DependencyVulnerabilityCheck` on this repository. After it finishes, query the resulting data table with `query_datatable` and summarize the worst 5 vulnerabilities.
+
+The `query_datatable` tool runs SQL against the recipe's output data tables (DuckDB under the hood). This is how the agent goes from raw recipe output to a structured answer.
+
+:::tip
+This is the same workflow `analyze-impact` skill walks the agent through, but driven by you. If you want the skill to do the orchestration, invoke it explicitly: `/moderne:analyze-impact` (Claude Code) or the equivalent in your agent.
+:::
+
+### Takeaways
+
+* The MCP server lets the agent run real recipes, not just search and read.
+* `query_datatable` closes the loop: the agent can turn raw recipe output into prioritized human-readable results.
+
+---
+
+## Exercise 5-5 (optional): Set up the tool browser
+
+### Goals for this exercise
+
+* See the live MCP build status in a browser dashboard
+* Test individual tools without needing an agent
+
+### Steps
+
+Enable the optional tool browser:
+
+```bash
+mod config features agent-tools tray --enabled
+```
+
+The next time an agent starts the MCP server, a system tray icon appears. Click it and choose **Tool Browser...** to open the dashboard. You'll see project cards with build status, file counts, and tool call metrics. From the dashboard you can also invoke individual tools directly, which is useful for debugging.
+
+See [Tool browser](../../user-documentation/agent-tools/mcp/tool-browser.md) for the full reference.
+
+### Takeaways
+
+* The tool browser is the easiest way to see what's happening inside the MCP server while an agent is connected.
+* Invoke tools manually from the dashboard when you want to test a tool's behavior without dragging an agent into it.
+
+---
+
+## Wrap-up
+
+You now have a working setup that combines:
+
+* A local workspace of repositories with built LSTs
+* The Moderne CLI installed and authenticated
+* Skills installed for your AI coding agent
+* The Moderne MCP server registered and exposing semantic tools
+* Prethink-generated context (`.moderne/context/`) describing each repository's architecture and code quality
+* A trigram search index for sub-second whole-workspace search
+
+Point all of this at your own repositories and you'll get the same setup with your code. The same `mod git sync` / `mod build` / `mod run` / `mod postbuild search index` commands work whether you're targeting public Spring projects or your private monorepo.
+
+## Further reading
+
+* [Skills for AI coding agents](../../user-documentation/agent-tools/skills.md)
+* [Moderne MCP server overview](../../user-documentation/agent-tools/mcp/overview.md)
+* [Moderne Prethink recipes](../../user-documentation/agent-tools/prethink.md)
+* [Moderne Trigrep](../../user-documentation/agent-tools/trigrep.md)
+* [AI-assisted recipe authoring workshop](../ai-recipes/workshop-overview.md) for using the same skills to build new recipes

--- a/docs/hands-on-learning/agent-tools/module-5-mcp.md
+++ b/docs/hands-on-learning/agent-tools/module-5-mcp.md
@@ -49,7 +49,9 @@ Start your agent inside the workspace from Module 1:
 
 ```bash
 cd ~/agent-tools-workshop
-claude
+claude       # Claude Code
+# cursor .   # Cursor
+# windsurf . # Windsurf
 ```
 
 In Claude Code, the MCP tools appear as `mcp__moderne__*` and are listed when the agent shows its available tools. In Cursor, they appear as MCP tool calls in the agent's chat. In each case, the names match the table in [Available tools](../../user-documentation/agent-tools/mcp/overview.md#available-tools).

--- a/docs/hands-on-learning/agent-tools/module-5-mcp.md
+++ b/docs/hands-on-learning/agent-tools/module-5-mcp.md
@@ -58,10 +58,10 @@ The exact path to `mod` depends on how you installed the CLI (Homebrew lands at 
 
 #### Step 2: Open the project and confirm tools are exposed
 
-Start your agent inside the workspace from Module 1:
+The MCP server must be started from within a git repository, so `cd` into one of the repos you synced in [Module 1](./module-1-cli-and-lsts.md) (Spring PetClinic is a good default) and start your agent there:
 
 ```bash
-cd ~/agent-tools-workshop
+cd ~/agent-tools-workshop/spring-projects/spring-petclinic
 claude       # Claude Code
 # cursor .   # Cursor
 # windsurf . # Windsurf
@@ -70,7 +70,7 @@ claude       # Claude Code
 In Claude Code, the MCP tools appear as `mcp__moderne__*` and are listed when the agent shows its available tools. In Cursor, they appear as MCP tool calls in the agent's chat. In each case, the names match the table in [Available tools](../../user-documentation/agent-tools/mcp/overview.md#available-tools).
 
 :::warning
-The MCP server **must be started from within a git repository**. If your working directory isn't a git repo, the server exits immediately and none of the tools become available. The `mod git sync` from [Module 1](./module-1-cli-and-lsts.md) takes care of this — every cloned repo is its own git directory.
+If your working directory isn't a git repo, the MCP server exits immediately and none of the tools become available. Starting at the workspace root (`~/agent-tools-workshop`) doesn't work — that directory is *not* a git repository, even though every subdirectory you synced is. Always start your agent inside one of the cloned repos.
 :::
 
 #### Step 3: Watch the build progress

--- a/docs/hands-on-learning/agent-tools/workshop-overview.md
+++ b/docs/hands-on-learning/agent-tools/workshop-overview.md
@@ -1,0 +1,62 @@
+---
+sidebar_label: Workshop overview
+description: Set up the Moderne agent tools and use Prethink, Trigrep, and the MCP server with your AI coding agent.
+---
+
+# Overview: Agent tools for AI coding agents
+
+AI coding agents are only as good as the context and tools they can reach. Out of the box, most agents only have grep, file reads, and shell commands, which means they read your code as text and infer everything else. On enterprise codebases that doesn't scale.
+
+The Moderne CLI ships a set of **agent tools** that change that. Skills teach agents how to work with recipes, the MCP server exposes semantic navigation and search, Prethink writes pre-resolved architectural and quality context into your repositories, and Trigrep gives sub-second indexed search. In this workshop, you'll install each of these and try them on a small set of Java and Spring projects.
+
+## What you'll learn
+
+* How to install and configure the Moderne CLI, the `rewrite-prethink` recipe modules, and Lossless Semantic Trees (LSTs) for a working set of repositories
+* How to install agent tools with `mod config agent-tools install` (and how to scope to a single agent like `copilot` or `claude`)
+* How to run Prethink and inspect the architectural and code quality context it generates
+* How to use Trigrep for fast literal, regex, and structural code search
+* How the Moderne MCP server exposes semantic tools (`find_types`, `find_methods`, `change_type`, `run_recipe`, etc.) to your coding agent
+
+## What you'll build
+
+A small workspace of public Java/Spring repositories with:
+
+* Locally built LSTs ready for recipe execution
+* Generated Prethink context (`.moderne/context/`) for each repo, including service endpoints, messaging connections, and code quality metrics
+* A trigram search index for whole-workspace search
+* An AI coding agent configured with Moderne skills, Prethink-aware context, and the Moderne MCP server
+
+By the end you'll have a working setup you can point at your own repositories the same day.
+
+## Prerequisites
+
+To get the most out of this workshop, you should be familiar with:
+
+* Running commands in a terminal
+* Cloning git repositories and basic git operations
+* A working knowledge of Java/Spring (helpful for reading the example projects, but not required)
+
+You will also need:
+
+* The [Moderne CLI](../../user-documentation/moderne-cli/getting-started/cli-intro.md) (version 4.2.1 or higher recommended). You'll install this in [Module 1](./module-1-cli-and-lsts.md)
+* A JDK installed locally (Java 17 or higher recommended)
+* An AI coding agent. The exercises demo with [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview), but every step works with [Cursor](https://cursor.sh), [GitHub Copilot](https://github.com/features/copilot), [Windsurf](https://codeium.com/windsurf), [Sourcegraph Amp](https://ampcode.com), or [OpenAI Codex](https://openai.com/codex)
+* A Moderne account on [app.moderne.io](https://app.moderne.io) (a free login is sufficient)
+
+If you've never used the Moderne CLI before, work through the [Introduction to OpenRewrite](../introduction/workshop-overview.md) workshop first. This workshop assumes you're comfortable running `mod` commands.
+
+:::warning
+Agents don't always respond the same way. Your results will differ from the examples shown here, and that's expected. Treat the exercises as a guide, not a script. You may need to adjust your prompts, skip steps the agent already completed, or steer the agent back on track. That's part of working with AI.
+:::
+
+:::note
+Most agents ask for your approval before running tools (reading files, executing commands, writing code, etc.). The exercises don't call out these approval steps explicitly. It's up to you whether to approve each action individually or configure your agent to proceed automatically.
+:::
+
+## Workshop modules
+
+* [Module 1: CLI and LSTs](./module-1-cli-and-lsts.md) - Install the Moderne CLI, install the Prethink recipe modules, sync repositories, and build LSTs
+* [Module 2: Install agent tools](./module-2-install-agent-tools.md) - Install skills and the MCP server with `mod config agent-tools install`, and verify what each agent now exposes
+* [Module 3: Prethink](./module-3-prethink.md) - Run Prethink, apply the changes, inspect the generated context, and ask your agent to visualize the code quality metrics
+* [Module 4: Trigrep](./module-4-trigrep.md) - Build a search index with `mod postbuild search index` and explore literal, regex, and structural queries
+* [Module 5: MCP server](./module-5-mcp.md) - Explore how the Moderne MCP server exposes semantic search, navigation, and refactoring tools to your agent

--- a/docs/hands-on-learning/agent-tools/workshop-overview.md
+++ b/docs/hands-on-learning/agent-tools/workshop-overview.md
@@ -53,6 +53,10 @@ Agents don't always respond the same way. Your results will differ from the exam
 Most agents ask for your approval before running tools (reading files, executing commands, writing code, etc.). The exercises don't call out these approval steps explicitly. It's up to you whether to approve each action individually or configure your agent to proceed automatically.
 :::
 
+:::tip Agent-agnostic by design
+Examples in this workshop demo with Claude Code (slash commands like `/moderne:create-recipe`, the `claude` startup command). Every step works the same way in Cursor, GitHub Copilot, Windsurf, Amp, and Codex. When you see a Claude-specific command, substitute the equivalent for your agent. See [Invoking skills](../../user-documentation/agent-tools/skills.md#invoking-skills) for the per-agent syntax.
+:::
+
 ## Workshop modules
 
 * [Module 1: CLI and LSTs](./module-1-cli-and-lsts.md) - Install the Moderne CLI, install the Prethink recipe modules, sync repositories, and build LSTs

--- a/docs/user-documentation/agent-tools/mcp/overview.md
+++ b/docs/user-documentation/agent-tools/mcp/overview.md
@@ -98,6 +98,7 @@ For the best experience, install both. Skills teach agents the recipe developmen
 
 ## Next steps
 
+* [Try the hands-on agent tools workshop](../../../hands-on-learning/agent-tools/workshop-overview.md) to set up the MCP server and exercise its tools on a sample workspace
 * [Install the MCP server](./getting-started.md) for your AI coding agent
 * [Set up the tool browser](./tool-browser.md) to monitor builds and test tools
 * [Review the security architecture](./security.md) for compliance and IT review

--- a/docs/user-documentation/agent-tools/prethink.md
+++ b/docs/user-documentation/agent-tools/prethink.md
@@ -627,8 +627,8 @@ After running a Prethink recipe, you'll find generated files in the `.moderne/co
 ├── coding-conventions.md
 ├── database-connections.csv
 ├── database-connections.md
-├── dependencies.csv
 ├── dependencies.md
+├── dependency-list-report.csv
 ├── dependency-usage.csv
 ├── dependency-usage.md
 ├── error-handling.csv
@@ -647,7 +647,7 @@ After running a Prethink recipe, you'll find generated files in the `.moderne/co
 ├── test-mapping.md
 ├── test-quality.csv
 ├── test-quality.md
-└── architecture-diagram.md
+└── architecture.md
 ```
 
 * **CSV files** contain structured data that AI agents can parse directly
@@ -698,6 +698,7 @@ This creates a feedback loop: the agent writes code, regenerates Prethink contex
 
 ## Next steps
 
+* [Try the hands-on agent tools workshop](../../hands-on-learning/agent-tools/workshop-overview.md) to run Prethink end-to-end on a sample workspace
 * [Run Prethink recipes on the Moderne Platform](../moderne-platform/getting-started/prethink.md)
 * [Generate Prethink context with the CLI](../moderne-cli/how-to-guides/cli-prethink.md)
 * [Explore Prethink code quality visualizations](../moderne-platform/getting-started/visualizations.md#prethink-code-quality-visualizations) for dashboards including executive summaries, coupling/cohesion matrices, and method risk radar charts

--- a/docs/user-documentation/agent-tools/skills.md
+++ b/docs/user-documentation/agent-tools/skills.md
@@ -201,5 +201,6 @@ This ensures the agent tools stay current as CLI capabilities evolve.
 
 ## Next steps
 
+* [Try the hands-on agent tools workshop](../../hands-on-learning/agent-tools/workshop-overview.md) to install skills and exercise them end-to-end
 * [Set up the Moderne MCP server](./mcp/overview.md) to give agents tools for semantic code search, navigation, and refactoring
 * [Learn about Moderne Prethink](./prethink.md) for giving agents pre-resolved codebase context

--- a/docs/user-documentation/agent-tools/trigrep.md
+++ b/docs/user-documentation/agent-tools/trigrep.md
@@ -298,6 +298,20 @@ Terms separated by space are implicitly ANDed. The `or` keyword creates disjunct
 | `returns:`    | Match methods by return type            | `returns:List`           |
 | `throws:`     | Match methods by declared exceptions    | `throws:IOException`     |
 
+:::warning Quoting multiple filters
+Don't combine multiple filters inside a single pair of shell quotes. The CLI parses `'visibility:public returns:List'` as a single filter with the value `public returns:List` and fails with `Unknown visibility: public returns:List`. Pass each filter as its own argument, or quote each individually:
+
+```bash
+# Works
+mod search . visibility:public returns:List
+mod search . "visibility:public" "returns:List"
+
+# Fails
+mod search . 'visibility:public returns:List'
+```
+
+:::
+
 ### Structural holes
 
 These holes require the `struct:` prefix (see [structural pattern matching](#structural-pattern-matching)).
@@ -397,6 +411,7 @@ Since Moderne Trigrep supports both Sourcegraph and Zoekt query syntax as well a
 
 ## Next steps
 
+* [Try the hands-on agent tools workshop](../../hands-on-learning/agent-tools/workshop-overview.md) to practice Trigrep queries on a sample workspace.
 * [Moderne CLI reference](../moderne-cli/cli-reference.md) for the full `mod search` command documentation.
 * [Type-aware code search](../moderne-platform/how-to-guides/introduction-to-type-aware-code-search.md) for the web-based search experience on the Moderne Platform.
 * [Recipe authoring fundamentals](../../hands-on-learning/fundamentals/workshop-overview.md) to learn how to build recipes for searches that require full type resolution.

--- a/docs/user-documentation/agent-tools/trigrep.md
+++ b/docs/user-documentation/agent-tools/trigrep.md
@@ -298,18 +298,27 @@ Terms separated by space are implicitly ANDed. The `or` keyword creates disjunct
 | `returns:`    | Match methods by return type            | `returns:List`           |
 | `throws:`     | Match methods by declared exceptions    | `throws:IOException`     |
 
-:::warning Quoting multiple filters
-Don't combine multiple filters inside a single pair of shell quotes. The CLI parses `'visibility:public returns:List'` as a single filter with the value `public returns:List` and fails with `Unknown visibility: public returns:List`. Pass each filter as its own argument, or quote each individually:
+:::warning Quoting multi-token queries
+The CLI treats a single-arg query as a **literal phrase** and re-emits it quoted in the `Searching for:` line. As a result, multi-token queries wrapped in a single pair of shell quotes lose their Sourcegraph semantics and almost always return 0 matches. Examples:
+
+* `'@Service or @Controller'` is searched as the literal phrase `@Service or @Controller` (which appears nowhere) — 0 matches.
+* `'visibility:public returns:List'` is parsed as a single filter with value `public returns:List` — fails with `Unknown visibility: public returns:List`.
+* `'KafkaTemplate -test'` is searched as the literal phrase `KafkaTemplate -test` — 0 matches.
+
+Pass each token as its own argument, or quote each individually:
 
 ```bash
 # Works
+mod search . @Service or @Controller
 mod search . visibility:public returns:List
-mod search . "visibility:public" "returns:List"
+mod search . "@Service" or "@Controller"
 
-# Fails
+# Fails (literal phrase)
+mod search . "@Service or @Controller"
 mod search . 'visibility:public returns:List'
 ```
 
+Quoting a single token to protect it from the shell (e.g. `"file:**/*Test.java"` to prevent glob expansion) is fine.
 :::
 
 ### Structural holes

--- a/docs/user-documentation/agent-tools/trigrep.md
+++ b/docs/user-documentation/agent-tools/trigrep.md
@@ -382,7 +382,7 @@ Even in a codebase with millions of files, the intersection of posting lists typ
 
 Moderne Trigrep generates its indexes from LSTs rather than raw source code, which gives the index access to symbol information, type data, and other semantic details that wouldn't be available from text alone. This is what powers semantic filters like `sym:`, `extends:`, and `visibility:`.
 
-The index files use the `.zoekt` extension and live in the `.moderne/search/` directory within each repository. You can use the `--force` flag to regenerate indexes even if they already exist, which is useful after significant code changes.
+The index files use the `.zoekt` extension and live in the `.moderne/mcp/search/` directory within each repository. You can use the `--force` flag to regenerate indexes even if they already exist, which is useful after significant code changes.
 
 </details>
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -683,6 +683,25 @@ const handsOnLearning = {
       ],
     },
     {
+      type: 'category' as const,
+      label: 'Agent tools for AI coding agents',
+      link: {
+        type: 'generated-index' as const,
+        title: 'Agent tools for AI coding agents',
+        description: 'Set up the Moderne agent tools and use Prethink, Trigrep, and the MCP server with your AI coding agent.',
+        slug: '/hands-on-learning/agent-tools',
+        keywords: ['ai', 'agent-tools', 'skills', 'mcp', 'prethink', 'trigrep'],
+      },
+      items: [
+        'hands-on-learning/agent-tools/workshop-overview',
+        'hands-on-learning/agent-tools/module-1-cli-and-lsts',
+        'hands-on-learning/agent-tools/module-2-install-agent-tools',
+        'hands-on-learning/agent-tools/module-3-prethink',
+        'hands-on-learning/agent-tools/module-4-trigrep',
+        'hands-on-learning/agent-tools/module-5-mcp',
+      ],
+    },
+    {
       type: 'link' as const,
       label: 'Live OpenRewrite training',
       description: 'Hands-on sessions for both newcomers and advanced practitioners.',


### PR DESCRIPTION
## Summary

Adds a new five-module hands-on workshop under `docs/hands-on-learning/agent-tools/` that walks through the Moderne agent tools end to end. Designed for use in a workshop next week with a mixed audience working primarily on Java/Spring projects.

The workshop links liberally to the existing reference docs (`agent-tools/skills.md`, `agent-tools/prethink.md`, `agent-tools/trigrep.md`, `agent-tools/mcp/*`, and the CLI guides) rather than duplicating their content. Modules:

* **Module 1: CLI and LSTs** — install the Moderne CLI, install `io.moderne.recipe:rewrite-prethink` (and the OpenRewrite building-block module), sync the `Default` org, and build LSTs locally.
* **Module 2: Install agent tools** — `mod config agent-tools install`, the per-agent variants (`copilot install`, `claude install`, etc.), and inspecting the installed skills.
* **Module 3: Prethink** — run `UpdatePrethinkContextNoAiStarter`, apply the changes, walk through the generated `.moderne/context/` files, and an exercise where the agent visualizes the code quality metrics and proposes a remediation plan cross-referenced against `test-gaps.csv`.
* **Module 4: Trigrep** — `mod postbuild search index`, literal/regex/structural queries, semantic filters (`visibility:`, `extends:`, `returns:`), and the `--last-search` recipe prefilter.
* **Module 5: MCP server** — confirming the MCP wiring per agent, exercising the semantic tools (`find_types`, `find_methods`, `find_annotations`, `find_implementations`), `change_type`/`change_method_name`/`pattern_replace`, running a recipe through `run_recipe` + `query_datatable`, and the optional tool browser.

The workshop is registered in `sidebars.ts` alongside the existing hands-on workshops with a generated index page at `/hands-on-learning/agent-tools`.

## Test plan

- [x] `yarn build` completes without new broken links or errors related to the added pages
- [x] Sidebar registration verified — workshop appears under "Hands-on learning" with the same shape as the AI-recipes workshop
- [ ] Walk through the exercises end-to-end against `app.moderne.io` Default org before the workshop
- [ ] Have a teammate skim for tone/accuracy