### PR TITLE
Enable Algolia click analytics and insights tracking

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -206,6 +206,10 @@ const config: Config = {
       apiKey: "15eb9c9f6f3147b1cf82b1b7f93cace8",
       indexName: "moderne",
       // Search filtering is handled by SearchFacetTabs (src/theme/SearchBar)
+      insights: true,
+      searchParameters: {
+        clickAnalytics: true,
+      },
     },
     announcementBar: {
       id: "code_remix_26",


### PR DESCRIPTION
## Summary

* Adds `insights: true` to the Algolia config to enable the Algolia Insights client in DocSearch v4
* Adds `searchParameters: { clickAnalytics: true }` so Algolia returns a `queryID` with results, enabling clicks to be correlated to specific searches
* Both options surface click data in the Algolia Analytics dashboard

## Test plan

* [ ] Open the docs site and perform a search
* [ ] Click a search result
* [ ] Verify click events appear in the Algolia Analytics dashboard