### PR TITLE
Stream build logs in CI by line-buffering grep

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Build website
         run: |
           set -o pipefail
-          yarn build 2>&1 | { grep -v "^Generated markdown file:" || true; }
+          yarn build 2>&1 | { grep --line-buffered -v "^Generated markdown file:" || true; }
         env:
           NODE_OPTIONS: --max-old-space-size=8192
           DOCUSAURUS_IGNORE_SSG_WARNINGS: true

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Build site
         run: |
           set -o pipefail
-          yarn build 2>&1 | { grep -v "^Generated markdown file:" || true; }
+          yarn build 2>&1 | { grep --line-buffered -v "^Generated markdown file:" || true; }
         env:
           SKIP_RECIPE_CATALOG: "1"
           CI_STRICT_LINKS: "1"


### PR DESCRIPTION
## Summary
* Add `--line-buffered` to the grep filter in `pages.yml` and `pr-validation.yml` so build output streams live instead of being block-buffered.
* GNU grep buffers stdout when piped to a non-terminal, which hides all `yarn build` output for ~6+ minutes during successful runs and makes recent exit-143 Pages deploy failures impossible to diagnose — the failures happen inside that silent window.
* No change to which lines are filtered; only when they're emitted. Same `Generated markdown file:` lines from `docusaurus-plugin-llms` are suppressed.

## Test plan
* [ ] Trigger PR validation on this PR and confirm `Build site` logs appear within the first ~30s rather than only at the end.
* [ ] After merge, watch the next `Deploy Moderne docs to Pages` run and confirm the long silent gap is gone.
* [ ] If a future deploy fails again with exit 143, the log should now show which build phase was active at SIGTERM time.