### PR TITLE
Refine Spring Boot migration workshop after review

### DIFF
--- a/docs/hands-on-learning/spring-boot-migration/module-1-migration-assessment.md
+++ b/docs/hands-on-learning/spring-boot-migration/module-1-migration-assessment.md
@@ -199,6 +199,6 @@ Other useful code insight recipes you may want to explore later: `FindInternalJa
 
 ## Takeaways
 
-* A full migration dry run surfaces real blockers before you start making changes
-* Code insight recipes help you quantify Java, Spring Boot, and `javax.*` usage hotspots
-* DevCenter gives you a baseline view to compare against after each wave
+* A full migration dry run surfaces real blockers before you start making changes.
+* Code insight recipes help you quantify Java, Spring Boot, and `javax.*` usage hotspots.
+* DevCenter gives you a baseline view to compare against after each wave.

--- a/docs/hands-on-learning/spring-boot-migration/module-1-migration-assessment.md
+++ b/docs/hands-on-learning/spring-boot-migration/module-1-migration-assessment.md
@@ -98,7 +98,7 @@ In this module, you will run the Spring Boot 4 migration recipe in the Moderne P
 
 1. Run the recipe against the organization by clicking the **Dry Run** button above the recipe list. A dry run executes the recipe across all repositories in the selected organization and shows you what changes it would make, without actually modifying any code.
 2. Open the change tree and click into a few files to review. Look for failures highlighted in the diffs by yellow squiggly lines.
-3. Take a few minutes to review the failures and note missing or incompatible classes and dependencies. 
+3. Take a few minutes to review the failures and note missing or incompatible classes and dependencies.
 
 Common blockers include:
 
@@ -149,7 +149,7 @@ A migration dry run plus the `Verify compilation` recipe ([`io.moderne.compiled.
 You won't see any diff results when running this recipe. It only generates data tables that you can access from the **Data tables** tab.
 :::
 
-This helps you confirm the baseline Java versions and build tooling in use so you know what you are starting from. For this example, you're using Java 8 and Maven across the board. 
+This helps you confirm the baseline Java versions and build tooling in use so you know what you are starting from. For this example, you're using Java 8 and Maven across the board.
 
 #### Step 2: Inspect Spring Boot versions
 

--- a/docs/hands-on-learning/spring-boot-migration/module-2-wave-planning.md
+++ b/docs/hands-on-learning/spring-boot-migration/module-2-wave-planning.md
@@ -128,6 +128,6 @@ This command may take a couple of minutes to run as it builds LSTs for each repo
 
 ## Takeaways
 
-* Dependency data helps you define a safe upgrade order
-* The Release-Train-Metro-Plan recipe and visualization in the platform produce a wave map directly
-* Organizing repos by wave lets you run recipes and releases in controlled batches
+* Dependency data helps you define a safe upgrade order.
+* The Release-Train-Metro-Plan recipe and visualization in the platform produce a wave map directly.
+* Organizing repos by wave lets you run recipes and releases in controlled batches.

--- a/docs/hands-on-learning/spring-boot-migration/module-3-establish-baseline.md
+++ b/docs/hands-on-learning/spring-boot-migration/module-3-establish-baseline.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: "Module 3: Establish a baseline"
+sidebar_label: "Module 3: Establish a baseline (Optional)"
 description: Normalize Maven, Java, and Spring Boot versions before major upgrades.
 ---
 

--- a/docs/hands-on-learning/spring-boot-migration/module-3-establish-baseline.md
+++ b/docs/hands-on-learning/spring-boot-migration/module-3-establish-baseline.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: "Module 3: Establish a baseline (Optional)"
+sidebar_label: "Module 3: Establish a baseline"
 description: Normalize Maven, Java, and Spring Boot versions before major upgrades.
 ---
 
@@ -20,8 +20,8 @@ You saw from the analysis earlier that these projects all use a variety of Sprin
 
 1. In the Moderne Platform, open the recipe builder and create a new recipe.
 2. Toggle off the `Auto-generate ID from name` setting so you can manually enter an ID, then fill in the fields as follows:
