### PR TITLE
Revert "Add Spring Boot OSS support deadline CTA to migration pages" (#641)

### DIFF
--- a/docs/user-documentation/recipes/popular-recipe-guides/migrate-to-spring-boot-3.md
+++ b/docs/user-documentation/recipes/popular-recipe-guides/migrate-to-spring-boot-3.md
@@ -9,16 +9,6 @@ import RunRecipe from '@site/src/components/RunRecipe';
 
 # Migrate to Spring Boot 3
 
-:::info
-
-**Spring Boot 3.5.x reaches end of OSS support on June 30, 2026.**
-
-Moderne's recipe automates your migration across dozens or hundreds of services. As the company that builds and maintains OpenRewrite, we can help you scope, coordinate, and execute your full portfolio migration so you're never chasing a deadline again.
-
-[**Book a free 30-minute migration scope discussion →**](https://www.moderne.ai/book-a-demo?utm_source=openrewrite_docs&utm_medium=referral&utm_campaign=26_spring_boot_demo)
-
-:::
-
 Spring Boot 3 brought one of the most significant breaking changes in the framework's history: the move from `javax.*` to `jakarta.*`, alongside renamed configuration properties, a rewritten Spring Security configuration model, and a baseline bump to Java 17. Every Spring Boot 2 codebase is touched by these changes.
 
 A manual upgrade typically means hunting through every `javax` import, every renamed property, and every deprecated annotation across dozens of repositories – repetitive work that's easy to leave half-done.

--- a/docs/user-documentation/recipes/popular-recipe-guides/migrate-to-spring-boot-4.md
+++ b/docs/user-documentation/recipes/popular-recipe-guides/migrate-to-spring-boot-4.md
@@ -9,16 +9,6 @@ import RunRecipe from '@site/src/components/RunRecipe';
 
 # Migrate to Spring Boot 4
 
-:::info
-
-**Spring Boot 3.5.x reaches end of OSS support on June 30, 2026.**
-
-Moderne's recipe automates your migration across dozens or hundreds of services. As the company that builds and maintains OpenRewrite, we can help you scope, coordinate, and execute your full portfolio migration so you're never chasing a deadline again.
-
-[**Book a free 30-minute migration scope discussion →**](https://www.moderne.ai/book-a-demo?utm_source=openrewrite_docs&utm_medium=referral&utm_campaign=26_spring_boot_demo)
-
-:::
-
 Spring Boot 4 reorganizes the starter layout into smaller, more focused modules, removes test annotations like `@MockBean` and `@SpyBean` in favor of Spring Framework's bean-override APIs, and pulls in major bumps to Spring Framework 7, Spring Security 7, Spring Cloud 2025.1, Hibernate 7.1, and a long tail of related libraries.
 
 A manual upgrade typically means renaming every starter dependency, hunting down deprecated test annotations, and chasing a cascade of framework-version bumps until everything aligns – the kind of churn that's easy to leave half-finished.

--- a/docs/user-documentation/recipes/recipe-catalog/java/spring/boot3/springboot33bestpractices.md
+++ b/docs/user-documentation/recipes/recipe-catalog/java/spring/boot3/springboot33bestpractices.md
@@ -13,16 +13,6 @@ import RunRecipe from '@site/src/components/RunRecipe';
 
 # Spring Boot 3.3 best practices
 
-:::info
-
-**Spring Boot 3.5.x reaches end of OSS support on June 30, 2026.**
-
-Moderne's recipe automates your migration across dozens or hundreds of services. As the company that builds and maintains OpenRewrite, we can help you scope, coordinate, and execute your full portfolio migration so you're never chasing a deadline again.
-
-[**Book a free 30-minute migration scope discussion →**](https://www.moderne.ai/book-a-demo?utm_source=openrewrite_docs&utm_medium=referral&utm_campaign=26_spring_boot_demo)
-
-:::
-
 **org.openrewrite.java.spring.boot3.SpringBoot33BestPractices**
 
 _Applies best practices to Spring Boot 3 applications._

--- a/docs/user-documentation/recipes/recipe-catalog/java/spring/boot3/upgradespringboot_3_0.md
+++ b/docs/user-documentation/recipes/recipe-catalog/java/spring/boot3/upgradespringboot_3_0.md
@@ -13,16 +13,6 @@ import RunRecipe from '@site/src/components/RunRecipe';
 
 # Migrate to Spring Boot 3.0
 
-:::info
-
-**Spring Boot 3.5.x reaches end of OSS support on June 30, 2026.**
-
-Moderne's recipe automates your migration across dozens or hundreds of services. As the company that builds and maintains OpenRewrite, we can help you scope, coordinate, and execute your full portfolio migration so you're never chasing a deadline again.
-
-[**Book a free 30-minute migration scope discussion →**](https://www.moderne.ai/book-a-demo?utm_source=openrewrite_docs&utm_medium=referral&utm_campaign=26_spring_boot_demo)
-
-:::
-
 **org.openrewrite.java.spring.boot3.UpgradeSpringBoot\_3\_0**
 
 _Migrate applications to the latest Spring Boot 3.0 release. This recipe will modify an application's build files, make changes to deprecated/preferred APIs, and migrate configuration settings that have changes between versions. This recipe will also chain additional framework migrations (Spring Framework, Spring Data, etc) that are required as part of the migration to Spring Boot 2.7._

--- a/docs/user-documentation/recipes/recipe-catalog/java/spring/boot3/upgradespringboot_3_1.md
+++ b/docs/user-documentation/recipes/recipe-catalog/java/spring/boot3/upgradespringboot_3_1.md
@@ -13,16 +13,6 @@ import RunRecipe from '@site/src/components/RunRecipe';
 
 # Migrate to Spring Boot 3.1
 
-:::info
-
-**Spring Boot 3.5.x reaches end of OSS support on June 30, 2026.**
-
-Moderne's recipe automates your migration across dozens or hundreds of services. As the company that builds and maintains OpenRewrite, we can help you scope, coordinate, and execute your full portfolio migration so you're never chasing a deadline again.
-
-[**Book a free 30-minute migration scope discussion →**](https://www.moderne.ai/book-a-demo?utm_source=openrewrite_docs&utm_medium=referral&utm_campaign=26_spring_boot_demo)
-
-:::
-
 **org.openrewrite.java.spring.boot3.UpgradeSpringBoot\_3\_1**
 
 _Migrate applications to the latest Spring Boot 3.1 release. This recipe will modify an application's build files, make changes to deprecated/preferred APIs, and migrate configuration settings that have changes between versions. This recipe will also chain additional framework migrations (Spring Framework, Spring Data, etc) that are required as part of the migration to Spring Boot 3.0._

--- a/docs/user-documentation/recipes/recipe-catalog/java/spring/boot3/upgradespringboot_3_2.md
+++ b/docs/user-documentation/recipes/recipe-catalog/java/spring/boot3/upgradespringboot_3_2.md
@@ -13,16 +13,6 @@ import RunRecipe from '@site/src/components/RunRecipe';
 
 # Migrate to Spring Boot 3.2
 
-:::info
-
-**Spring Boot 3.5.x reaches end of OSS support on June 30, 2026.**
-
-Moderne's recipe automates your migration across dozens or hundreds of services. As the company that builds and maintains OpenRewrite, we can help you scope, coordinate, and execute your full portfolio migration so you're never chasing a deadline again.
-
-[**Book a free 30-minute migration scope discussion →**](https://www.moderne.ai/book-a-demo?utm_source=openrewrite_docs&utm_medium=referral&utm_campaign=26_spring_boot_demo)
-
-:::
-
 **org.openrewrite.java.spring.boot3.UpgradeSpringBoot\_3\_2**
 
 _Migrate applications to the latest Spring Boot 3.2 release. This recipe will modify an application's build files, make changes to deprecated/preferred APIs, and migrate configuration settings that have changes between versions. This recipe will also chain additional framework migrations (Spring Framework, Spring Data, etc) that are required as part of the migration to Spring Boot 3.1._

--- a/docs/user-documentation/recipes/recipe-catalog/java/spring/boot3/upgradespringboot_3_3.md
+++ b/docs/user-documentation/recipes/recipe-catalog/java/spring/boot3/upgradespringboot_3_3.md
@@ -13,16 +13,6 @@ import RunRecipe from '@site/src/components/RunRecipe';
 
 # Migrate to Spring Boot 3.3
 
-:::info
-
-**Spring Boot 3.5.x reaches end of OSS support on June 30, 2026.**
-
-Moderne's recipe automates your migration across dozens or hundreds of services. As the company that builds and maintains OpenRewrite, we can help you scope, coordinate, and execute your full portfolio migration so you're never chasing a deadline again.
-
-[**Book a free 30-minute migration scope discussion →**](https://www.moderne.ai/book-a-demo?utm_source=openrewrite_docs&utm_medium=referral&utm_campaign=26_spring_boot_demo)
-
-:::
-
 **org.openrewrite.java.spring.boot3.UpgradeSpringBoot\_3\_3**
 
 _Migrate applications to the latest Spring Boot 3.3 release. This recipe will modify an application's build files, make changes to deprecated/preferred APIs, and migrate configuration settings that have changes between versions. This recipe will also chain additional framework migrations (Spring Framework, Spring Data, etc) that are required as part of the migration to Spring Boot 3.2._

--- a/docs/user-documentation/recipes/recipe-catalog/java/spring/boot3/upgradespringboot_3_4-community-edition.md
+++ b/docs/user-documentation/recipes/recipe-catalog/java/spring/boot3/upgradespringboot_3_4-community-edition.md
@@ -13,16 +13,6 @@ import RunRecipe from '@site/src/components/RunRecipe';
 
 # Migrate to Spring Boot 3.4 (Community Edition)
 
-:::info
-
-**Spring Boot 3.5.x reaches end of OSS support on June 30, 2026.**
-
-Moderne's recipe automates your migration across dozens or hundreds of services. As the company that builds and maintains OpenRewrite, we can help you scope, coordinate, and execute your full portfolio migration so you're never chasing a deadline again.
-
-[**Book a free 30-minute migration scope discussion →**](https://www.moderne.ai/book-a-demo?utm_source=openrewrite_docs&utm_medium=referral&utm_campaign=26_spring_boot_demo)
-
-:::
-
 **org.openrewrite.java.spring.boot3.UpgradeSpringBoot\_3\_4**
 
 _Migrate applications to the latest Spring Boot 3.4 release. This recipe will modify an application's build files, make changes to deprecated/preferred APIs._

--- a/docs/user-documentation/recipes/recipe-catalog/java/spring/boot3/upgradespringboot_3_4-moderne-edition.md
+++ b/docs/user-documentation/recipes/recipe-catalog/java/spring/boot3/upgradespringboot_3_4-moderne-edition.md
@@ -8,16 +8,6 @@ import RunRecipe from '@site/src/components/RunRecipe';
 
 # Migrate to Spring Boot 3.4 (Moderne Edition)
 
-:::info
-
-**Spring Boot 3.5.x reaches end of OSS support on June 30, 2026.**
-
-Moderne's recipe automates your migration across dozens or hundreds of services. As the company that builds and maintains OpenRewrite, we can help you scope, coordinate, and execute your full portfolio migration so you're never chasing a deadline again.
-
-[**Book a free 30-minute migration scope discussion →**](https://www.moderne.ai/book-a-demo?utm_source=openrewrite_docs&utm_medium=referral&utm_campaign=26_spring_boot_demo)
-
-:::
-
 **io.moderne.java.spring.boot3.UpgradeSpringBoot\_3\_4**
 
 _Migrate applications to the latest Spring Boot 3.4 release. This recipe will modify an application's build files, make changes to deprecated/preferred APIs, and migrate configuration settings that have changes between versions. This recipe will also chain additional framework migrations (Spring Framework, Spring Data, etc) that are required as part of the migration to Spring Boot 3.4._

--- a/docs/user-documentation/recipes/recipe-catalog/java/spring/boot3/upgradespringboot_3_5-community-edition.md
+++ b/docs/user-documentation/recipes/recipe-catalog/java/spring/boot3/upgradespringboot_3_5-community-edition.md
@@ -13,16 +13,6 @@ import RunRecipe from '@site/src/components/RunRecipe';
 
 # Migrate to Spring Boot 3.5 (Community Edition)
 
-:::info
-
-**Spring Boot 3.5.x reaches end of OSS support on June 30, 2026.**
-
-Moderne's recipe automates your migration across dozens or hundreds of services. As the company that builds and maintains OpenRewrite, we can help you scope, coordinate, and execute your full portfolio migration so you're never chasing a deadline again.
-
-[**Book a free 30-minute migration scope discussion →**](https://www.moderne.ai/book-a-demo?utm_source=openrewrite_docs&utm_medium=referral&utm_campaign=26_spring_boot_demo)
-
-:::
-
 **org.openrewrite.java.spring.boot3.UpgradeSpringBoot\_3\_5**
 
 _Migrate applications to the latest Spring Boot 3.5 release. This recipe will modify an application's build files, make changes to deprecated/preferred APIs._

--- a/docs/user-documentation/recipes/recipe-catalog/java/spring/boot3/upgradespringboot_3_5-moderne-edition.md
+++ b/docs/user-documentation/recipes/recipe-catalog/java/spring/boot3/upgradespringboot_3_5-moderne-edition.md
@@ -8,16 +8,6 @@ import RunRecipe from '@site/src/components/RunRecipe';
 
 # Migrate to Spring Boot 3.5 (Moderne Edition)
 
-:::info
-
-**Spring Boot 3.5.x reaches end of OSS support on June 30, 2026.**
-
-Moderne's recipe automates your migration across dozens or hundreds of services. As the company that builds and maintains OpenRewrite, we can help you scope, coordinate, and execute your full portfolio migration so you're never chasing a deadline again.
-
-[**Book a free 30-minute migration scope discussion →**](https://www.moderne.ai/book-a-demo?utm_source=openrewrite_docs&utm_medium=referral&utm_campaign=26_spring_boot_demo)
-
-:::
-
 **io.moderne.java.spring.boot3.UpgradeSpringBoot\_3\_5**
 
 _Migrate applications to the latest Spring Boot 3.5 release. This recipe will modify an application's build files, make changes to deprecated/preferred APIs, and migrate configuration settings that have changes between versions. This recipe will also chain additional framework migrations (Spring Framework, Spring Data, etc) that are required as part of the migration to Spring Boot 3.5._

--- a/docs/user-documentation/recipes/recipe-catalog/java/spring/boot4/springboot4bestpractices.md
+++ b/docs/user-documentation/recipes/recipe-catalog/java/spring/boot4/springboot4bestpractices.md
@@ -8,16 +8,6 @@ import RunRecipe from '@site/src/components/RunRecipe';
 
 # Spring Boot 4.0 best practices
 
-:::info
-
-**Spring Boot 3.5.x reaches end of OSS support on June 30, 2026.**
-
-Moderne's recipe automates your migration across dozens or hundreds of services. As the company that builds and maintains OpenRewrite, we can help you scope, coordinate, and execute your full portfolio migration so you're never chasing a deadline again.
-
-[**Book a free 30-minute migration scope discussion →**](https://www.moderne.ai/book-a-demo?utm_source=openrewrite_docs&utm_medium=referral&utm_campaign=26_spring_boot_demo)
-
-:::
-
 **io.moderne.java.spring.boot4.SpringBoot4BestPractices**
 
 _Applies best practices to Spring Boot 4.+ applications._

--- a/docs/user-documentation/recipes/recipe-catalog/java/spring/boot4/upgradespringboot_4_0-community-edition.md
+++ b/docs/user-documentation/recipes/recipe-catalog/java/spring/boot4/upgradespringboot_4_0-community-edition.md
@@ -13,16 +13,6 @@ import RunRecipe from '@site/src/components/RunRecipe';
 
 # Migrate to Spring Boot 4.0 (Community Edition)
 
-:::info
-
-**Spring Boot 3.5.x reaches end of OSS support on June 30, 2026.**
-
-Moderne's recipe automates your migration across dozens or hundreds of services. As the company that builds and maintains OpenRewrite, we can help you scope, coordinate, and execute your full portfolio migration so you're never chasing a deadline again.
-
-[**Book a free 30-minute migration scope discussion →**](https://www.moderne.ai/book-a-demo?utm_source=openrewrite_docs&utm_medium=referral&utm_campaign=26_spring_boot_demo)
-
-:::
-
 **org.openrewrite.java.spring.boot4.UpgradeSpringBoot\_4\_0**
 
 _Migrate applications to the latest Spring Boot 4.0 release. This recipe will modify an application's build files, make changes to deprecated/preferred APIs._

--- a/docs/user-documentation/recipes/recipe-catalog/java/spring/boot4/upgradespringboot_4_0-moderne-edition.md
+++ b/docs/user-documentation/recipes/recipe-catalog/java/spring/boot4/upgradespringboot_4_0-moderne-edition.md
@@ -8,16 +8,6 @@ import RunRecipe from '@site/src/components/RunRecipe';
 
 # Migrate to Spring Boot 4.0 (Moderne Edition)
 
-:::info
-
-**Spring Boot 3.5.x reaches end of OSS support on June 30, 2026.**
-
-Moderne's recipe automates your migration across dozens or hundreds of services. As the company that builds and maintains OpenRewrite, we can help you scope, coordinate, and execute your full portfolio migration so you're never chasing a deadline again.
-
-[**Book a free 30-minute migration scope discussion →**](https://www.moderne.ai/book-a-demo?utm_source=openrewrite_docs&utm_medium=referral&utm_campaign=26_spring_boot_demo)
-
-:::
-
 **io.moderne.java.spring.boot4.UpgradeSpringBoot\_4\_0**
 
 _Migrate applications to the latest Spring Boot 4.0 release. This recipe will modify an application's build files, make changes to deprecated/preferred APIs, and migrate configuration settings that have changes between versions. This recipe will also chain additional framework migrations (Spring Framework, Spring Data, etc) that are required as part of the migration to Spring Boot 4.0._


### PR DESCRIPTION
## Summary

- Reverts #641 — the Spring Boot OSS support deadline CTA was added across 14 migration pages and is being rolled back.

## Test plan

- [ ] CI build passes