### PR TITLE
[experiment] future.faster: false (disable Rspack/SWC)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -45,15 +45,30 @@ jobs:
         run: |
           set +e
           set -o pipefail
-          /usr/bin/time -v -o /tmp/build-time.txt yarn build 2>&1 \
-            | { grep --line-buffered -v "^Generated markdown file:" || true; }
+          start=$(date +%s)
+          yarn build 2>&1 | { grep --line-buffered -v "^Generated markdown file:" || true; }
           BUILD_RC=${PIPESTATUS[0]}
+          elapsed=$(( $(date +%s) - start ))
+
+          cgroup_path=$(awk -F: '$1 == "0" {print $3}' /proc/self/cgroup 2>/dev/null || true)
+          peak_file="/sys/fs/cgroup${cgroup_path}/memory.peak"
+          [[ -r "$peak_file" ]] || peak_file=/sys/fs/cgroup/memory.peak
+
           {
-            echo '## Build wall stats (`/usr/bin/time -v`)'
-            echo '```'
-            cat /tmp/build-time.txt 2>/dev/null || echo '(time output not captured)'
-            echo '```'
+            echo '## Build memory profile'
+            echo ""
+            printf 'Elapsed: **%dm %02ds**\n\n' $((elapsed/60)) $((elapsed%60))
+            if [[ -r "$peak_file" ]]; then
+              peak_bytes=$(cat "$peak_file")
+              peak_mb=$((peak_bytes / 1024 / 1024))
+              echo "Peak cgroup memory: **${peak_mb} MB** (${peak_bytes} bytes)"
+              echo ""
+              echo "Source: \`$peak_file\`"
+            else
+              echo '(cgroup memory.peak not available)'
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
+
           exit "$BUILD_RC"
         env:
           DOCUSAURUS_IGNORE_SSG_WARNINGS: true

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,10 +22,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - name: Collect workflow telemetry
-        uses: catchpoint/workflow-telemetry-action@v2
-        with:
-          comment_on_pr: false
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
@@ -48,7 +44,61 @@ jobs:
       - name: Build website
         run: |
           set -o pipefail
-          yarn build 2>&1 | { grep --line-buffered -v "^Generated markdown file:" || true; }
+
+          # Background sampler: ts,pid,ppid,rss_kb,vsz_kb,comm — every 2s
+          {
+            while :; do
+              ts=$(date +%s)
+              ps -eo pid=,ppid=,rss=,vsz=,comm= 2>/dev/null \
+                | awk -v ts="$ts" '$5 ~ /^(node|yarn)$/ {print ts","$1","$2","$3","$4","$5}'
+              sleep 2
+            done
+          } > /tmp/proc-samples.csv 2>/dev/null &
+          SAMPLER_PID=$!
+
+          set +e
+          /usr/bin/time -v -o /tmp/build-time.txt \
+            bash -c 'yarn build 2>&1' \
+            | { grep --line-buffered -v "^Generated markdown file:" || true; }
+          BUILD_RC=${PIPESTATUS[0]}
+          set -e
+
+          kill "$SAMPLER_PID" 2>/dev/null || true
+          wait "$SAMPLER_PID" 2>/dev/null || true
+
+          {
+            echo "## Build memory profile"
+            echo ""
+            echo "### Wall stats (\`/usr/bin/time -v\`)"
+            echo '```'
+            grep -E "Elapsed|User time|System time|Maximum resident|page faults|Percent of CPU" /tmp/build-time.txt || true
+            echo '```'
+            echo ""
+            echo "### Peak RSS per node/yarn process (top 20)"
+            echo "| PID | PPID | Peak RSS (MB) | Command |"
+            echo "|---:|---:|---:|:---|"
+            awk -F, '
+              { if (($4+0) > peak[$2]+0) { peak[$2]=$4; ppid[$2]=$3; comm[$2]=$6 } }
+              END {
+                for (p in peak) printf "%s\t%s\t%.0f\t%s\n", p, ppid[p], peak[p]/1024, comm[p]
+              }
+            ' /tmp/proc-samples.csv \
+              | sort -t$'\t' -k3 -rn \
+              | head -20 \
+              | awk -F$'\t' '{printf "| %s | %s | %s | `%s` |\n", $1, $2, $3, $4}'
+            echo ""
+            echo "### Concurrency"
+            awk -F, '
+              { count[$1]++ }
+              END {
+                max=0
+                for (t in count) if (count[t]>max) max=count[t]
+                printf "Max concurrent node/yarn processes (2s sample): **%d**\n", max
+              }
+            ' /tmp/proc-samples.csv
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          exit "$BUILD_RC"
         env:
           DOCUSAURUS_IGNORE_SSG_WARNINGS: true
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,6 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - name: Collect workflow telemetry
+        uses: catchpoint/workflow-telemetry-action@v2
+        with:
+          comment_on_pr: false
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -46,7 +46,6 @@ jobs:
           set -o pipefail
           yarn build 2>&1 | { grep --line-buffered -v "^Generated markdown file:" || true; }
         env:
-          NODE_OPTIONS: --max-old-space-size=8192
           DOCUSAURUS_IGNORE_SSG_WARNINGS: true
 
       - name: Upload Build Artifact

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -43,61 +43,17 @@ jobs:
 
       - name: Build website
         run: |
-          set -o pipefail
-
-          # Background sampler: ts,pid,ppid,rss_kb,vsz_kb,comm — every 2s
-          {
-            while :; do
-              ts=$(date +%s)
-              ps -eo pid=,ppid=,rss=,vsz=,comm= 2>/dev/null \
-                | awk -v ts="$ts" '$5 ~ /^(node|yarn)$/ {print ts","$1","$2","$3","$4","$5}'
-              sleep 2
-            done
-          } > /tmp/proc-samples.csv 2>/dev/null &
-          SAMPLER_PID=$!
-
           set +e
-          /usr/bin/time -v -o /tmp/build-time.txt \
-            bash -c 'yarn build 2>&1' \
+          set -o pipefail
+          /usr/bin/time -v -o /tmp/build-time.txt yarn build 2>&1 \
             | { grep --line-buffered -v "^Generated markdown file:" || true; }
           BUILD_RC=${PIPESTATUS[0]}
-          set -e
-
-          kill "$SAMPLER_PID" 2>/dev/null || true
-          wait "$SAMPLER_PID" 2>/dev/null || true
-
           {
-            echo "## Build memory profile"
-            echo ""
-            echo "### Wall stats (\`/usr/bin/time -v\`)"
+            echo '## Build wall stats (`/usr/bin/time -v`)'
             echo '```'
-            grep -E "Elapsed|User time|System time|Maximum resident|page faults|Percent of CPU" /tmp/build-time.txt || true
+            cat /tmp/build-time.txt 2>/dev/null || echo '(time output not captured)'
             echo '```'
-            echo ""
-            echo "### Peak RSS per node/yarn process (top 20)"
-            echo "| PID | PPID | Peak RSS (MB) | Command |"
-            echo "|---:|---:|---:|:---|"
-            awk -F, '
-              { if (($4+0) > peak[$2]+0) { peak[$2]=$4; ppid[$2]=$3; comm[$2]=$6 } }
-              END {
-                for (p in peak) printf "%s\t%s\t%.0f\t%s\n", p, ppid[p], peak[p]/1024, comm[p]
-              }
-            ' /tmp/proc-samples.csv \
-              | sort -t$'\t' -k3 -rn \
-              | head -20 \
-              | awk -F$'\t' '{printf "| %s | %s | %s | `%s` |\n", $1, $2, $3, $4}'
-            echo ""
-            echo "### Concurrency"
-            awk -F, '
-              { count[$1]++ }
-              END {
-                max=0
-                for (t in count) if (count[t]>max) max=count[t]
-                printf "Max concurrent node/yarn processes (2s sample): **%d**\n", max
-              }
-            ' /tmp/proc-samples.csv
           } >> "$GITHUB_STEP_SUMMARY"
-
           exit "$BUILD_RC"
         env:
           DOCUSAURUS_IGNORE_SSG_WARNINGS: true

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -40,10 +40,6 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - name: Collect workflow telemetry
-        uses: catchpoint/workflow-telemetry-action@v2
-        with:
-          comment_on_pr: false
       - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v6
@@ -57,7 +53,61 @@ jobs:
       - name: Build site
         run: |
           set -o pipefail
-          yarn build 2>&1 | { grep --line-buffered -v "^Generated markdown file:" || true; }
+
+          # Background sampler: ts,pid,ppid,rss_kb,vsz_kb,comm — every 2s
+          {
+            while :; do
+              ts=$(date +%s)
+              ps -eo pid=,ppid=,rss=,vsz=,comm= 2>/dev/null \
+                | awk -v ts="$ts" '$5 ~ /^(node|yarn)$/ {print ts","$1","$2","$3","$4","$5}'
+              sleep 2
+            done
+          } > /tmp/proc-samples.csv 2>/dev/null &
+          SAMPLER_PID=$!
+
+          set +e
+          /usr/bin/time -v -o /tmp/build-time.txt \
+            bash -c 'yarn build 2>&1' \
+            | { grep --line-buffered -v "^Generated markdown file:" || true; }
+          BUILD_RC=${PIPESTATUS[0]}
+          set -e
+
+          kill "$SAMPLER_PID" 2>/dev/null || true
+          wait "$SAMPLER_PID" 2>/dev/null || true
+
+          {
+            echo "## Build memory profile"
+            echo ""
+            echo "### Wall stats (\`/usr/bin/time -v\`)"
+            echo '```'
+            grep -E "Elapsed|User time|System time|Maximum resident|page faults|Percent of CPU" /tmp/build-time.txt || true
+            echo '```'
+            echo ""
+            echo "### Peak RSS per node/yarn process (top 20)"
+            echo "| PID | PPID | Peak RSS (MB) | Command |"
+            echo "|---:|---:|---:|:---|"
+            awk -F, '
+              { if (($4+0) > peak[$2]+0) { peak[$2]=$4; ppid[$2]=$3; comm[$2]=$6 } }
+              END {
+                for (p in peak) printf "%s\t%s\t%.0f\t%s\n", p, ppid[p], peak[p]/1024, comm[p]
+              }
+            ' /tmp/proc-samples.csv \
+              | sort -t$'\t' -k3 -rn \
+              | head -20 \
+              | awk -F$'\t' '{printf "| %s | %s | %s | `%s` |\n", $1, $2, $3, $4}'
+            echo ""
+            echo "### Concurrency"
+            awk -F, '
+              { count[$1]++ }
+              END {
+                max=0
+                for (t in count) if (count[t]>max) max=count[t]
+                printf "Max concurrent node/yarn processes (2s sample): **%d**\n", max
+              }
+            ' /tmp/proc-samples.csv
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          exit "$BUILD_RC"
         env:
           CI_STRICT_LINKS: "1"
           DOCUSAURUS_IGNORE_SSG_WARNINGS: true

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -40,6 +40,10 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
+      - name: Collect workflow telemetry
+        uses: catchpoint/workflow-telemetry-action@v2
+        with:
+          comment_on_pr: false
       - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v6

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -55,6 +55,5 @@ jobs:
           set -o pipefail
           yarn build 2>&1 | { grep --line-buffered -v "^Generated markdown file:" || true; }
         env:
-          SKIP_RECIPE_CATALOG: "1"
           CI_STRICT_LINKS: "1"
           DOCUSAURUS_IGNORE_SSG_WARNINGS: true

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -52,61 +52,17 @@ jobs:
 
       - name: Build site
         run: |
-          set -o pipefail
-
-          # Background sampler: ts,pid,ppid,rss_kb,vsz_kb,comm — every 2s
-          {
-            while :; do
-              ts=$(date +%s)
-              ps -eo pid=,ppid=,rss=,vsz=,comm= 2>/dev/null \
-                | awk -v ts="$ts" '$5 ~ /^(node|yarn)$/ {print ts","$1","$2","$3","$4","$5}'
-              sleep 2
-            done
-          } > /tmp/proc-samples.csv 2>/dev/null &
-          SAMPLER_PID=$!
-
           set +e
-          /usr/bin/time -v -o /tmp/build-time.txt \
-            bash -c 'yarn build 2>&1' \
+          set -o pipefail
+          /usr/bin/time -v -o /tmp/build-time.txt yarn build 2>&1 \
             | { grep --line-buffered -v "^Generated markdown file:" || true; }
           BUILD_RC=${PIPESTATUS[0]}
-          set -e
-
-          kill "$SAMPLER_PID" 2>/dev/null || true
-          wait "$SAMPLER_PID" 2>/dev/null || true
-
           {
-            echo "## Build memory profile"
-            echo ""
-            echo "### Wall stats (\`/usr/bin/time -v\`)"
+            echo '## Build wall stats (`/usr/bin/time -v`)'
             echo '```'
-            grep -E "Elapsed|User time|System time|Maximum resident|page faults|Percent of CPU" /tmp/build-time.txt || true
+            cat /tmp/build-time.txt 2>/dev/null || echo '(time output not captured)'
             echo '```'
-            echo ""
-            echo "### Peak RSS per node/yarn process (top 20)"
-            echo "| PID | PPID | Peak RSS (MB) | Command |"
-            echo "|---:|---:|---:|:---|"
-            awk -F, '
-              { if (($4+0) > peak[$2]+0) { peak[$2]=$4; ppid[$2]=$3; comm[$2]=$6 } }
-              END {
-                for (p in peak) printf "%s\t%s\t%.0f\t%s\n", p, ppid[p], peak[p]/1024, comm[p]
-              }
-            ' /tmp/proc-samples.csv \
-              | sort -t$'\t' -k3 -rn \
-              | head -20 \
-              | awk -F$'\t' '{printf "| %s | %s | %s | `%s` |\n", $1, $2, $3, $4}'
-            echo ""
-            echo "### Concurrency"
-            awk -F, '
-              { count[$1]++ }
-              END {
-                max=0
-                for (t in count) if (count[t]>max) max=count[t]
-                printf "Max concurrent node/yarn processes (2s sample): **%d**\n", max
-              }
-            ' /tmp/proc-samples.csv
           } >> "$GITHUB_STEP_SUMMARY"
-
           exit "$BUILD_RC"
         env:
           CI_STRICT_LINKS: "1"

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -57,5 +57,4 @@ jobs:
         env:
           SKIP_RECIPE_CATALOG: "1"
           CI_STRICT_LINKS: "1"
-          NODE_OPTIONS: --max-old-space-size=8192
           DOCUSAURUS_IGNORE_SSG_WARNINGS: true

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -54,15 +54,30 @@ jobs:
         run: |
           set +e
           set -o pipefail
-          /usr/bin/time -v -o /tmp/build-time.txt yarn build 2>&1 \
-            | { grep --line-buffered -v "^Generated markdown file:" || true; }
+          start=$(date +%s)
+          yarn build 2>&1 | { grep --line-buffered -v "^Generated markdown file:" || true; }
           BUILD_RC=${PIPESTATUS[0]}
+          elapsed=$(( $(date +%s) - start ))
+
+          cgroup_path=$(awk -F: '$1 == "0" {print $3}' /proc/self/cgroup 2>/dev/null || true)
+          peak_file="/sys/fs/cgroup${cgroup_path}/memory.peak"
+          [[ -r "$peak_file" ]] || peak_file=/sys/fs/cgroup/memory.peak
+
           {
-            echo '## Build wall stats (`/usr/bin/time -v`)'
-            echo '```'
-            cat /tmp/build-time.txt 2>/dev/null || echo '(time output not captured)'
-            echo '```'
+            echo '## Build memory profile'
+            echo ""
+            printf 'Elapsed: **%dm %02ds**\n\n' $((elapsed/60)) $((elapsed%60))
+            if [[ -r "$peak_file" ]]; then
+              peak_bytes=$(cat "$peak_file")
+              peak_mb=$((peak_bytes / 1024 / 1024))
+              echo "Peak cgroup memory: **${peak_mb} MB** (${peak_bytes} bytes)"
+              echo ""
+              echo "Source: \`$peak_file\`"
+            else
+              echo '(cgroup memory.peak not available)'
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
+
           exit "$BUILD_RC"
         env:
           CI_STRICT_LINKS: "1"

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -181,7 +181,7 @@ const config: Config = {
   ],
 
   future: {
-    faster: true,
+    faster: false,
     v4: true,
   },
 


### PR DESCRIPTION
**Not for merge.** Branched off \`drop-node-heap-override\` to harvest PR-validation data.

## Hypothesis
Disabling \`future.faster\` reverts the build from Rspack/SWC back to webpack/terser. If Rspack's threading model is what spikes peak memory, this should look better. If webpack/terser is actually worse for this site, this should be slower / use more memory — also informative.

## What to look at
The Build site step's GitHub Actions step summary reports \`Elapsed\` and \`Peak cgroup memory\`. Compare against the cgroup-peak run on \`drop-node-heap-override\` head.