### PR TITLE
Remove insights: true to fix crash on search result click

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -206,6 +206,10 @@ const config: Config = {
       apiKey: "15eb9c9f6f3147b1cf82b1b7f93cace8",
       indexName: "moderne",
       // Search filtering is handled by SearchFacetTabs (src/theme/SearchBar)
+      insights: true,
+      searchParameters: {
+        clickAnalytics: true,
+      },
     },
     announcementBar: {
       id: "code_remix_26",

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -206,7 +206,6 @@ const config: Config = {
       apiKey: "15eb9c9f6f3147b1cf82b1b7f93cace8",
       indexName: "moderne",
       // Search filtering is handled by SearchFacetTabs (src/theme/SearchBar)
-      insights: true,
       searchParameters: {
         clickAnalytics: true,
       },


### PR DESCRIPTION
## Summary

* Removes `insights: true` from the Algolia config to fix an uncaught `TypeError` that occurred on every search result click
* Keeps `clickAnalytics: true` in `searchParameters` so Algolia still returns `queryID` in search responses

## Root cause

DocSearch v4 does not attach `__autocomplete_algoliaCredentials` to hit objects. The `insights: true` option auto-loads `search-insights` v2.15.0 from CDN, which is a "modern" client that expects those credentials on each hit before firing `clickedObjectIDsAfterSearch`. When they're absent the call crashes:

```
Uncaught TypeError: can't access property "appId", u is undefined
    clickedObjectIDsAfterSearch ...
```

This is a DocSearch v4 bug. Removing `insights: true` avoids the crash until upstream fixes it.

## Test plan

* [ ] Perform a search and click a result — confirm no `TypeError` in the console
* [ ] Confirm Algolia Analytics dashboard still shows search query data