### PR TITLE
Fix Pages SIGTERM 143 by disabling Docusaurus SSG worker threads

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -43,33 +43,8 @@ jobs:
 
       - name: Build website
         run: |
-          set +e
           set -o pipefail
-          start=$(date +%s)
           yarn build 2>&1 | { grep --line-buffered -v "^Generated markdown file:" || true; }
-          BUILD_RC=${PIPESTATUS[0]}
-          elapsed=$(( $(date +%s) - start ))
-
-          cgroup_path=$(awk -F: '$1 == "0" {print $3}' /proc/self/cgroup 2>/dev/null || true)
-          peak_file="/sys/fs/cgroup${cgroup_path}/memory.peak"
-          [[ -r "$peak_file" ]] || peak_file=/sys/fs/cgroup/memory.peak
-
-          {
-            echo '## Build memory profile'
-            echo ""
-            printf 'Elapsed: **%dm %02ds**\n\n' $((elapsed/60)) $((elapsed%60))
-            if [[ -r "$peak_file" ]]; then
-              peak_bytes=$(cat "$peak_file")
-              peak_mb=$((peak_bytes / 1024 / 1024))
-              echo "Peak cgroup memory: **${peak_mb} MB** (${peak_bytes} bytes)"
-              echo ""
-              echo "Source: \`$peak_file\`"
-            else
-              echo '(cgroup memory.peak not available)'
-            fi
-          } >> "$GITHUB_STEP_SUMMARY"
-
-          exit "$BUILD_RC"
         env:
           DOCUSAURUS_IGNORE_SSG_WARNINGS: true
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -45,15 +45,30 @@ jobs:
         run: |
           set +e
           set -o pipefail
-          /usr/bin/time -v -o /tmp/build-time.txt yarn build 2>&1 \
-            | { grep --line-buffered -v "^Generated markdown file:" || true; }
+          start=$(date +%s)
+          yarn build 2>&1 | { grep --line-buffered -v "^Generated markdown file:" || true; }
           BUILD_RC=${PIPESTATUS[0]}
