### PR TITLE
chore: restore SKIP_RECIPE_CATALOG and CI_STRICT_LINKS to PR validation

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -55,4 +55,6 @@ jobs:
           set -o pipefail
           yarn build 2>&1 | { grep --line-buffered -v "^Generated markdown file:" || true; }
         env:
+          SKIP_RECIPE_CATALOG: "1"
+          CI_STRICT_LINKS: "1"
           DOCUSAURUS_IGNORE_SSG_WARNINGS: true


### PR DESCRIPTION
## Summary

* Restores `SKIP_RECIPE_CATALOG: "1"` and `CI_STRICT_LINKS: "1"` to the PR validation build step
- * These were removed temporarily in #662 to benchmark full build time on Node 24
* Benchmark is complete — restoring to keep PR builds fast and enforce strict link checking