### PR TITLE
Hide Trigrep and MCP modules from agent-tools workshop

### DIFF
--- a/docs/hands-on-learning/agent-tools/module-2-install-agent-tools.md
+++ b/docs/hands-on-learning/agent-tools/module-2-install-agent-tools.md
@@ -110,7 +110,7 @@ If you want the procedural guidance but not the live MCP server (for example, on
 mod config agent-tools skills install
 ```
 
-This installs skills for every detected agent but leaves the MCP server unconfigured. You can pair this with [Module 4](./module-4-trigrep.md) (Trigrep) to get fast search via the CLI without needing the MCP server.
+This installs skills for every detected agent but leaves the MCP server unconfigured.
 
 ### Takeaways
 

--- a/docs/hands-on-learning/agent-tools/module-2-install-agent-tools.md
+++ b/docs/hands-on-learning/agent-tools/module-2-install-agent-tools.md
@@ -111,6 +111,7 @@ mod config agent-tools skills install
 ```
 
 This installs skills for every detected agent but leaves the MCP server unconfigured.
+{/* Hidden until ready for consumption: You can pair this with [Module 4](./module-4-trigrep.md) (Trigrep) to get fast search via the CLI without needing the MCP server. */}
 
 ### Takeaways
 

--- a/docs/hands-on-learning/agent-tools/module-3-prethink.md
+++ b/docs/hands-on-learning/agent-tools/module-3-prethink.md
@@ -300,6 +300,3 @@ The Moderne Platform has built-in [Prethink code quality visualizations](../../u
 * Asking the agent to visualize first, then plan, helps it ground its reasoning in the data rather than its priors.
 * Once the agent writes any code, you can re-run Prethink to see whether the metrics actually improved. See [Incremental Prethink via MCP](../../user-documentation/agent-tools/prethink.md#incremental-prethink-via-mcp) for the feedback loop.
 
-## Next up
-
-In [Module 4](./module-4-trigrep.md), you'll build a trigram search index across the same workspace and explore what makes Trigrep faster and more structurally aware than `grep`.

--- a/docs/hands-on-learning/agent-tools/module-3-prethink.md
+++ b/docs/hands-on-learning/agent-tools/module-3-prethink.md
@@ -300,3 +300,7 @@ The Moderne Platform has built-in [Prethink code quality visualizations](../../u
 * Asking the agent to visualize first, then plan, helps it ground its reasoning in the data rather than its priors.
 * Once the agent writes any code, you can re-run Prethink to see whether the metrics actually improved. See [Incremental Prethink via MCP](../../user-documentation/agent-tools/prethink.md#incremental-prethink-via-mcp) for the feedback loop.
 
+{/* Hidden until ready for consumption: */}
+{/* ## Next up */}
+{/* In [Module 4](./module-4-trigrep.md), you'll build a trigram search index across the same workspace and explore what makes Trigrep faster and more structurally aware than `grep`. */}
+

--- a/docs/hands-on-learning/agent-tools/workshop-overview.md
+++ b/docs/hands-on-learning/agent-tools/workshop-overview.md
@@ -62,5 +62,3 @@ Examples in this workshop demo with Claude Code (slash commands like `/moderne:c
 * [Module 1: CLI and LSTs](./module-1-cli-and-lsts.md) - Install the Moderne CLI, install the Prethink recipe modules, sync repositories, and build LSTs
 * [Module 2: Install agent tools](./module-2-install-agent-tools.md) - Install skills and the MCP server with `mod config agent-tools install`, and verify what each agent now exposes
 * [Module 3: Prethink](./module-3-prethink.md) - Run Prethink, apply the changes, inspect the generated context, and ask your agent to visualize the code quality metrics
-* [Module 4: Trigrep](./module-4-trigrep.md) - Build a search index with `mod postbuild search index` and explore literal, regex, and structural queries
-* [Module 5: MCP server](./module-5-mcp.md) - Explore how the Moderne MCP server exposes semantic search, navigation, and refactoring tools to your agent

--- a/docs/hands-on-learning/agent-tools/workshop-overview.md
+++ b/docs/hands-on-learning/agent-tools/workshop-overview.md
@@ -62,3 +62,6 @@ Examples in this workshop demo with Claude Code (slash commands like `/moderne:c
 * [Module 1: CLI and LSTs](./module-1-cli-and-lsts.md) - Install the Moderne CLI, install the Prethink recipe modules, sync repositories, and build LSTs
 * [Module 2: Install agent tools](./module-2-install-agent-tools.md) - Install skills and the MCP server with `mod config agent-tools install`, and verify what each agent now exposes
 * [Module 3: Prethink](./module-3-prethink.md) - Run Prethink, apply the changes, inspect the generated context, and ask your agent to visualize the code quality metrics
+{/* Hidden until ready for consumption: */}
+{/* * [Module 4: Trigrep](./module-4-trigrep.md) - Build a search index with `mod postbuild search index` and explore literal, regex, and structural queries */}
+{/* * [Module 5: MCP server](./module-5-mcp.md) - Explore how the Moderne MCP server exposes semantic search, navigation, and refactoring tools to your agent */}

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -697,8 +697,6 @@ const handsOnLearning = {
         'hands-on-learning/agent-tools/module-1-cli-and-lsts',
         'hands-on-learning/agent-tools/module-2-install-agent-tools',
         'hands-on-learning/agent-tools/module-3-prethink',
-        'hands-on-learning/agent-tools/module-4-trigrep',
-        'hands-on-learning/agent-tools/module-5-mcp',
       ],
     },
     {

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -697,6 +697,9 @@ const handsOnLearning = {
         'hands-on-learning/agent-tools/module-1-cli-and-lsts',
         'hands-on-learning/agent-tools/module-2-install-agent-tools',
         'hands-on-learning/agent-tools/module-3-prethink',
+        // Hidden until ready for consumption:
+        // 'hands-on-learning/agent-tools/module-4-trigrep',
+        // 'hands-on-learning/agent-tools/module-5-mcp',
       ],
     },
     {


### PR DESCRIPTION
## Summary

Modules 4 (Trigrep) and 5 (MCP server) of the new agent-tools hands-on workshop aren't ready for consumption yet, so this hides them: removes the entries from the sidebar and the workshop overview's module list, and drops the forward-references in modules 2 and 3 so the workshop ends cleanly at Module 3. The module source files are left in place so re-enabling is a one-line revert.

## Test plan

- [x] yarn build succeeds with no new warnings
- [ ] Verify the agent-tools workshop sidebar only shows modules 1-3