### PR TITLE
Hide agent tools workshop until ready to share

### DIFF
--- a/docs/hands-on-learning.md
+++ b/docs/hands-on-learning.md
@@ -90,6 +90,7 @@ Use AI as a co-author to build an OpenRewrite migration recipe from scratch. Lea
 
 [Start workshop →](./hands-on-learning/ai-recipes/workshop-overview.md)
 
+{/* Hidden until ready to share publicly:
 ### Agent tools for AI coding agents
 
 Set up the Moderne agent tools and use Prethink, Trigrep, and the MCP server with your AI coding agent. Build a working setup you can point at your own repositories the same day.
@@ -105,6 +106,7 @@ Set up the Moderne agent tools and use Prethink, Trigrep, and the MCP server wit
 **Prerequisites:** Comfort running terminal commands, basic git familiarity, and a working AI coding agent (Claude Code, Cursor, GitHub Copilot, Windsurf, Amp, or Codex).
 
 [Start workshop →](./hands-on-learning/agent-tools/workshop-overview.md)
+*/}
 
 ## Need help?
 

--- a/docs/hands-on-learning/agent-tools/module-1-cli-and-lsts.md
+++ b/docs/hands-on-learning/agent-tools/module-1-cli-and-lsts.md
@@ -1,6 +1,7 @@
 ---
 sidebar_label: "Module 1: CLI and LSTs"
 description: Install the Moderne CLI, install the Prethink recipe modules, and build LSTs for a working set of Java and Spring projects.
+draft: true
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/hands-on-learning/agent-tools/module-2-install-agent-tools.md
+++ b/docs/hands-on-learning/agent-tools/module-2-install-agent-tools.md
@@ -1,6 +1,7 @@
 ---
 sidebar_label: "Module 2: Install agent tools"
 description: Install Moderne skills and the MCP server with mod config agent-tools install, scope to specific agents, and verify what your AI agent now exposes.
+draft: true
 ---
 
 # Module 2: Install agent tools

--- a/docs/hands-on-learning/agent-tools/module-3-prethink.md
+++ b/docs/hands-on-learning/agent-tools/module-3-prethink.md
@@ -1,6 +1,7 @@
 ---
 sidebar_label: "Module 3: Prethink"
 description: Run Prethink on a working set, apply the changes, and ask your agent to visualize the generated code quality metrics.
+draft: true
 ---
 
 # Module 3: Prethink

--- a/docs/hands-on-learning/agent-tools/module-4-trigrep.md
+++ b/docs/hands-on-learning/agent-tools/module-4-trigrep.md
@@ -1,6 +1,7 @@
 ---
 sidebar_label: "Module 4: Trigrep"
 description: Build a trigram search index with mod postbuild search index, then explore literal, regex, and structural queries across your workspace.
+draft: true
 ---
 
 # Module 4: Trigrep

--- a/docs/hands-on-learning/agent-tools/module-5-mcp.md
+++ b/docs/hands-on-learning/agent-tools/module-5-mcp.md
@@ -1,6 +1,7 @@
 ---
 sidebar_label: "Module 5: MCP server"
 description: Explore the Moderne MCP server and the semantic search, navigation, and refactoring tools it exposes to your AI coding agent.
+draft: true
 ---
 
 # Module 5: MCP server

--- a/docs/hands-on-learning/agent-tools/workshop-overview.md
+++ b/docs/hands-on-learning/agent-tools/workshop-overview.md
@@ -1,6 +1,7 @@
 ---
 sidebar_label: Workshop overview
 description: Set up the Moderne agent tools and use Prethink, Trigrep, and the MCP server with your AI coding agent.
+draft: true
 ---
 
 # Overview: Agent tools for AI coding agents

--- a/docs/user-documentation/agent-tools/mcp/overview.md
+++ b/docs/user-documentation/agent-tools/mcp/overview.md
@@ -99,7 +99,7 @@ For the best experience, install both. Skills teach agents the recipe developmen
 
 ## Next steps
 
-* [Try the hands-on agent tools workshop](../../../hands-on-learning/agent-tools/workshop-overview.md) to set up the MCP server and exercise its tools on a sample workspace
+{/* Hidden until ready to share publicly: * [Try the hands-on agent tools workshop](../../../hands-on-learning/agent-tools/workshop-overview.md) to set up the MCP server and exercise its tools on a sample workspace */}
 * [Install the MCP server](./getting-started.md) for your AI coding agent
 * [Set up the tool browser](./tool-browser.md) to monitor builds and test tools
 * [Review the security architecture](./security.md) for compliance and IT review

--- a/docs/user-documentation/agent-tools/prethink.md
+++ b/docs/user-documentation/agent-tools/prethink.md
@@ -698,7 +698,7 @@ This creates a feedback loop: the agent writes code, regenerates Prethink contex
 
 ## Next steps
 
