### PR TITLE
Document ${extension} placeholder in distributionUrl

### DIFF
--- a/docs/user-documentation/moderne-cli/references/cli-4-0-0-changes.md
+++ b/docs/user-documentation/moderne-cli/references/cli-4-0-0-changes.md
@@ -195,12 +195,12 @@ Host the distribution files on an internal server and point `distributionUrl` in
 
 ```properties
 version=4.0.0
-distributionUrl=https://nexus.corp.example.com/repository/releases/moderne-cli-${platform}/${version}/moderne-cli-${platform}-${version}.sh
+distributionUrl=https://nexus.corp.example.com/repository/releases/moderne-cli-${platform}/${version}/moderne-cli-${platform}-${version}.${extension}
 distributionSha256Sum=abc123...
 jdkUrl=skip
 ```
 
-The wrapper will replace `${version}` and `${platform}` automatically. Platform values are `linux`, `osx`, or `windows`.
+The wrapper will replace `${version}`, `${platform}`, and `${extension}` automatically. Platform values are `linux`, `osx`, or `windows`. Extension values are `sh` on Linux and macOS and `zip` on Windows, so a single `distributionUrl` works for every platform sharing the properties file.
 
 Setting `jdkUrl=skip` tells the wrapper not to download a JDK on its own. In this case, you will need Java 25+ available via `MODERNE_JAVA_HOME` or your `PATH`.
 


### PR DESCRIPTION
## Summary

The CLI wrapper now expands `${extension}` (to `sh` on Linux/macOS, `zip` on Windows). Update the internal-mirror example so a single `distributionUrl` works for every platform sharing the same `moderne-wrapper.properties` file.

- Companion to moderneinc/moderne-cli#3854.

## Test plan

* [ ] `yarn start` — site builds with no broken links (small text-only edit, single existing section).