### PR TITLE
Link AI recipes and agent tools workshops from hands-on learning index

### DIFF
--- a/docs/hands-on-learning.md
+++ b/docs/hands-on-learning.md
@@ -74,6 +74,38 @@ Plan and execute a Spring Boot 4 migration with confidence. Learn to assess your
 
 [Start workshop →](./hands-on-learning/spring-boot-migration/workshop-overview.md)
 
+### AI-assisted recipe authoring
+
+Use AI as a co-author to build an OpenRewrite migration recipe from scratch. Learn a repeatable workflow for planning, building, and testing recipes with the Moderne CLI's built-in AI skills.
+
+**What you'll learn:**
+
+* The Moderne skills workflow for AI-assisted recipe development (`create-recipe` → `run-recipe` → `create-organization` → iterate)
+* How to guide AI to choose the right recipe type (declarative YAML, imperative Java, Refaster templates)
+* Why test-driven development is a natural fit for AI-generated recipes
+* How to validate AI-generated recipes against real-world repositories
+* Techniques for reviewing, correcting, and improving AI output
+
+**Prerequisites:** Java development experience and basic OpenRewrite concepts. Complete the Fundamentals workshop first if you're new to recipe authoring.
+
+[Start workshop →](./hands-on-learning/ai-recipes/workshop-overview.md)
+
+### Agent tools for AI coding agents
+
+Set up the Moderne agent tools and use Prethink, Trigrep, and the MCP server with your AI coding agent. Build a working setup you can point at your own repositories the same day.
+
+**What you'll learn:**
+
+* How to install and configure the Moderne CLI, the `rewrite-prethink` recipe modules, and LSTs for a working set of repositories
+* How to install agent tools with `mod config agent-tools install` and scope to a specific agent
+* How to run Prethink and inspect the architectural and code quality context it generates
+* How to use Trigrep for fast literal, regex, and structural code search
+* How the Moderne MCP server exposes semantic tools (`find_types`, `find_methods`, `change_type`, `run_recipe`) to your coding agent
+
+**Prerequisites:** Comfort running terminal commands, basic git familiarity, and a working AI coding agent (Claude Code, Cursor, GitHub Copilot, Windsurf, Amp, or Codex).
+
+[Start workshop →](./hands-on-learning/agent-tools/workshop-overview.md)
+
 ## Need help?
 
 If you get stuck or have questions, join the community:


### PR DESCRIPTION
## Summary

The hands-on learning index page was missing entries for two recently added workshops. This adds workshop cards (description, what you'll learn, prerequisites, link) for **AI-assisted recipe authoring** and **Agent tools for AI coding agents**, in the same order as the sidebar.

## Test plan

- [x] `yarn build` passes with no errors or broken links
- [ ] Spot-check rendered page on preview deploy