+          elapsed=$(( $(date +%s) - start ))
+
+          cgroup_path=$(awk -F: '$1 == "0" {print $3}' /proc/self/cgroup 2>/dev/null || true)
+          peak_file="/sys/fs/cgroup${cgroup_path}/memory.peak"
+          [[ -r "$peak_file" ]] || peak_file=/sys/fs/cgroup/memory.peak
+
           {
-            echo '## Build wall stats (`/usr/bin/time -v`)'
-            echo '```'
-            cat /tmp/build-time.txt 2>/dev/null || echo '(time output not captured)'
-            echo '```'
+            echo '## Build memory profile'
+            echo ""
+            printf 'Elapsed: **%dm %02ds**\n\n' $((elapsed/60)) $((elapsed%60))
+            if [[ -r "$peak_file" ]]; then
+              peak_bytes=$(cat "$peak_file")
+              peak_mb=$((peak_bytes / 1024 / 1024))
+              echo "Peak cgroup memory: **${peak_mb} MB** (${peak_bytes} bytes)"
+              echo ""
+              echo "Source: \`$peak_file\`"
+            else
+              echo '(cgroup memory.peak not available)'
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
+
           exit "$BUILD_RC"
         env:
           DOCUSAURUS_IGNORE_SSG_WARNINGS: true

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,10 +22,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - name: Collect workflow telemetry
-        uses: catchpoint/workflow-telemetry-action@v2
-        with:
-          comment_on_pr: false
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
@@ -48,7 +44,61 @@ jobs:
       - name: Build website
         run: |
           set -o pipefail
-          yarn build 2>&1 | { grep --line-buffered -v "^Generated markdown file:" || true; }
+
+          # Background sampler: ts,pid,ppid,rss_kb,vsz_kb,comm — every 2s
+          {
+            while :; do
+              ts=$(date +%s)
+              ps -eo pid=,ppid=,rss=,vsz=,comm= 2>/dev/null \
+                | awk -v ts="$ts" '$5 ~ /^(node|yarn)$/ {print ts","$1","$2","$3","$4","$5}'
+              sleep 2
+            done
+          } > /tmp/proc-samples.csv 2>/dev/null &
+          SAMPLER_PID=$!
+
+          set +e
+          /usr/bin/time -v -o /tmp/build-time.txt \
+            bash -c 'yarn build 2>&1' \
+            | { grep --line-buffered -v "^Generated markdown file:" || true; }
+          BUILD_RC=${PIPESTATUS[0]}
+          set -e
+
+          kill "$SAMPLER_PID" 2>/dev/null || true
+          wait "$SAMPLER_PID" 2>/dev/null || true
+
+          {
+            echo "## Build memory profile"
+            echo ""
+            echo "### Wall stats (\`/usr/bin/time -v\`)"
+            echo '```'
+            grep -E "Elapsed|User time|System time|Maximum resident|page faults|Percent of CPU" /tmp/build-time.txt || true
+            echo '```'
+            echo ""
+            echo "### Peak RSS per node/yarn process (top 20)"
+            echo "| PID | PPID | Peak RSS (MB) | Command |"
+            echo "|---:|---:|---:|:---|"
+            awk -F, '
+              { if (($4+0) > peak[$2]+0) { peak[$2]=$4; ppid[$2]=$3; comm[$2]=$6 } }
+              END {
+                for (p in peak) printf "%s\t%s\t%.0f\t%s\n", p, ppid[p], peak[p]/1024, comm[p]
+              }
+            ' /tmp/proc-samples.csv \
+              | sort -t$'\t' -k3 -rn \
+              | head -20 \
+              | awk -F$'\t' '{printf "| %s | %s | %s | `%s` |\n", $1, $2, $3, $4}'
+            echo ""
+            echo "### Concurrency"
+            awk -F, '
+              { count[$1]++ }
+              END {
+                max=0
+                for (t in count) if (count[t]>max) max=count[t]
+                printf "Max concurrent node/yarn processes (2s sample): **%d**\n", max
+              }
+            ' /tmp/proc-samples.csv
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          exit "$BUILD_RC"
         env:
           DOCUSAURUS_IGNORE_SSG_WARNINGS: true
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,6 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - name: Collect workflow telemetry
+        uses: catchpoint/workflow-telemetry-action@v2
+        with:
+          comment_on_pr: false
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -46,7 +46,6 @@ jobs:
           set -o pipefail
           yarn build 2>&1 | { grep --line-buffered -v "^Generated markdown file:" || true; }
         env:
-          NODE_OPTIONS: --max-old-space-size=8192
           DOCUSAURUS_IGNORE_SSG_WARNINGS: true
 
       - name: Upload Build Artifact

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -43,61 +43,17 @@ jobs:
 
       - name: Build website
         run: |
-          set -o pipefail
-
-          # Background sampler: ts,pid,ppid,rss_kb,vsz_kb,comm — every 2s
-          {
-            while :; do
-              ts=$(date +%s)
-              ps -eo pid=,ppid=,rss=,vsz=,comm= 2>/dev/null \
-                | awk -v ts="$ts" '$5 ~ /^(node|yarn)$/ {print ts","$1","$2","$3","$4","$5}'
-              sleep 2
-            done
-          } > /tmp/proc-samples.csv 2>/dev/null &
-          SAMPLER_PID=$!
-
           set +e
-          /usr/bin/time -v -o /tmp/build-time.txt \
-            bash -c 'yarn build 2>&1' \
+          set -o pipefail
+          /usr/bin/time -v -o /tmp/build-time.txt yarn build 2>&1 \
             | { grep --line-buffered -v "^Generated markdown file:" || true; }
           BUILD_RC=${PIPESTATUS[0]}
-          set -e
-
-          kill "$SAMPLER_PID" 2>/dev/null || true
-          wait "$SAMPLER_PID" 2>/dev/null || true
-
           {
-            echo "## Build memory profile"
-            echo ""
-            echo "### Wall stats (\`/usr/bin/time -v\`)"
+            echo '## Build wall stats (`/usr/bin/time -v`)'
             echo '```'
-            grep -E "Elapsed|User time|System time|Maximum resident|page faults|Percent of CPU" /tmp/build-time.txt || true
+            cat /tmp/build-time.txt 2>/dev/null || echo '(time output not captured)'
             echo '```'
-            echo ""
-            echo "### Peak RSS per node/yarn process (top 20)"
-            echo "| PID | PPID | Peak RSS (MB) | Command |"
-            echo "|---:|---:|---:|:---|"
-            awk -F, '
-              { if (($4+0) > peak[$2]+0) { peak[$2]=$4; ppid[$2]=$3; comm[$2]=$6 } }
-              END {
-                for (p in peak) printf "%s\t%s\t%.0f\t%s\n", p, ppid[p], peak[p]/1024, comm[p]
-              }
-            ' /tmp/proc-samples.csv \
-              | sort -t$'\t' -k3 -rn \
-              | head -20 \
-              | awk -F$'\t' '{printf "| %s | %s | %s | `%s` |\n", $1, $2, $3, $4}'
-            echo ""
-            echo "### Concurrency"
-            awk -F, '
-              { count[$1]++ }
-              END {
-                max=0
-                for (t in count) if (count[t]>max) max=count[t]
-                printf "Max concurrent node/yarn processes (2s sample): **%d**\n", max
-              }
-            ' /tmp/proc-samples.csv
           } >> "$GITHUB_STEP_SUMMARY"
-
           exit "$BUILD_RC"
         env:
           DOCUSAURUS_IGNORE_SSG_WARNINGS: true

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -40,10 +40,6 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - name: Collect workflow telemetry
-        uses: catchpoint/workflow-telemetry-action@v2
-        with:
-          comment_on_pr: false
       - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v6
@@ -57,7 +53,61 @@ jobs:
       - name: Build site
         run: |
           set -o pipefail
-          yarn build 2>&1 | { grep --line-buffered -v "^Generated markdown file:" || true; }
+
+          # Background sampler: ts,pid,ppid,rss_kb,vsz_kb,comm — every 2s
+          {
+            while :; do
+              ts=$(date +%s)
+              ps -eo pid=,ppid=,rss=,vsz=,comm= 2>/dev/null \
+                | awk -v ts="$ts" '$5 ~ /^(node|yarn)$/ {print ts","$1","$2","$3","$4","$5}'
+              sleep 2
+            done
+          } > /tmp/proc-samples.csv 2>/dev/null &
+          SAMPLER_PID=$!
+
+          set +e
+          /usr/bin/time -v -o /tmp/build-time.txt \
+            bash -c 'yarn build 2>&1' \
+            | { grep --line-buffered -v "^Generated markdown file:" || true; }
+          BUILD_RC=${PIPESTATUS[0]}
+          set -e
+
+          kill "$SAMPLER_PID" 2>/dev/null || true
+          wait "$SAMPLER_PID" 2>/dev/null || true
+
+          {
+            echo "## Build memory profile"
+            echo ""
+            echo "### Wall stats (\`/usr/bin/time -v\`)"
+            echo '```'
+            grep -E "Elapsed|User time|System time|Maximum resident|page faults|Percent of CPU" /tmp/build-time.txt || true
+            echo '```'
+            echo ""
+            echo "### Peak RSS per node/yarn process (top 20)"
+            echo "| PID | PPID | Peak RSS (MB) | Command |"
+            echo "|---:|---:|---:|:---|"
+            awk -F, '
+              { if (($4+0) > peak[$2]+0) { peak[$2]=$4; ppid[$2]=$3; comm[$2]=$6 } }
+              END {
+                for (p in peak) printf "%s\t%s\t%.0f\t%s\n", p, ppid[p], peak[p]/1024, comm[p]
+              }
+            ' /tmp/proc-samples.csv \
+              | sort -t$'\t' -k3 -rn \
+              | head -20 \
+              | awk -F$'\t' '{printf "| %s | %s | %s | `%s` |\n", $1, $2, $3, $4}'
+            echo ""
+            echo "### Concurrency"
+            awk -F, '
+              { count[$1]++ }
+              END {
+                max=0
+                for (t in count) if (count[t]>max) max=count[t]
+                printf "Max concurrent node/yarn processes (2s sample): **%d**\n", max
+              }
+            ' /tmp/proc-samples.csv
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          exit "$BUILD_RC"
         env:
           CI_STRICT_LINKS: "1"
           DOCUSAURUS_IGNORE_SSG_WARNINGS: true

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -40,6 +40,10 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
+      - name: Collect workflow telemetry
+        uses: catchpoint/workflow-telemetry-action@v2
+        with:
+          comment_on_pr: false
       - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v6

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -55,6 +55,5 @@ jobs:
           set -o pipefail
           yarn build 2>&1 | { grep --line-buffered -v "^Generated markdown file:" || true; }
         env:
-          SKIP_RECIPE_CATALOG: "1"
           CI_STRICT_LINKS: "1"
           DOCUSAURUS_IGNORE_SSG_WARNINGS: true

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -52,61 +52,17 @@ jobs:
 
       - name: Build site
         run: |
-          set -o pipefail
-
-          # Background sampler: ts,pid,ppid,rss_kb,vsz_kb,comm — every 2s
-          {
-            while :; do
-              ts=$(date +%s)
-              ps -eo pid=,ppid=,rss=,vsz=,comm= 2>/dev/null \
-                | awk -v ts="$ts" '$5 ~ /^(node|yarn)$/ {print ts","$1","$2","$3","$4","$5}'
-              sleep 2
-            done
-          } > /tmp/proc-samples.csv 2>/dev/null &
-          SAMPLER_PID=$!
-
           set +e
-          /usr/bin/time -v -o /tmp/build-time.txt \
-            bash -c 'yarn build 2>&1' \
+          set -o pipefail
+          /usr/bin/time -v -o /tmp/build-time.txt yarn build 2>&1 \
             | { grep --line-buffered -v "^Generated markdown file:" || true; }
           BUILD_RC=${PIPESTATUS[0]}
-          set -e
-
-          kill "$SAMPLER_PID" 2>/dev/null || true
-          wait "$SAMPLER_PID" 2>/dev/null || true
-
           {
-            echo "## Build memory profile"
-            echo ""
-            echo "### Wall stats (\`/usr/bin/time -v\`)"
+            echo '## Build wall stats (`/usr/bin/time -v`)'
             echo '```'
-            grep -E "Elapsed|User time|System time|Maximum resident|page faults|Percent of CPU" /tmp/build-time.txt || true
+            cat /tmp/build-time.txt 2>/dev/null || echo '(time output not captured)'
             echo '```'
-            echo ""
-            echo "### Peak RSS per node/yarn process (top 20)"
-            echo "| PID | PPID | Peak RSS (MB) | Command |"
-            echo "|---:|---:|---:|:---|"
-            awk -F, '
-              { if (($4+0) > peak[$2]+0) { peak[$2]=$4; ppid[$2]=$3; comm[$2]=$6 } }
-              END {
-                for (p in peak) printf "%s\t%s\t%.0f\t%s\n", p, ppid[p], peak[p]/1024, comm[p]
-              }
-            ' /tmp/proc-samples.csv \
-              | sort -t$'\t' -k3 -rn \
-              | head -20 \
-              | awk -F$'\t' '{printf "| %s | %s | %s | `%s` |\n", $1, $2, $3, $4}'
-            echo ""
-            echo "### Concurrency"
-            awk -F, '
-              { count[$1]++ }
-              END {
-                max=0
-                for (t in count) if (count[t]>max) max=count[t]
-                printf "Max concurrent node/yarn processes (2s sample): **%d**\n", max
-              }
-            ' /tmp/proc-samples.csv
           } >> "$GITHUB_STEP_SUMMARY"
-
           exit "$BUILD_RC"
         env:
           CI_STRICT_LINKS: "1"

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -80,5 +80,6 @@ jobs:
 
           exit "$BUILD_RC"
         env:
+          SKIP_RECIPE_CATALOG: "1"
           CI_STRICT_LINKS: "1"
           DOCUSAURUS_IGNORE_SSG_WARNINGS: true

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -57,5 +57,4 @@ jobs:
         env:
           SKIP_RECIPE_CATALOG: "1"
           CI_STRICT_LINKS: "1"
-          NODE_OPTIONS: --max-old-space-size=8192
           DOCUSAURUS_IGNORE_SSG_WARNINGS: true

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -54,15 +54,30 @@ jobs:
         run: |
           set +e
           set -o pipefail
-          /usr/bin/time -v -o /tmp/build-time.txt yarn build 2>&1 \
-            | { grep --line-buffered -v "^Generated markdown file:" || true; }
+          start=$(date +%s)
+          yarn build 2>&1 | { grep --line-buffered -v "^Generated markdown file:" || true; }
           BUILD_RC=${PIPESTATUS[0]}
+          elapsed=$(( $(date +%s) - start ))
+
+          cgroup_path=$(awk -F: '$1 == "0" {print $3}' /proc/self/cgroup 2>/dev/null || true)
+          peak_file="/sys/fs/cgroup${cgroup_path}/memory.peak"
+          [[ -r "$peak_file" ]] || peak_file=/sys/fs/cgroup/memory.peak
+
           {
-            echo '## Build wall stats (`/usr/bin/time -v`)'
-            echo '```'
-            cat /tmp/build-time.txt 2>/dev/null || echo '(time output not captured)'
-            echo '```'
+            echo '## Build memory profile'
+            echo ""
+            printf 'Elapsed: **%dm %02ds**\n\n' $((elapsed/60)) $((elapsed%60))
+            if [[ -r "$peak_file" ]]; then
+              peak_bytes=$(cat "$peak_file")
+              peak_mb=$((peak_bytes / 1024 / 1024))
+              echo "Peak cgroup memory: **${peak_mb} MB** (${peak_bytes} bytes)"
+              echo ""
+              echo "Source: \`$peak_file\`"
+            else
+              echo '(cgroup memory.peak not available)'
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
+
           exit "$BUILD_RC"
         env:
           CI_STRICT_LINKS: "1"

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -52,33 +52,8 @@ jobs:
 
       - name: Build site
         run: |
-          set +e
           set -o pipefail
-          start=$(date +%s)
           yarn build 2>&1 | { grep --line-buffered -v "^Generated markdown file:" || true; }
-          BUILD_RC=${PIPESTATUS[0]}
-          elapsed=$(( $(date +%s) - start ))
-
-          cgroup_path=$(awk -F: '$1 == "0" {print $3}' /proc/self/cgroup 2>/dev/null || true)
-          peak_file="/sys/fs/cgroup${cgroup_path}/memory.peak"
-          [[ -r "$peak_file" ]] || peak_file=/sys/fs/cgroup/memory.peak
-
-          {
-            echo '## Build memory profile'
-            echo ""
-            printf 'Elapsed: **%dm %02ds**\n\n' $((elapsed/60)) $((elapsed%60))
-            if [[ -r "$peak_file" ]]; then
-              peak_bytes=$(cat "$peak_file")
-              peak_mb=$((peak_bytes / 1024 / 1024))
-              echo "Peak cgroup memory: **${peak_mb} MB** (${peak_bytes} bytes)"
-              echo ""
-              echo "Source: \`$peak_file\`"
-            else
-              echo '(cgroup memory.peak not available)'
-            fi
-          } >> "$GITHUB_STEP_SUMMARY"
-
-          exit "$BUILD_RC"
         env:
           SKIP_RECIPE_CATALOG: "1"
           CI_STRICT_LINKS: "1"

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -181,7 +181,22 @@ const config: Config = {
   ],
 
   future: {
-    faster: true,
+    faster: {
+      // SSG worker threads parallelise per-page rendering; each worker
+      // holds a React render tree, multiplying peak memory across pages
+      // in flight. With the full recipe-catalog build (~5,700 pages) on
+      // ubuntu-latest's 16 GB the kernel SIGTERMs the job mid-build.
+      // Serialising SSG keeps peak memory bounded; Rspack/SWC keep
+      // their own internal parallelism for the bundling/minimising work.
+      ssgWorkerThreads: false,
+      swcJsLoader: true,
+      swcJsMinimizer: true,
+      swcHtmlMinimizer: true,
+      lightningCssMinimizer: true,
+      rspackBundler: true,
+      rspackPersistentCache: true,
+      mdxCrossCompilerCache: true,
+    },
     v4: true,
   },
 


### PR DESCRIPTION
## Summary

The `Deploy Moderne docs to Pages` workflow has been hitting intermittent SIGTERM 143 failures during `Build website`. Investigation traced the root cause to **Docusaurus's SSG worker threads** — under `future.faster: true`, the SSG side spawns Node worker threads to render pages in parallel, each holding a full React render tree. With the full ~5,700-page recipe-catalog build on `ubuntu-latest`'s 16 GB, the combined RSS pushes past the runner's memory budget and the kernel/runner agent SIGTERMs the job mid-build.

This PR fixes the failure by serialising SSG (`ssgWorkerThreads: false`) while preserving Rspack/SWC's internal parallelism for bundling and minification. Trade-off: ~14:00 elapsed instead of ~9:00, in exchange for the build actually completing.

## Changes

* **`docusaurus.config.ts`** — expand `future.faster: true` to the explicit object form, set `ssgWorkerThreads: false`, keep all other faster sub-options (`swcJsLoader`, `swcJsMinimizer`, `swcHtmlMinimizer`, `lightningCssMinimizer`, `rspackBundler`, `rspackPersistentCache`, `mdxCrossCompilerCache`) on. Comment in code explains the constraint.
* **`.github/workflows/pages.yml`** — remove `NODE_OPTIONS: --max-old-space-size=8192`. With the SSG fix in place, the build fits comfortably in V8's default 4 GB heap. The override was actually amplifying memory pressure: `NODE_OPTIONS` is inherited by every child Node process, so each worker advertised an 8 GB heap quota.
* **`.github/workflows/pr-validation.yml`** — same `NODE_OPTIONS` removal.

## Investigation

Five-cell parallel experiment via PRs #656–#659:

| PR | Lever | Outcome | Build site elapsed |
|----|-------|---------|--------------------|
| #654 (this PR, baseline before fix) | `faster: true`, no override | ❌ SIGTERM 143 | 17:52 |
| #656 | `--no-minify` | inconclusive (cancelled at 23:00+) | — |
| #657 | `future.faster: false` (back to webpack/terser) | ❌ V8 OOM 134 — confirms webpack path needs >4 GB heap | ~14:00 |
| #658 | `taskset -c 0,1 yarn build` | ✅ success (proves OS-level worker throttling fixes it) | 14:36 |
| #659 | `future.faster.ssgWorkerThreads: false` | ✅ success (config-level fix; same effect, no `taskset` needed) | 14:04 |

The taskset and ssgWorkerThreads experiments both prevented the SIGTERM. The config-level fix is preferred because it lives in versioned code and only serialises the work that actually causes the problem — Rspack/SWC continue running their internal Rust thread pools at full parallelism for bundling and minification.

Companion to #651 (line-buffered build output, merged earlier).

## Test plan

* [ ] PR validation on this branch completes successfully.
* [ ] After merge, watch the next several `Deploy Moderne docs to Pages` runs and confirm the SIGTERM 143 pattern does not recur.
* [ ] Build wall time on Pages should land around 14 min (up from the prior ~10 min on successful runs, down from the 17:52 ceiling on failing ones).
* [ ] PR validation Build site step still completes well under 10 min thanks to `SKIP_RECIPE_CATALOG: "1"`.

## Cleanup once merged

Close experiment PRs #656, #657, #658, #659 — all served their purpose as data-collection branches.