-   - **Name:** `Spring Boot Migration Workshop Baseline`
-   - **ID:** `com.example.ecom.recipe.SpringBootMigrationWorkshopBaseline`
+   * **Name:** `Spring Boot Migration Workshop Baseline`
+   * **ID:** `com.example.ecom.recipe.SpringBootMigrationWorkshopBaseline`
 
 <figure>
   ![New recipe dialog with name and manually entered ID for the baseline recipe](./assets/workshop-baseline-name-id.png)

--- a/docs/hands-on-learning/spring-boot-migration/module-4-smoke-test.md
+++ b/docs/hands-on-learning/spring-boot-migration/module-4-smoke-test.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: "Module 4: Raise baseline and smoke test"
+sidebar_label: "Module 4: Java 17 upgrade and Spring Boot 4 smoke test"
 description: Upgrade to Java 17 and run a Spring Boot 4 smoke test.
 ---
 

--- a/docs/hands-on-learning/spring-boot-migration/module-4-smoke-test.md
+++ b/docs/hands-on-learning/spring-boot-migration/module-4-smoke-test.md
@@ -65,7 +65,7 @@ mod build $WORKSPACE
 <details>
 <summary>Reference output</summary>
 
-```
+```text
 Starting build process...
 Running Wave 0...
 ecom-common built successfully
@@ -297,7 +297,7 @@ Now that your repositories are upgraded to Java 17, you can run another quick sm
 
 #### Step 1: Run the upgrade recipe
 