-* [Try the hands-on agent tools workshop](../../hands-on-learning/agent-tools/workshop-overview.md) to run Prethink end-to-end on a sample workspace
+{/* Hidden until ready to share publicly: * [Try the hands-on agent tools workshop](../../hands-on-learning/agent-tools/workshop-overview.md) to run Prethink end-to-end on a sample workspace */}
 * [Run Prethink recipes on the Moderne Platform](../moderne-platform/getting-started/prethink.md)
 * [Generate Prethink context with the CLI](../moderne-cli/how-to-guides/cli-prethink.md)
 * [Explore Prethink code quality visualizations](../moderne-platform/getting-started/visualizations.md#prethink-code-quality-visualizations) for dashboards including executive summaries, coupling/cohesion matrices, and method risk radar charts

--- a/docs/user-documentation/agent-tools/skills.md
+++ b/docs/user-documentation/agent-tools/skills.md
@@ -201,6 +201,6 @@ This ensures the agent tools stay current as CLI capabilities evolve.
 
 ## Next steps
 
-* [Try the hands-on agent tools workshop](../../hands-on-learning/agent-tools/workshop-overview.md) to install skills and exercise them end-to-end
+{/* Hidden until ready to share publicly: * [Try the hands-on agent tools workshop](../../hands-on-learning/agent-tools/workshop-overview.md) to install skills and exercise them end-to-end */}
 * [Set up the Moderne MCP server](./mcp/overview.md) to give agents tools for semantic code search, navigation, and refactoring
 * [Learn about Moderne Prethink](./prethink.md) for giving agents pre-resolved codebase context

--- a/docs/user-documentation/agent-tools/trigrep.md
+++ b/docs/user-documentation/agent-tools/trigrep.md
@@ -420,7 +420,7 @@ Since Moderne Trigrep supports both Sourcegraph and Zoekt query syntax as well a
 
 ## Next steps
 
-* [Try the hands-on agent tools workshop](../../hands-on-learning/agent-tools/workshop-overview.md) to practice Trigrep queries on a sample workspace.
+{/* Hidden until ready to share publicly: * [Try the hands-on agent tools workshop](../../hands-on-learning/agent-tools/workshop-overview.md) to practice Trigrep queries on a sample workspace. */}
 * [Moderne CLI reference](../moderne-cli/cli-reference.md) for the full `mod search` command documentation.
 * [Type-aware code search](../moderne-platform/how-to-guides/introduction-to-type-aware-code-search.md) for the web-based search experience on the Moderne Platform.
 * [Recipe authoring fundamentals](../../hands-on-learning/fundamentals/workshop-overview.md) to learn how to build recipes for searches that require full type resolution.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -682,25 +682,26 @@ const handsOnLearning = {
         'hands-on-learning/ai-recipes/module-3-test',
       ],
     },
-    {
-      type: 'category' as const,
-      label: 'Agent tools for AI coding agents',
-      link: {
-        type: 'generated-index' as const,
-        title: 'Agent tools for AI coding agents',
-        description: 'Set up the Moderne agent tools and use Prethink, Trigrep, and the MCP server with your AI coding agent.',
-        slug: '/hands-on-learning/agent-tools',
-        keywords: ['ai', 'agent-tools', 'skills', 'mcp', 'prethink', 'trigrep'],
-      },
-      items: [
-        'hands-on-learning/agent-tools/workshop-overview',
-        'hands-on-learning/agent-tools/module-1-cli-and-lsts',
-        'hands-on-learning/agent-tools/module-2-install-agent-tools',
-        'hands-on-learning/agent-tools/module-3-prethink',
-        'hands-on-learning/agent-tools/module-4-trigrep',
-        'hands-on-learning/agent-tools/module-5-mcp',
-      ],
-    },
+    // Hidden until ready to share publicly:
+    // {
+    //   type: 'category' as const,
+    //   label: 'Agent tools for AI coding agents',
+    //   link: {
+    //     type: 'generated-index' as const,
+    //     title: 'Agent tools for AI coding agents',
+    //     description: 'Set up the Moderne agent tools and use Prethink, Trigrep, and the MCP server with your AI coding agent.',
+    //     slug: '/hands-on-learning/agent-tools',
+    //     keywords: ['ai', 'agent-tools', 'skills', 'mcp', 'prethink', 'trigrep'],
+    //   },
+    //   items: [
+    //     'hands-on-learning/agent-tools/workshop-overview',
+    //     'hands-on-learning/agent-tools/module-1-cli-and-lsts',
+    //     'hands-on-learning/agent-tools/module-2-install-agent-tools',
+    //     'hands-on-learning/agent-tools/module-3-prethink',
+    //     'hands-on-learning/agent-tools/module-4-trigrep',
+    //     'hands-on-learning/agent-tools/module-5-mcp',
+    //   ],
+    // },
     {
       type: 'link' as const,
       label: 'Live OpenRewrite training',


### PR DESCRIPTION
## Summary

* Comment out the "Agent tools for AI coding agents" sidebar category in `sidebars.ts`, the section on the hands-on learning hub page, and the workshop links in the Next steps lists of `skills.md`, `prethink.md`, `trigrep.md`, and `mcp/overview.md`.
* Mark all six workshop content files under `docs/hands-on-learning/agent-tools/` as `draft: true` so they are excluded from production builds but preserved in source for later release.
* Each commented block is prefixed with "Hidden until ready to share publicly:" so it's easy to find and restore.

## Test plan

- [ ] Confirm the agent tools workshop no longer appears in the sidebar or on `/hands-on-learning` in a production build
- [ ] Confirm no broken-link warnings introduced