### PR TITLE
Document missing Trigrep filters (type, select, count, abstract, ...)

### DIFF
--- a/docs/user-documentation/agent-tools/trigrep.md
+++ b/docs/user-documentation/agent-tools/trigrep.md
@@ -61,7 +61,6 @@ To refine your search, you can combine terms with boolean logic:
 
 * **AND** (implicit) — Multiple terms are combined with AND. For example, `@Service getUserById` only matches files containing both.
 * **OR** — Use `or` for either term to match. For example, `@Service or @Controller` matches files with either annotation.
-* **NOT** — Prefix with `-` to exclude. For example, `-test` filters out files containing `test`.
 * **Grouping** — Parentheses control precedence. For example, `(@Service or @Controller) getUserById` finds files with `getUserById` that also have either annotation.
 
 You can also combine literal searches with [filters](#filters) to narrow results by file path, repository, language, or Java-specific properties like visibility and inheritance.
@@ -274,7 +273,7 @@ This section provides a quick reference for all query operators, filters, and st
 
 ### Boolean operators
 
-Terms separated by space are implicitly ANDed. The `or` keyword creates disjunction. Parentheses group terms. A leading `-` negates a term.
+Terms separated by space are implicitly ANDed. The `or` keyword creates disjunction. Parentheses group terms.
 
 ### Filters
 
@@ -286,8 +285,8 @@ Terms separated by space are implicitly ANDed. The `or` keyword creates disjunct
 | `rev:`         | Sourcegraph-only branch/tag filter. Alias: `revision:`                                                                                   | `rev:main`                   |
 | `lang:`        | Filter by language. Aliases: `language:`, `l:` (Sourcegraph)                                                                             | `lang:java`                  |
 | `case:`        | Control case sensitivity (`yes`/`no`)                                                                                                    | `case:yes findById`          |
-| `type:`        | Restrict matching surface: `file` (content, default), `path` (file names only), or `symbol` (matches at symbol-name granularity). Must precede the term it applies to | `type:symbol Person`         |
-| `sym:`         | Match symbols by substring on their fully qualified name. Alias: `symbol:`                                                               | `sym:UserRepository`         |
+| `type:`        | Restrict matching surface: `file` (content, default), `path` (file names only), or `symbol` (symbol declarations only — literal terms; see note below) | `type:symbol Person`         |
+| `sym:`         | Match symbols by substring on their fully qualified name. Zoekt-native; trigrep also accepts it in Sourcegraph mode. Alias: `symbol:`    | `sym:UserRepository`         |
 | `select:`      | Filter symbol matches by kind: `symbol.class`, `symbol.interface`, `symbol.enum`, `symbol.method`, `symbol.constructor`, `symbol.field`  | `select:symbol.method`       |
 | `count:`       | Cap total results returned by the query                                                                                                  | `count:500`                  |
 | `content:`     | Search file content explicitly (Sourcegraph). Pairs with `patternType:` and disambiguates literals that look like a filter prefix        | `content:"text"`             |
@@ -310,8 +309,8 @@ The `type:`, `case:`, `count:`, and `patternType:` filters affect how subsequent
 
 `type:symbol` and `sym:` are not synonyms either:
 
-* `type:symbol Person` is the narrow lens — it matches at symbol-name granularity (e.g., the `Person` class itself, not `PersonRepository`).
-* `sym:Person` is the wide net — it does a substring match on each symbol's fully qualified name, so it picks up any symbol whose FQN contains `Person`: the `PersonRepository` class, every method inside `class Person` (because their FQN is `...Person.methodName`), and so on. The match is still constrained to symbols — it won't surface string literals, comments, or other non-symbol text.
+* `type:symbol Person` matches `Person` at symbol *declaration sites* only — class headers, method/constructor signatures, and field declarations. So `class PersonRepository`, `Person currentPerson;`, and `void savePerson(Person p)` all match, but uses inside method bodies, imports, and comments do not. This restriction applies to literal terms; regex patterns (`type:symbol /Person/`) currently bypass it and search the full file.
+* `sym:Person` matches every symbol whose fully qualified name contains `Person`. That covers `Person`, `PersonRepository`, etc., plus every method and field inside them (`Person.getFirstName`, `PersonRepository.findByLastName`, ...) because each member's FQN inherits the containing class name. The match is still constrained to symbols — it won't surface string literals, comments, or other non-symbol text.
 
 Bare `Person` is broader still — every textual occurrence including imports, comments, and string literals.
 :::
@@ -321,7 +320,6 @@ The CLI treats a single-arg query as a **literal phrase** and re-emits it quoted
 
 * `'@Service or @Controller'` is searched as the literal phrase `@Service or @Controller` (which appears nowhere) — 0 matches.
 * `'visibility:public returns:List'` is parsed as a single filter with value `public returns:List` — fails with `Unknown visibility: public returns:List`.
-* `'KafkaTemplate -test'` is searched as the literal phrase `KafkaTemplate -test` — 0 matches.
 
 Pass each token as its own argument, or quote each individually:
 

--- a/docs/user-documentation/agent-tools/trigrep.md
+++ b/docs/user-documentation/agent-tools/trigrep.md
@@ -286,8 +286,8 @@ Terms separated by space are implicitly ANDed. The `or` keyword creates disjunct
 | `rev:`         | Sourcegraph-only branch/tag filter. Alias: `revision:`                                                                                   | `rev:main`                   |
 | `lang:`        | Filter by language. Aliases: `language:`, `l:` (Sourcegraph)                                                                             | `lang:java`                  |
 | `case:`        | Control case sensitivity (`yes`/`no`)                                                                                                    | `case:yes findById`          |
-| `type:`        | Restrict matching surface: `file` (content, default), `path` (file names only), or `symbol` (symbol sections)                            | `type:path Repository`       |
-| `sym:`         | Restrict to symbol definitions. Alias: `symbol:`                                                                                         | `sym:UserRepository`         |
+| `type:`        | Restrict matching surface: `file` (content, default), `path` (file names only), or `symbol` (matches at symbol-name granularity). Must precede the term it applies to | `type:symbol Person`         |
+| `sym:`         | Match symbols by substring on their fully qualified name. Alias: `symbol:`                                                               | `sym:UserRepository`         |
 | `select:`      | Filter symbol matches by kind: `symbol.class`, `symbol.interface`, `symbol.enum`, `symbol.method`, `symbol.constructor`, `symbol.field`  | `select:symbol.method`       |
 | `count:`       | Cap total results returned by the query                                                                                                  | `count:500`                  |
 | `content:`     | Search file content explicitly (Sourcegraph). Pairs with `patternType:` and disambiguates literals that look like a filter prefix        | `content:"text"`             |
@@ -303,6 +303,17 @@ Terms separated by space are implicitly ANDed. The `or` keyword creates disjunct
 
 :::info
 The Sourcegraph filters `context:`, `fork:`, `archived:`, and `timeout:` are parsed but have no effect on local indexes — they emit a warning and are dropped from the query.
+:::
+
+:::info[Filter ordering and `type:symbol` vs `sym:`]
+The `type:`, `case:`, `count:`, and `patternType:` filters affect how subsequent terms are parsed, so they must appear **before** the term they apply to. For example, `type:symbol Person` filters the search; `Person type:symbol` is silently equivalent to bare `Person`.
+
+`type:symbol` and `sym:` are not synonyms either:
+
+* `type:symbol Person` is the narrow lens — it matches at symbol-name granularity (e.g., the `Person` class itself, not `PersonRepository`).
+* `sym:Person` is the wide net — it does a substring match on each symbol's fully qualified name, so it picks up any symbol whose FQN contains `Person`: the `PersonRepository` class, every method inside `class Person` (because their FQN is `...Person.methodName`), and so on. The match is still constrained to symbols — it won't surface string literals, comments, or other non-symbol text.
+
+Bare `Person` is broader still — every textual occurrence including imports, comments, and string literals.
 :::
 
 :::warning[Quoting multi-token queries]

--- a/docs/user-documentation/agent-tools/trigrep.md
+++ b/docs/user-documentation/agent-tools/trigrep.md
@@ -61,6 +61,7 @@ To refine your search, you can combine terms with boolean logic:
 
 * **AND** (implicit) — Multiple terms are combined with AND. For example, `@Service getUserById` only matches files containing both.
 * **OR** — Use `or` for either term to match. For example, `@Service or @Controller` matches files with either annotation.
+* **NOT** — Prefix with `-` to exclude. Because the CLI intercepts leading `-` as an option marker, insert `--` between the path and the query: `mod search . -- @RestController -test` finds files containing `@RestController` but not `test`.
 * **Grouping** — Parentheses control precedence. For example, `(@Service or @Controller) getUserById` finds files with `getUserById` that also have either annotation.
 
 You can also combine literal searches with [filters](#filters) to narrow results by file path, repository, language, or Java-specific properties like visibility and inheritance.
@@ -273,7 +274,7 @@ This section provides a quick reference for all query operators, filters, and st
 
 ### Boolean operators
 
-Terms separated by space are implicitly ANDed. The `or` keyword creates disjunction. Parentheses group terms.
+Terms separated by space are implicitly ANDed. The `or` keyword creates disjunction. Parentheses group terms. A leading `-` negates a term (requires `--` between the path and the query — see the [NOT example above](#literal-and-sourcegraph-style-queries)).
 
 ### Filters
 
@@ -320,6 +321,7 @@ The CLI treats a single-arg query as a **literal phrase** and re-emits it quoted
 
 * `'@Service or @Controller'` is searched as the literal phrase `@Service or @Controller` (which appears nowhere) — 0 matches.
 * `'visibility:public returns:List'` is parsed as a single filter with value `public returns:List` — fails with `Unknown visibility: public returns:List`.
+* `'KafkaTemplate -test'` is searched as the literal phrase `KafkaTemplate -test` — 0 matches. To use `-` negation, pass terms unquoted with `--`: `mod search . -- KafkaTemplate -test`.
 
 Pass each token as its own argument, or quote each individually:
 

--- a/docs/user-documentation/agent-tools/trigrep.md
+++ b/docs/user-documentation/agent-tools/trigrep.md
@@ -305,10 +305,8 @@ Terms separated by space are implicitly ANDed. The `or` keyword creates disjunct
 The Sourcegraph filters `context:`, `fork:`, `archived:`, and `timeout:` are parsed but have no effect on local indexes — they emit a warning and are dropped from the query.
 :::
 
-:::info[Filter ordering and `type:symbol` vs `sym:`]
-The `type:`, `case:`, `count:`, and `patternType:` filters affect how subsequent terms are parsed, so they must appear **before** the term they apply to. For example, `type:symbol Person` filters the search; `Person type:symbol` is silently equivalent to bare `Person`.
-
-`type:symbol` and `sym:` are not synonyms either:
+:::info[`type:symbol` vs `sym:`]
+`type:symbol` and `sym:` are not synonyms:
 
 * `type:symbol Person` matches `Person` at symbol *declaration sites* only — class headers, method/constructor signatures, and field declarations. So `class PersonRepository`, `Person currentPerson;`, and `void savePerson(Person p)` all match, but uses inside method bodies, imports, and comments do not. This restriction applies to literal terms; regex patterns (`type:symbol /Person/`) currently bypass it and search the full file.
 * `sym:Person` matches every symbol whose fully qualified name contains `Person`. That covers `Person`, `PersonRepository`, etc., plus every method and field inside them (`Person.getFirstName`, `PersonRepository.findByLastName`, ...) because each member's FQN inherits the containing class name. The match is still constrained to symbols — it won't surface string literals, comments, or other non-symbol text.

--- a/docs/user-documentation/agent-tools/trigrep.md
+++ b/docs/user-documentation/agent-tools/trigrep.md
@@ -128,7 +128,7 @@ When you need to match code shapes that regular expressions struggle with (like 
 
 The key concept is the **hole**, written as `:[name]`. A hole matches content and optionally captures it for reference. For example, the pattern `logger.:[level](:[message])` matches any logger call, capturing the log level and message separately. Unlike the regex equivalent, this correctly handles nested parentheses in the message argument.
 
-To use structural matching, add the `struct:` prefix before your pattern (e.g., `mod search working-set struct:'logger.:[level](:[message])'`). Without this prefix, hole syntax is treated as literal text.
+To use structural matching, add the `struct:` prefix (or its `structural:` alias) before your pattern (e.g., `mod search working-set struct:'logger.:[level](:[message])'`). Without this prefix, hole syntax is treated as literal text. In Sourcegraph mode you can also enter structural mode with `patternType:structural`, which lets bare terms in the rest of the query be parsed as Comby patterns.
 
 You can use typed holes to constrain what they match:
 
@@ -205,10 +205,6 @@ Both dialects share the same core query features: literal search, regex, boolean
 | Pattern type switching | `patternType:regexp foo.bar` | `/foo.bar/` (slash-delimited) |
 | Revision filter        | `rev:main`                   | `branch:main`                 |
 
-:::info
-Features like `context:`, `fork:`, `archived:`, and `timeout:` are parsed in Sourcegraph mode but not applicable to local indexes. They produce a warning and are dropped from the query.
-:::
-
 ### Example queries in both syntaxes
 
 **Filter by file path:**
@@ -282,21 +278,32 @@ Terms separated by space are implicitly ANDed. The `or` keyword creates disjunct
 
 ### Filters
 
-| Filter        | Description                             | Example                  |
-|---------------|-----------------------------------------|--------------------------|
-| `file:`       | Match file paths (globs or regex)       | `file:src/**/*.java`     |
-| `repo:`       | Match repository names                  | `repo:user-service@main` |
-| `branch:`     | Match git branch names                  | `branch:feature-*`       |
-| `lang:`       | Filter by language                      | `lang:java`              |
-| `case:`       | Control case sensitivity                | `case:yes findById`      |
-| `sym:`        | Restrict to symbol definitions          | `sym:UserRepository`     |
-| `visibility:` | Filter by access modifier               | `visibility:public`      |
-| `static:`     | Filter for static modifier              | `static:yes`             |
-| `final:`      | Filter for final modifier               | `final:yes`              |
-| `extends:`    | Match classes extending a type          | `extends:BaseService`    |
-| `implements:` | Match classes implementing an interface | `implements:Repository`  |
-| `returns:`    | Match methods by return type            | `returns:List`           |
-| `throws:`     | Match methods by declared exceptions    | `throws:IOException`     |
+| Filter         | Description                                                                                                                              | Example                      |
+|----------------|------------------------------------------------------------------------------------------------------------------------------------------|------------------------------|
+| `file:`        | Match file paths (globs or regex). Aliases: `f:`, `path:` (Sourcegraph)                                                                  | `file:src/**/*.java`         |
+| `repo:`        | Match repository names. Use `name@branch` to also filter by branch. Alias: `r:`                                                          | `repo:user-service@main`     |
+| `branch:`      | Match git branch names. Alias: `b:`                                                                                                      | `branch:feature-*`           |
+| `rev:`         | Sourcegraph-only branch/tag filter. Alias: `revision:`                                                                                   | `rev:main`                   |
+| `lang:`        | Filter by language. Aliases: `language:`, `l:` (Sourcegraph)                                                                             | `lang:java`                  |
+| `case:`        | Control case sensitivity (`yes`/`no`)                                                                                                    | `case:yes findById`          |
+| `type:`        | Restrict matching surface: `file` (content, default), `path` (file names only), or `symbol` (symbol sections)                            | `type:path Repository`       |
+| `sym:`         | Restrict to symbol definitions. Alias: `symbol:`                                                                                         | `sym:UserRepository`         |
+| `select:`      | Filter symbol matches by kind: `symbol.class`, `symbol.interface`, `symbol.enum`, `symbol.method`, `symbol.constructor`, `symbol.field`  | `select:symbol.method`       |
+| `count:`       | Cap total results returned by the query                                                                                                  | `count:500`                  |
+| `content:`     | Search file content explicitly (Sourcegraph). Pairs with `patternType:` and disambiguates literals that look like a filter prefix        | `content:"text"`             |
+| `patternType:` | Sourcegraph-only. Switch how bare terms are interpreted: `keyword` (default), `literal`, `regexp`, or `structural`                       | `patternType:regexp foo.bar` |
+| `visibility:`  | Filter by access modifier: `public`, `private`, `protected`, `package` (or `package-private`), or `any` (Sourcegraph; matches everything) | `visibility:public`          |
+| `static:`      | Filter for static modifier (`yes`/`no`)                                                                                                  | `static:yes`                 |
+| `final:`       | Filter for final modifier (`yes`/`no`)                                                                                                   | `final:yes`                  |
+| `abstract:`    | Filter for abstract modifier (`yes`/`no`)                                                                                                | `abstract:yes`               |
+| `extends:`     | Match classes extending a type                                                                                                           | `extends:BaseService`        |
+| `implements:`  | Match classes implementing an interface                                                                                                  | `implements:Repository`      |
+| `returns:`     | Match methods by return type                                                                                                             | `returns:List`               |
+| `throws:`      | Match methods by declared exceptions                                                                                                     | `throws:IOException`         |
+
+:::info
+The Sourcegraph filters `context:`, `fork:`, `archived:`, and `timeout:` are parsed but have no effect on local indexes — they emit a warning and are dropped from the query.
+:::
 
 :::warning[Quoting multi-token queries]
 The CLI treats a single-arg query as a **literal phrase** and re-emits it quoted in the `Searching for:` line. As a result, multi-token queries wrapped in a single pair of shell quotes lose their Sourcegraph semantics and almost always return 0 matches. Examples:


### PR DESCRIPTION
## Summary

* Adds the filters that `mod search` accepts but the Trigrep doc was missing: `type:`, `select:`, `count:`, `abstract:`, plus the Sourcegraph-only `content:`, `rev:`, and `patternType:` (which previously only appeared in the dialect-comparison table).
* Documents aliases for the existing filters (`f:`/`path:`, `r:`, `b:`, `language:`/`l:`, `revision:`, `symbol:`, `structural:`) and tags Sourcegraph-only entries inline so the table covers both Zoekt and Sourcegraph dialects.
* Expands `visibility:` and `case:` value lists, notes that `visibility:any` is Sourcegraph-only, and moves the warn-and-drop callout (`context:`, `fork:`, `archived:`, `timeout:`) next to the filter table.
* Mentions `structural:` as an alias for `struct:`, and that `patternType:structural` puts the rest of the query into Comby mode.

Verified against `SourcegraphQueryBuilder` and `QueryBuilder` in the trigrep repo and the `requote()` filter list in `mod/.../commands/Search.java`.

## Test plan

* [ ] `yarn start` builds clean (no errors, warnings, or broken links) — verified locally
* [ ] Spot-check the rendered filter table in the dev preview