-In Module 1, you ran the recipe in the platform and used the `Verify compilation` recipe ([`io.moderne.compiled.verification.VerifyCompilation`](https://docs.openrewrite.org/recipes/compiled/verification/verifycompilation)) to check for build failures. Now, you can run the Spring Boot 4 Upgrade recipe ([`io.moderne.java.spring.boot4.UpgradeSpringBoot_4_0`](https://docs.openrewrite.org/recipes/java/spring/boot4/upgradespringboot_4_0-moderne-edition)) by itself with the CLI and verify the build directly to isolate any remaining obstacles that may require custom fixes. 
+In Module 1, you ran the recipe in the platform and used the `Verify compilation` recipe ([`io.moderne.compiled.verification.VerifyCompilation`](https://docs.openrewrite.org/recipes/compiled/verification/verifycompilation)) to check for build failures. Now, you can run the Spring Boot 4 Upgrade recipe ([`io.moderne.java.spring.boot4.UpgradeSpringBoot_4_0`](https://docs.openrewrite.org/recipes/java/spring/boot4/upgradespringboot_4_0-moderne-edition)) by itself with the CLI and verify the build directly to isolate any remaining obstacles that may require custom fixes.
 
 First, run the recipe and apply the changes:
 
@@ -314,7 +314,7 @@ Don't worry if you see warnings about "errors while running the recipe." You'll 
 You may wish to open the diffs to inspect the changes before applying them. Use ctrl-click (Windows) or cmd-click (Mac) on the `Fix results` links to preview the changes after running the recipe.
 :::
 
-#### Step 2: Build wave 0 and wave 1
+#### Step 2: Build Wave 0 and Wave 1
 
 Now, you can run your build wave by wave. Expect Wave 0 to build cleanly and Wave 1 to fail due to the QueryDSL issues you saw in Module 1.
 

--- a/docs/hands-on-learning/spring-boot-migration/module-4-smoke-test.md
+++ b/docs/hands-on-learning/spring-boot-migration/module-4-smoke-test.md
@@ -18,7 +18,7 @@ In this module, you will raise the Java baseline to 17 and run a controlled Spri
 ### Steps
 
 1. Back in the [Moderne Platform](https://app.moderne.io), relogin if needed, then click **Activity** in the left navigation. The Activity page shows a history of all recipe runs, including their status and results.
-2. Open the failed run of your custom `Try Spring Boot 4 Upgrade` recipe from Module 1 that included [`io.moderne.java.spring.boot4.UpgradeSpringBoot_4_0`](https://docs.openrewrite.org/recipes/java/spring/boot4/upgradespringboot_4_0) and [`io.moderne.compiled.verification.VerifyCompilation`](https://docs.openrewrite.org/recipes/compiled/verification/verifycompilation).
+2. Open the failed run of your custom `Try Spring Boot 4 Upgrade` recipe from Module 1 that included [`io.moderne.java.spring.boot4.UpgradeSpringBoot_4_0`](https://docs.openrewrite.org/recipes/java/spring/boot4/upgradespringboot_4_0-moderne-edition) and [`io.moderne.compiled.verification.VerifyCompilation`](https://docs.openrewrite.org/recipes/compiled/verification/verifycompilation).
 3. Click the **Visualizations** tab and run the **Composite recipe results** visualization.
 
 <figure>
@@ -339,6 +339,6 @@ mod build $WORKSPACE
 
 ## Takeaways
 
-* The composite visualization shows why Java 17 is a prerequisite for Spring Boot 4
-* A Java 17 upgrade raises the baseline across the organization before framework changes
-* The Spring Boot 4 smoke test exposes blockers without committing to a full upgrade
+* The composite visualization shows why Java 17 is a prerequisite for Spring Boot 4.
+* A Java 17 upgrade raises the baseline across the organization before framework changes.
+* The Spring Boot 4 smoke test exposes blockers without committing to a full upgrade.

--- a/docs/hands-on-learning/spring-boot-migration/module-5-build-querydsl-recipe.md
+++ b/docs/hands-on-learning/spring-boot-migration/module-5-build-querydsl-recipe.md
@@ -97,7 +97,7 @@ The agent will run the same searches you did above, cross-reference them with th
 
 #### Step 1: Set up the recipe project
 
-Create a directory for the recipe project and launch your AI coding agent. This exercise uses [Claude Code](https://docs.anthropic.com/en/docs/claude-code) with the Moderne extension, but you can use any AI coding agent or build the recipe manually. If you don't have an agent available, skip to the fallback option in Step 4.
+Create a directory for the recipe project and launch your AI coding agent. This exercise uses [Claude Code](https://docs.anthropic.com/en/docs/claude-code) with the Moderne extension, but you can use any AI coding agent or build the recipe manually. If you prefer not to use an agent, skip to the alternative path in Step 4.
 
 ```bash
 mkdir -p $PROJECTS/rewrite-querydsl && cd $PROJECTS/rewrite-querydsl
@@ -153,8 +153,9 @@ Once the agent has produced the recipe, build and install it locally. Use the gr
 mod config recipes jar install <group>:<artifact>:<version>  # e.g., org.openrewrite.recipe:rewrite-querydsl:0.1.0-SNAPSHOT
 ```
 
-:::tip
-If you are running short on time or your agent is not cooperating, you can use the pre-built recipe as a fallback:
+:::info Alternative path
+
+If you prefer not to use an agent, install the pre-built QueryDSL recipes from the Moderne training organization — the same recipes you would have built:
 
 ```bash
 cd $PROJECTS
@@ -164,7 +165,8 @@ mvn clean install
 mod config recipes jar install org.openrewrite.recipe:rewrite-querydsl:0.1.0-SNAPSHOT
 ```
 
-This is the "answer key" — the same recipe you would have built. You can compare your version against it after the workshop.
+You can compare your version against this one after the workshop.
+
 :::
 
 ### Takeaways
@@ -189,7 +191,7 @@ This exercise followed an abbreviated version of the plan-build-test workflow fr
 
 #### Step 1: Run the recipe
 
-Run your recipe against the workspace to see what it changes. If you used the pre-built fallback, the recipe name is `org.openrewrite.recipe.querydsl.UpgradeToQueryDsl5`:
+Run your recipe against the workspace to see what it changes. If you installed the pre-built recipes, the recipe name is `org.openrewrite.recipe.querydsl.UpgradeToQueryDsl5`:
 
 ```bash
 mod run $WORKSPACE --recipe org.openrewrite.recipe.querydsl.UpgradeToQueryDsl5

--- a/docs/hands-on-learning/spring-boot-migration/module-5-build-querydsl-recipe.md
+++ b/docs/hands-on-learning/spring-boot-migration/module-5-build-querydsl-recipe.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: "Module 5: Build the QueryDSL recipe"
+sidebar_label: "Module 5: Building the QueryDSL upgrade recipe"
 description: Diagnose the QueryDSL blocker and build a custom upgrade recipe with AI assistance.
 ---
 

--- a/docs/hands-on-learning/spring-boot-migration/module-6-wave-migration.md
+++ b/docs/hands-on-learning/spring-boot-migration/module-6-wave-migration.md
@@ -54,12 +54,12 @@ You can't use recipe builder in this case since you are referring to a custom re
 mod config recipes yaml install $WORKSHOP/CustomUpgradeSpringBoot_4_0.yml
 ```
 
-## Exercise 6-2: Upgrade wave 0
+## Exercise 6-2: Upgrade Wave 0
 
 ### Goals for this exercise
 
-* Apply the composite recipe to wave 0
-* Build and release wave 0
+* Apply the composite recipe to Wave 0
+* Build and release Wave 0
 
 ### Steps
 
@@ -87,12 +87,12 @@ $WORKSHOP/release.sh 0
 
 This isn't surprising since you saw Wave 0 successfully build earlier. It was Wave 1 that failed last time, so the real test will be upgrading Wave 1.
 
-## Exercise 6-3: Upgrade wave 1
+## Exercise 6-3: Upgrade Wave 1
 
 ### Goals for this exercise
 
-* Apply the composite recipe to wave 1
-* Build and release wave 1
+* Apply the composite recipe to Wave 1
+* Build and release Wave 1
 
 ### Steps
 

--- a/docs/hands-on-learning/spring-boot-migration/module-6-wave-migration.md
+++ b/docs/hands-on-learning/spring-boot-migration/module-6-wave-migration.md
@@ -23,7 +23,7 @@ Additionally, since you will be upgrading in waves to ensure that custom library
 This is an example of a migration recipe _freight train_. You will often build a custom recipe that runs the out-of-the-box recipes and then applies some additional ones that are needed in your particular environment. In this workshop, the composite recipe upgrades internal dependencies, applies the Spring Boot 4 recipe, and then runs the QueryDSL upgrade.
 :::
 
-1. Create a local YAML recipe file in your `$WORKSHOP` directory. This composite recipe is named `org.openrewrite.recipe.querydsl.CustomUpgradeSpringBoot_4_0` and combines [`org.openrewrite.java.dependencies.UpgradeDependencyVersion`](https://docs.openrewrite.org/recipes/java/dependencies/upgradedependencyversion), [`io.moderne.java.spring.boot4.UpgradeSpringBoot_4_0`](https://docs.openrewrite.org/recipes/java/spring/boot4/upgradespringboot_4_0), and `org.openrewrite.recipe.querydsl.UpgradeToQueryDsl5`. If you prefer, you can copy and paste the YAML directly into a new file instead of using the command.
+1. Create a local YAML recipe file in your `$WORKSHOP` directory. This composite recipe is named `org.openrewrite.recipe.querydsl.CustomUpgradeSpringBoot_4_0` and combines [`org.openrewrite.java.dependencies.UpgradeDependencyVersion`](https://docs.openrewrite.org/recipes/java/dependencies/upgradedependencyversion), [`io.moderne.java.spring.boot4.UpgradeSpringBoot_4_0`](https://docs.openrewrite.org/recipes/java/spring/boot4/upgradespringboot_4_0-moderne-edition), and `org.openrewrite.recipe.querydsl.UpgradeToQueryDsl5`. If you prefer, you can copy and paste the YAML directly into a new file instead of using the command.
 
 ```bash
 cat <<'EOF' > $WORKSHOP/CustomUpgradeSpringBoot_4_0.yml
@@ -295,9 +295,9 @@ The final dashboard should show all 11 repositories on Spring Boot 4.0 and Java 
 
 ## Takeaways
 
-* Composite "freight train" recipes bundle prerequisite upgrades with the main migration step
-* Wave-by-wave upgrades keep dependency releases aligned and reduce downstream breakage
-* DevCenter refreshes provide a quick progress check after each wave
+* Composite "freight train" recipes bundle prerequisite upgrades with the main migration step.
+* Wave-by-wave upgrades keep dependency releases aligned and reduce downstream breakage.
+* DevCenter refreshes provide a quick progress check after each wave.
 
 ## Learn more
 

--- a/docs/hands-on-learning/spring-boot-migration/workshop-overview.md
+++ b/docs/hands-on-learning/spring-boot-migration/workshop-overview.md
@@ -5,7 +5,7 @@ description: A high-level overview of the Spring Boot migration workshop.
 
 # Overview: Preparing for Spring Boot migration
 
-Spring Boot migrations are rarely just a version bump. You need to understand your repositories, identify hidden dependencies, align build tooling, and plan release waves so downstream services can upgrade safely. This workshop walks you through a realistic, end-to-end prep flow using the Moderne Platform and CLI so you can move into a Spring Boot 4 migration with fewer surprises.
+Spring Boot migrations are rarely just a version bump. You need to understand your repositories, identify hidden dependencies, align build tooling, and plan release **waves** — small batches of repos upgraded together so downstream consumers can follow safely. This workshop walks you through a realistic, end-to-end prep flow using the Moderne Platform and CLI so you can move into a Spring Boot 4 migration with fewer surprises.
 
 Throughout the workshop, you will see screenshot placeholders and collapsible **Reference output** sections. Use them as quick sanity checks to confirm you are on the right path. Do not worry if your output differs slightly (CLI versions, repository counts, and file paths can vary).
 
@@ -14,9 +14,22 @@ Throughout the workshop, you will see screenshot placeholders and collapsible **
 * How to perform a dry run and understand what failed
 * How to find which Java and Spring Boot versions you're using
 * How to plan upgrade waves using dependency data
-* How to set a stable baseline before major upgrades
+* How to set a stable baseline — a known-good starting point where every repo runs the same Maven, Java, and Spring Boot versions — before major upgrades
 * How to diagnose third-party blockers like QueryDSL with `mod search`
-* How to build custom recipes with AI assistance
+* How to drive an AI coding agent (with prompting and `mod search`) to author a custom OpenRewrite recipe — or install pre-built recipes if you prefer to skip the authoring step
+* How to compose recipes into a freight-train and complete the migration in waves
+
+## What you'll build
+
+* A wave-organized workspace mirroring your portfolio's upgrade order, which you can reuse as the template for your real migration.
+* A hand-authored OpenRewrite recipe for QueryDSL 4 → 5 that you can commit to your organization's recipe repository.
+* A composite "freight-train" recipe YAML bundling prerequisites and the Spring Boot 4 upgrade — the deliverable you carry out of the workshop.
+
+:::note Freight-train recipe
+
+A composite OpenRewrite recipe that bundles prerequisite upgrades together with the target upgrade so they apply atomically. Composition is what turns one-off recipes into reusable migration infrastructure you can run across an entire portfolio.
+
+:::
 
 ## Prerequisites
 
@@ -25,6 +38,9 @@ To get the most out of this workshop, you should:
 * Have intermediate Java knowledge, including Maven dependency management
 * Be familiar with Spring Boot fundamentals
 * Be comfortable running CLI commands and managing git changes
+* Prior OpenRewrite recipe authoring is helpful but not required
+
+Custom recipes are normally written by engineers with OpenRewrite expertise. In Module 5 you delegate that work to an AI coding agent, using prompting and `mod search` to discover what needs to change. If you prefer not to use an agent, you can install the pre-built QueryDSL recipes from the Moderne training organization — the same recipes you would have built.
 
 You will also need:
 
@@ -37,7 +53,18 @@ You will also need:
 
 * [Module 1: Migration assessment](./module-1-migration-assessment.md) - Run an initial migration and gather code insight data
 * [Module 2: Wave planning](./module-2-wave-planning.md) - Analyze dependencies in the platform and organize upgrade waves
-* [Module 3: Establish a baseline (Optional)](./module-3-establish-baseline.md) - Normalize Maven, Java, and Spring Boot versions across the portfolio
-* [Module 4: Java 17 upgrade and Spring Boot 4 smoke test](./module-4-smoke-test.md) - Raise Java version to 17 and Smoke test the Spring Boot 4 migration
-* [Module 5: Build the QueryDSL recipe](./module-5-build-querydsl-recipe.md) - Diagnose the blocker and build a custom recipe with AI
+* [Module 3: Establish a baseline](./module-3-establish-baseline.md) - Normalize Maven, Java, and Spring Boot versions across the portfolio
+* [Module 4: Java 17 upgrade and Spring Boot 4 smoke test](./module-4-smoke-test.md) - Raise Java version to 17 and smoke test the Spring Boot 4 migration
+* [Module 5: Build the QueryDSL recipe](./module-5-build-querydsl-recipe.md) - Diagnose the blocker and build a custom recipe with an AI agent — or install the pre-built recipes from the Moderne training organization
 * [Module 6: Finish migration in waves](./module-6-wave-migration.md) - Compose a freight-train recipe and complete the migration in waves
+
+Modules 4 and 5 produce the recipes that Module 6 composes into the freight-train YAML you run across the portfolio.
+
+## Companion workshops
+
+The two recipe-authoring activities you encounter in Module 5 — writing OpenRewrite recipes by hand and using AI agents to explore an organization and produce recipes — are each topics in their own right. Both are delivered as separate, regular-cadence workshops:
+
+* [Fundamentals of recipe development](../fundamentals/workshop-overview.md) - Author OpenRewrite recipes yourself: declarative YAML, Refaster templates, and imperative visitors
+* [Teaching AI to write better OpenRewrite recipes](../ai-recipes/workshop-overview.md) - Drive an AI agent through a plan-build-test workflow to scaffold, generate, and validate recipes
+
+Ask your facilitator about the next scheduled session for either workshop.

--- a/docs/hands-on-learning/spring-boot-migration/workshop-overview.md
+++ b/docs/hands-on-learning/spring-boot-migration/workshop-overview.md
@@ -37,7 +37,7 @@ You will also need:
 
 * [Module 1: Migration assessment](./module-1-migration-assessment.md) - Run an initial migration and gather code insight data
 * [Module 2: Wave planning](./module-2-wave-planning.md) - Analyze dependencies in the platform and organize upgrade waves
-* [Module 3: Establish a baseline](./module-3-establish-baseline.md) - Normalize Maven, Java, and Spring Boot versions across the portfolio
-* [Module 4: Raise baseline and smoke test](./module-4-smoke-test.md) - Raise the baseline and validate readiness
+* [Module 3: Establish a baseline (Optional)](./module-3-establish-baseline.md) - Normalize Maven, Java, and Spring Boot versions across the portfolio
+* [Module 4: Java 17 upgrade and Spring Boot 4 smoke test](./module-4-smoke-test.md) - Raise Java version to 17 and Smoke test the Spring Boot 4 migration
 * [Module 5: Build the QueryDSL recipe](./module-5-build-querydsl-recipe.md) - Diagnose the blocker and build a custom recipe with AI
 * [Module 6: Finish migration in waves](./module-6-wave-migration.md) - Compose a freight-train recipe and complete the migration in waves

--- a/docs/hands-on-learning/spring-boot-migration/workshop-overview.md
+++ b/docs/hands-on-learning/spring-boot-migration/workshop-overview.md
@@ -21,9 +21,9 @@ Throughout the workshop, you will see screenshot placeholders and collapsible **
 
 ## What you'll build
 
-* A wave-organized workspace mirroring your portfolio's upgrade order, which you can reuse as the template for your real migration.
-* A hand-authored OpenRewrite recipe for QueryDSL 4 → 5 that you can commit to your organization's recipe repository.
-* A composite "freight-train" recipe YAML bundling prerequisites and the Spring Boot 4 upgrade — the deliverable you carry out of the workshop.
+* A wave-organized workspace mirroring your portfolio's upgrade order, which you can reuse as the template for your real migration
+* A hand-authored OpenRewrite recipe for QueryDSL 4 → 5 that you can commit to your organization's recipe repository
+* A composite "freight-train" recipe YAML bundling prerequisites and the Spring Boot 4 upgrade — the deliverable you carry out of the workshop
 
 :::note Freight-train recipe
 
@@ -55,7 +55,7 @@ You will also need:
 * [Module 2: Wave planning](./module-2-wave-planning.md) - Analyze dependencies in the platform and organize upgrade waves
 * [Module 3: Establish a baseline](./module-3-establish-baseline.md) - Normalize Maven, Java, and Spring Boot versions across the portfolio
 * [Module 4: Java 17 upgrade and Spring Boot 4 smoke test](./module-4-smoke-test.md) - Raise Java version to 17 and smoke test the Spring Boot 4 migration
-* [Module 5: Build the QueryDSL recipe](./module-5-build-querydsl-recipe.md) - Diagnose the blocker and build a custom recipe with an AI agent — or install the pre-built recipes from the Moderne training organization
+* [Module 5: Building the QueryDSL upgrade recipe](./module-5-build-querydsl-recipe.md) - Diagnose the blocker and build a custom recipe with an AI agent — or install the pre-built recipes from the Moderne training organization
 * [Module 6: Finish migration in waves](./module-6-wave-migration.md) - Compose a freight-train recipe and complete the migration in waves
 
 Modules 4 and 5 produce the recipes that Module 6 composes into the freight-train YAML you run across the portfolio.


### PR DESCRIPTION
## Summary

Refine the Spring Boot Migration workshop based on a multi-persona +
technical writer review (junior dev, seasoned Spring Boot dev, senior
architect, technical writer).

### Workshop overview
* Add `What you'll build` section listing the three persistent artifacts (workspace, QueryDSL recipe, freight-train YAML)
* Define `wave`, `baseline`, and `freight-train recipe` (callout) inline at first use
* Reframe Module 5: AI agent is the default; pre-built training-org recipes are the peer alternative
* Add `Companion workshops` section linking the fundamentals and ai-recipes workshops
* Add artifact-chain sentence connecting Modules 4/5 to Module 6
* Add `Prior OpenRewrite recipe authoring is helpful but not required` to prerequisites

### Module 3
* Drop `(Optional)` from sidebar_label (module is required for downstream consistency)
* Convert dash bullets to asterisks per style guide

### Module 4
* Add `text` language hint to Reference output code fence
* Capitalize `Build Wave 0 and Wave 1` step header
* Drop trailing whitespace

### Module 5
* Realign pre-built training-org recipes as a peer alternative, not a fallback
* Replace `:::tip` fallback callout with `:::info Alternative path`
* Update inline references from "fallback" to "alternative path" / "installed the pre-built recipes"

### Module 6
* Capitalize `Wave 0` / `Wave 1` consistently in exercise titles and goal bullets

### Module 1
* Drop trailing whitespace

## Test plan
* [x] `yarn start` — no build errors or warnings on any of the seven workshop pages
* [ ] Visual check on rendered admonitions (`:::note Freight-train recipe`, `:::info Alternative path`)
* [ ] Click-through pass on all internal links
* [ ] Resolve open TODOs in PR comment