### PR TITLE
Fix Algolia click analytics crashing and events not firing

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -31,6 +31,7 @@ const config: Config = {
   clientModules: [
     require.resolve('./src/client/gtagGuard.js'),
     require.resolve('./src/client/loadNeoDesign.js'),
+    require.resolve('./src/client/algoliaInsights.js'),
   ],
 
   headTags: [
@@ -206,6 +207,7 @@ const config: Config = {
       apiKey: "15eb9c9f6f3147b1cf82b1b7f93cace8",
       indexName: "moderne",
       // Search filtering is handled by SearchFacetTabs (src/theme/SearchBar)
+      insights: true,
       searchParameters: {
         clickAnalytics: true,
       },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-medium-image-zoom": "^5.2.10",
-    "react-player": "^2.16.0"
+    "react-player": "^2.16.0",
+    "search-insights": "2.17.3"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^3.10.1",

--- a/src/client/algoliaInsights.js
+++ b/src/client/algoliaInsights.js
@@ -1,0 +1,11 @@
+import aa from 'search-insights';
+
+// Pre-initialize the Algolia Insights client so it is bundled and available
+// synchronously. Without this, DocSearch loads search-insights from CDN
+// asynchronously, which causes click events to be queued but never flushed
+// before page navigation.
+aa('init', {
+  appId: 'MEFFK0HGO6',
+  apiKey: '15eb9c9f6f3147b1cf82b1b7f93cace8',
+  useCookie: true,
+});

--- a/src/theme/SearchBar/index.tsx
+++ b/src/theme/SearchBar/index.tsx
@@ -118,13 +118,40 @@ function useNavigator({
 function useTransformSearchClient(): DocSearchModalProps['transformSearchClient'] {
   const {
     siteMetadata: {docusaurusVersion},
+    siteConfig: {themeConfig},
   } = useDocusaurusContext();
+  const {appId, apiKey} = themeConfig.algolia as {appId: string; apiKey: string};
+
   return useCallback(
     (searchClient: DocSearchTransformClient) => {
       searchClient.addAlgoliaAgent('docusaurus', docusaurusVersion);
+
+      // DocSearch v4.6.3 doesn't attach __autocomplete_algoliaCredentials,
+      // __autocomplete_queryID, or __autocomplete_indexName to hits, which
+      // causes the insights plugin to crash on click. This is fixed in the
+      // DocSearch main branch but not yet released. Backport the fix here
+      // and remove once @docsearch/react > 4.6.3 ships.
+      const originalSearch = (
+        searchClient as unknown as {search: (...args: unknown[]) => Promise<{results: unknown[]}>}
+      ).search.bind(searchClient);
+      (searchClient as unknown as {search: unknown}).search = async function (...args: unknown[]) {
+        const response = await originalSearch(...args);
+        response?.results?.forEach((result: unknown) => {
+          const r = result as {queryID?: string; index?: string; hits?: Record<string, unknown>[]};
+          if (r?.queryID && Array.isArray(r.hits)) {
+            r.hits.forEach((hit) => {
+              hit.__autocomplete_queryID = r.queryID;
+              hit.__autocomplete_indexName = r.index;
+              hit.__autocomplete_algoliaCredentials = {appId, apiKey};
+            });
+          }
+        });
+        return response;
+      };
+
       return searchClient;
     },
-    [docusaurusVersion],
+    [docusaurusVersion, appId, apiKey],
   );
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12066,6 +12066,11 @@ schema-utils@^4.2.0, schema-utils@^4.3.0, schema-utils@^4.3.3:
     ajv-formats "^2.1.1"
     ajv-keywords "^5.1.0"
 
+search-insights@2.17.3:
+  version "2.17.3"
+  resolved "https://registry.yarnpkg.com/search-insights/-/search-insights-2.17.3.tgz#8faea5d20507bf348caba0724e5386862847b661"
+  integrity sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==
+
 section-matter@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz"


### PR DESCRIPTION
## Summary

- **Root cause**: DocSearch v4.6.3 doesn't attach `__autocomplete_algoliaCredentials`, `__autocomplete_queryID`, or `__autocomplete_indexName` to search hits. The bundled `search-insights` v2.x is a "modern" client that expects credentials on each hit, causing a `TypeError: can't access property 'appId'` crash on every search result click.
- **Secondary issue**: With `insights: true`, DocSearch loads `search-insights` from CDN via a dynamic `<script>` tag. Click events fire and are queued in a stub, but page navigation happens before the CDN script loads and processes the queue — events are silently lost.
- **Fix**: Backport the unreleased DocSearch fix in `useTransformSearchClient` (attaches the 3 missing properties to hits after search), install `search-insights@2.17.3` as a proper bundled dependency, and pre-initialize the insights client in a `clientModule` so `window.aa` is synchronously ready.

## Changes

* `src/theme/SearchBar/index.tsx` — patch `useTransformSearchClient` to attach `__autocomplete_algoliaCredentials`, `__autocomplete_queryID`, `__autocomplete_indexName` to hits (backport of unreleased DocSearch fix; remove once `@docsearch/react > 4.6.3` ships)
* `src/client/algoliaInsights.js` — new client module that pre-initializes `search-insights` synchronously before DocSearch loads
* `docusaurus.config.ts` — register `algoliaInsights.js` as a client module; re-enable `insights: true` now that the crash is fixed
* `package.json` + `yarn.lock` — add `search-insights@2.17.3` as a direct dependency

## Test plan

* Locally tested with Chrome MCP: searched "recipe", clicked first result, confirmed two `sendBeacon` calls to `insights.algolia.io` fired successfully with no console errors
* No TypeError in the console (previously crashed on every click)