### PR TITLE
docs: compress advanced workshop to ~2 hour scope

### DIFF
--- a/docs/hands-on-learning/advanced/module-1-recipe-development-environment.md
+++ b/docs/hands-on-learning/advanced/module-1-recipe-development-environment.md
@@ -5,47 +5,40 @@ description: Set up your environment and debug recipes with the Moderne plugin a
 
 # Module 1: Recipe development environment and debugging
 
-This module introduces the primary tools you'll use to author, run, and debug advanced OpenRewrite recipes. You'll explore the Moderne IntelliJ plugin's capabilities and learn how to debug recipes using both IDE-based tests and CLI runs.
-
-We’ll build on what you may have seen in the fundamentals course and take a deeper dive into real-world development and troubleshooting workflows.
+This module takes a deeper dive into the tools you'll use to author, run, and debug advanced OpenRewrite recipes. You'll explore the Moderne IntelliJ plugin's multi-repository search and recipe generation, then learn how to debug recipes using both IDE breakpoints and CLI runs.
 
 :::info
-If you have not already run through [Fundamentals of recipe development](../fundamentals/workshop-overview.md), you will want to at least complete [Module 1: Recipe development environment](../fundamentals/module-1-recipe-development-environment.md) to validate your development environment and ensure you have all the necessary tools and setup to develop and run advanced OpenRewrite recipes. This includes making sure you have cloned the [`rewrite-recipe-starter` repository](https://github.com/moderneinc/rewrite-recipe-starter).)
+This module assumes you have already completed [Fundamentals Module 1: Recipe development environment](../fundamentals/module-1-recipe-development-environment.md). That module covers the environment setup this workshop depends on, including cloning the [`rewrite-recipe-starter` repository](https://github.com/moderneinc/rewrite-recipe-starter), installing the Moderne plugin and CLI, and running the starter's tests. Complete it first if you haven't, then return here.
 :::
 
 ## Exercise 1a: Using the Moderne plugin for IntelliJ
 
-Moderne offers an [IntelliJ IDEA plugin](https://plugins.jetbrains.com/plugin/17565-moderne) that can not only help you create and debug recipes, but can also assist with your general development experience by allowing you to easily search for code across all of your repositories at once.
+In this exercise, you'll use the [Moderne IntelliJ plugin](https://plugins.jetbrains.com/plugin/17565-moderne) to search across repositories for an API, generate a recipe from it, and run that recipe via the plugin and the CLI.
 
 ### Goals for this exercise
 
-* Install and configure the Moderne IntelliJ IDEA plugin.
+* Configure the Moderne plugin with repositories to search across.
 * Perform a type-aware search across all of your local repositories.
 * Create a simple search recipe.
 * Run the recipe with the Moderne plugin and the CLI.
 
 ### Steps
 
-1. If you haven't already installed and configured the Moderne IntelliJ IDEA plugin, follow along with our [Moderne plugin installation guide](../../user-documentation/moderne-ide-integration/how-to-guides/moderne-plugin-install.md)
-   * If you have many repositories checked out locally and want to search across those, please add the root directory as a `Multi-repo`.
-   * If you don't have many repositories checked out locally or would prefer to see what it looks like to add a Moderne organization, please select one of the Moderne organizations (such as `Default` or `Netflix`) in the `Multi-repos` section. 
+1. You should already have the Moderne IntelliJ IDEA plugin installed from [Fundamentals Module 1](../fundamentals/module-1-recipe-development-environment.md). (If not, install it now with the [Moderne plugin installation guide](../../user-documentation/moderne-ide-integration/how-to-guides/moderne-plugin-install.md).) Make sure the plugin has repositories to search across: either add a local root directory as a `Multi-repo`, or select a Moderne organization (such as `Default` or `Netflix`) in the `Multi-repos` section.
 2. Open any Java class in IntelliJ and look for an API that you're interested in searching for (e.g., `System.out.println(..)` or `ListUtils.map(..)`). Then, follow the instructions in our [multi-repository code search doc](../../user-documentation/moderne-ide-integration/how-to-guides/code-search.md) to look for that API across all of the repositories you added to the Moderne plugin.
 3. Next, let's create a simple search recipe that finds that API you searched for. Right-click on the API again and select `Refactor > Create OpenRewrite Recipe...`. Then select that you want to create a `Visitor Style` recipe.
    * For more details on creating recipes with the Moderne plugin, check out our [how to create recipes guide](../../user-documentation/moderne-ide-integration/how-to-guides/creating-recipes.md).
 4. You should now have a scratch file that contains a simple recipe. Copy it over to the `rewrite-recipe-starter` repository and add it to the `com.yourorg` package (or whatever you renamed your package to).
    * [Here's an example of what this might look like for finding System.out.println](https://gist.github.com/mike-solomon/3b49a5d19c8824776bcc4ee871b87cdd)
-5. There are two ways to run the recipe: from inside of IntelliJ or with the CLI. Let's start with running the recipe in IntelliJ against all of the repositories that you've specified in the Moderne plugin configuration.
-6. On the line where the class is defined, you should notice an arrow to the left of the text. Click it and then press `Run <class_name>`.
+5. To run the recipe inside IntelliJ, click the gutter arrow next to the class declaration and select `Run <class_name>`.
 
 <figure>
   ![IntelliJ gutter icon to run a recipe class from the Moderne plugin](./assets/run-recipe-from-plugin.gif)
   <figcaption></figcaption>
 </figure>
 
-7. The recipe will then begin running against all of the repositories you've specified. If any changes are made, you can find those in the `Changes` tab. If the recipe is a search recipe, you can find all search results in the `Find` tab.
-8. Next, let's try running the same recipe with the Moderne CLI. Right-click on the class name and select `Set Active Recipe`.
-9. Open your terminal, navigate to your workshop directory, and run the recipe: `mod run . --active-recipe`.
-10. You should see that this recipe ran and marked all the locations in all of the repositories that matched the API you generated the recipe from.
+6. The recipe runs against every repository you've configured in the plugin. Find code changes in the `Changes` tab and search results in the `Find` tab.
+7. You can also run this recipe from the Moderne CLI using the **Set Active Recipe** + `mod run . --active-recipe` workflow you used in [Fundamentals Module 1](../fundamentals/module-1-recipe-development-environment.md#step-4-install-and-verify-locally): right-click the class name, select **Set Active Recipe**, then run `mod run . --active-recipe` from your workshop directory.
 
 ### Takeaways
 
@@ -62,18 +55,12 @@ In this exercise, you’ll learn how to debug recipes using both IDE breakpoints
 * Debug recipes using the Moderne IntelliJ plugin.
 * Understand how to set breakpoints in a recipe class or visitor.
 * Use the `TreeVisitingPrinter` to see what an LST looks like.
-* Understand how to set breakpoints in a recipe class or visitor.
 
 ### Steps
 
-1. Follow [our guide for how to debug a recipe with the Moderne plugin](../../user-documentation/moderne-ide-integration/how-to-guides/debugging-recipes.md#step-4-debug-your-recipe).
-   * This will walk you through the necessary steps to set an active recipe, build LSTs to run it against, then run and debug your recipe.
-   * You will also see how to use the Moderne CLI to attach a remote debugger with `modw --debug run . --active-recipe`.
-2. Open a test case for a recipe (e.g., `FindSpringBeansTest`), set breakpoints inside the `visit()` method or relevant visitor logic.
-   * Run the test in debug mode (using the green bug icon in IntelliJ) and inspect the variables and visitor flow as you step through.
-3. Another useful thing to do when debugging is to [configure the TreeVisitingPrinter](https://docs.openrewrite.org/concepts-and-explanations/tree-visiting-printer). This will really help you understand the different [Java LST elements](https://docs.openrewrite.org/concepts-and-explanations/lst-examples).
-    * Follow along with the instructions in that guide and make sure you can see what the LST looks like when it finds a match.
-    * **Note**: you'll need to add `import org.openrewrite.java.TreeVisitingPrinter;` to your import statements in your recipe.
+1. Follow [our guide for how to debug a recipe with the Moderne plugin](../../user-documentation/moderne-ide-integration/how-to-guides/debugging-recipes.md#step-4-debug-your-recipe). It walks you through setting an active recipe, building LSTs, and debugging the recipe — including how to attach a remote debugger from the CLI with `modw --debug run . --active-recipe`.
+2. Open a test case (e.g., `FindSpringBeansTest`), set breakpoints inside `visit()` or the visitor logic, then run the test in debug mode (green bug icon in IntelliJ) and step through to inspect variables and visitor flow.
+3. [Configure the TreeVisitingPrinter](https://docs.openrewrite.org/concepts-and-explanations/tree-visiting-printer) to see what an LST looks like when your recipe finds a match — a great way to learn the different [Java LST elements](https://docs.openrewrite.org/concepts-and-explanations/lst-examples). You'll need to add `import org.openrewrite.java.TreeVisitingPrinter;` to your recipe's imports.
 
 ### Takeaways
 

--- a/docs/hands-on-learning/advanced/module-2-data-tables.md
+++ b/docs/hands-on-learning/advanced/module-2-data-tables.md
@@ -14,21 +14,13 @@ In this exercise, you’ll review the use of a data table to extract superclass 
 ### Goals for this exercise
 
 * See how to define and populate data tables in recipes.
-* Learn how to run and inspect data table output using the Moderne platform or CLI.
+* See how a data table's structure is defined and how its contents are verified in tests.
 
 ### Steps
 
-1. With the [`rewrite-recipe-starter`](https://github.com/moderneinc/rewrite-recipe-starter) still open in IntelliJ, open the `ClassHierarchy` recipe.
-   * You can find this recipe in [src/main/java/com/yourorg/ClassHierarchy.java](https://github.com/moderneinc/rewrite-recipe-starter/blob/main/src/main/java/com/yourorg/ClassHierarchy.java).
-2. Review the `ClassHierarchy` recipe to see how data tables are defined and populated.
-   * Notice there is a `ClassHierarchyReport` member and that the `.insertRow(...)` method is called against it in the visitor.
-   * This member is marked as `transient` to make sure it does not get serialized since it is only needed at runtime.
-3. Now open [src/main/java/com/yourorg/table/ClassHierarchyReport.java](https://github.com/moderneinc/rewrite-recipe-starter/blob/main/src/main/java/com/yourorg/table/ClassHierarchyReport.java).
-   * This is where the structure of the data table is defined. You can see that there is a `displayName` and `description` for each field, as well as a type.
-   * In this case, there is also an `enum` defined. This can be a useful way to add more semantic meaning to the data instead of using arbitrary strings.
-4. Now open the unit tests for `ClassHierarchy`.
-   * You can find them in [src/test/java/com/yourorg/ClassHierarchyTest.java](https://github.com/moderneinc/rewrite-recipe-starter/blob/main/src/test/java/com/yourorg/ClassHierarchyTest.java).
-   * You will also see that a `RecipeSpec` is provided using `assertThat(rows).containsExactly(...)` to test whether a data table is there and if it has the expected data or not.
+1. In the `rewrite-recipe-starter` project, open [`ClassHierarchy.java`](https://github.com/moderneinc/rewrite-recipe-starter/blob/main/src/main/java/com/yourorg/ClassHierarchy.java) and note the `transient ClassHierarchyReport` member and the `.insertRow(...)` call in the visitor. (It is `transient` so it is not serialized, since it is only needed at runtime.)
+2. Open [`table/ClassHierarchyReport.java`](https://github.com/moderneinc/rewrite-recipe-starter/blob/main/src/main/java/com/yourorg/table/ClassHierarchyReport.java) to see how the data table is defined: each column has a `displayName`, `description`, and type, and an `enum` is used to give the data more semantic meaning than arbitrary strings.
+3. Open [`ClassHierarchyTest.java`](https://github.com/moderneinc/rewrite-recipe-starter/blob/main/src/test/java/com/yourorg/ClassHierarchyTest.java) and note how a `RecipeSpec` with `assertThat(rows).containsExactly(...)` verifies the data table contents.
 
 ### Takeaways
 
@@ -48,21 +40,13 @@ In this exercise, you'll write a recipe to find any comments in Java source file
 
 ### Steps
 
-1. Open the unit test [src/test/java/com/yourorg/TrackJavaTodosTest.java](https://github.com/moderneinc/rewrite-recipe-starter/blob/main/src/test/java/com/yourorg/TrackJavaTodosTest.java) again.
-   * Notice the code at the top of the test. These lines test for the presence of the expected data tables.
-   * Remove the `@Disabled` annotations, and run the tests to see that it fails with an error that the expected data table is missing. You will need to add a data table that allows these tests to pass.
-2. Now open [src/main/java/com/yourorg/table/TodoCommentsReport.java](https://github.com/moderneinc/rewrite-recipe-starter/blob/main/src/test/java/com/yourorg/table/TodoCommentsReport.java).
-   * This code has been provided for you. It defines the fields for the data table that you will need to populate in the next step.
-   * All of the members are type `String`, and the `sourcePath` one is identical to the example above.
-3. Now open [src/main/java/com/yourorg/TrackJavaTodos.java](https://github.com/moderneinc/rewrite-recipe-starter/blob/main/src/main/java/com/yourorg/TrackJavaTodos.java) again.
-   * Using the knowledge gained in Exercise 2a, add the necessary `.insertRow(...)` statements to populate the data table.
-   * Use the example from Exercise 2a to help you populate `sourcePath`.
-   * If you are having trouble with where to find the data for `elementType`, use `System.out.println()` or the debugger to find the right method that matches what the tests show.
-      * Hint: Look at the `.getTree().getClass()` method.
-4. Build your project and run the tests.
-   * All tests should pass, and you should see a message that the project was successfully built.
-   * If one or more of the tests fail, use the description of the failure to try to find where the problem is.
-5. In case you get completely stuck or just need a reference, [here's an example of a completed `TrackJavaTodos.java` file](https://github.com/moderneinc/rewrite-recipe-starter/blob/workshop-solutions/src/main/java/com/yourorg/TrackJavaTodos.java).
+1. Open the unit test [`TrackJavaTodosTest.java`](https://github.com/moderneinc/rewrite-recipe-starter/blob/main/src/test/java/com/yourorg/TrackJavaTodosTest.java). The lines at the top test for the presence of the expected data table. Remove the `@Disabled` annotations and run the tests — they fail because the data table is missing.
+2. Open [`table/TodoCommentsReport.java`](https://github.com/moderneinc/rewrite-recipe-starter/blob/main/src/main/java/com/yourorg/table/TodoCommentsReport.java). This is provided for you and defines the data table fields you will populate. All members are `String`, and `sourcePath` is identical to the `ClassHierarchy` example.
+3. Open [`TrackJavaTodos.java`](https://github.com/moderneinc/rewrite-recipe-starter/blob/main/src/main/java/com/yourorg/TrackJavaTodos.java) and, using what you saw in Exercise 2a, add the `.insertRow(...)` statements to populate the data table.
+   * Populate `sourcePath` the same way as the `ClassHierarchy` example.
+   * For `elementType`, use `System.out.println()` or the debugger to find the right method. Hint: look at `.getTree().getClass()`.
+4. Build your project and run the tests. They should all pass. If any fail, use the failure description to locate the problem.
+5. If you get stuck, see the [completed `TrackJavaTodos.java`](https://github.com/moderneinc/rewrite-recipe-starter/blob/workshop-solutions/src/main/java/com/yourorg/TrackJavaTodos.java) for reference.
 
 ### Takeaways
 

--- a/docs/hands-on-learning/advanced/module-3-scanning-recipes.md
+++ b/docs/hands-on-learning/advanced/module-3-scanning-recipes.md
@@ -11,7 +11,7 @@ Before moving on to the following exercise, you should review the [OpenRewrite d
 
 ## Exercise 3a: Explore a scanning recipe
 
-In this exercise, you'll explore the [`AppendToReleaseNotes`](https://github.com/moderneinc/rewrite-recipe-starter/blob/main/src/main/java/com/yourorg/AppendToReleaseNotes.java) recipe. This is a scanning recipe that appends release notes to a file based on a marker found elsewhere in the project. 
+In this exercise, you'll explore the [`AppendToReleaseNotes`](https://github.com/moderneinc/rewrite-recipe-starter/blob/main/src/main/java/com/yourorg/AppendToReleaseNotes.java) recipe. This is a scanning recipe that appends release notes to a file based on a marker found elsewhere in the project.
 
 ### Goals for this exercise
 
@@ -21,18 +21,10 @@ In this exercise, you'll explore the [`AppendToReleaseNotes`](https://github.com
 
 ### Steps
 
-1. With the [`rewrite-recipe-starter`](https://github.com/moderneinc/rewrite-recipe-starter) still open in IntelliJ, open the `AppendToReleaseNotes` recipe.
-   * You can find this recipe in [src/main/java/com/yourorg/AppendToReleaseNotes.java](https://github.com/moderneinc/rewrite-recipe-starter/blob/main/src/main/java/com/yourorg/AppendToReleaseNotes.java).
-2. Review the `AppendToReleaseNotes` recipe and notice the differences from recipes you may have seen before.
-   * Note that it extends `ScanningRecipe` rather than just `Recipe`, and that there is an `Accumulator` member defined to keep track of the data needed by the visitor.
-   * Also, in addition to the `getVisitor()` method, there are three additional overrides: `generate()` and `getScanner()`. All three methods also define an `Accumulator` parameter. There is also an overridden `getInitialValue()` method that returns a new `Accumulator`.
-3. Now open the unit tests for `AppendToReleaseNotes`.
-   * You can find them in [src/test/java/com/yourorg/AppendToReleaseNotesTest.java](https://github.com/moderneinc/rewrite-recipe-starter/blob/main/src/test/java/com/yourorg/AppendToReleaseNotesTest.java).
-4. Review the unit tests to see some of the specifics about testing a scanning recipe.
-   * Notice how `@Test void createNewReleaseNotes() { ... }` uses `org.openrewrite.test.SourceSpecs.text(java.lang.String, java.lang.String, ...)` to provide a before and after text block, with the third parameter using `spec -> spec.path(Path.of("RELEASE.md")` to set the path where the source file either exists or should be created.
-   * The before text block is `doesNotExist()` to indicate that the file does not exist initially. Conversely, you can pass in `doesNotExist()` as the second argument to indicate that the file should be deleted.
+1. In the `rewrite-recipe-starter` project, open [`AppendToReleaseNotes.java`](https://github.com/moderneinc/rewrite-recipe-starter/blob/main/src/main/java/com/yourorg/AppendToReleaseNotes.java). Note that it extends `ScanningRecipe` rather than `Recipe`, has an `Accumulator` member to share state across phases, and overrides `getInitialValue()`, `getScanner()`, `generate()`, and `getVisitor()` (each passing the `Accumulator`).
+2. Open [`AppendToReleaseNotesTest.java`](https://github.com/moderneinc/rewrite-recipe-starter/blob/main/src/test/java/com/yourorg/AppendToReleaseNotesTest.java) and look at `createNewReleaseNotes()`. It uses `SourceSpecs.text(before, after, spec -> spec.path(Path.of("RELEASE.md")))` to set the file path, with `doesNotExist()` as the before block to indicate the file is created (pass it as the after block instead to indicate deletion).
 
-## Takeaways
+### Takeaways
 
 * Scanning recipes enable inspection and generation across multiple files.
 * A custom class can be used as an accumulator to allow state to be shared among the phases of a scanning recipe.
@@ -51,31 +43,16 @@ In this exercise, you'll write a scanning recipe to find any comments in Java so
 
 ### Steps
 
-1. Open the unit test [src/test/java/com/yourorg/TrackJavaTodosFileTest.java](https://github.com/moderneinc/rewrite-recipe-starter/blob/main/src/test/java/com/yourorg/TrackJavaTodosFileTest.java) in IntelliJ IDEA.
-   * Read through the tests, to get a feel for the cases you should cover.
-   * Remove the `@Disabled` annotations, and run the tests to see that it fails. 
-2. Now open the scanning recipe template [src/main/java/com/yourorg/TrackJavaTodosFile.java](https://github.com/moderneinc/rewrite-recipe-starter/blob/main/src/main/java/com/yourorg/TrackJavaTodosFile.java).
-   * Using the knowledge gained in Exercise 3a, and the requirements from the test, write a scanning recipe that collects all the `TODO` comments and copies them in to a file called `TODO.md`.   
-   * Note that it extends `ScanningRecipe` rather than just `Recipe`, and that there is an `Accumulator` member defined to keep track of the data needed by the visitor.
-   * You'll need to override three methods: `getVisitor()`, `generate()` and `getScanner()`. All three methods also define an accumulator parameter class called `TodoComments`. The accumulator and the `getInitialValue()` method have already been defined for you.
-   * In this case, the accumulator class (`TodoComments`) has members for both a `boolean` value to maintain whether the `TODO.md` file exists or not (similar to the previous exercise), as well as a list of strings to collect the comments that are found.
-   * There is also an option already to defined that allows you to pass in a `String` to use as the header for the markdown file.
-3. Add the necessary code inside `getScanner()` to traverse the necessary LST elements.
-   * You'll need to use two different visitors: `JavaIsoVisitor` to visit all the Java source files, and `TreeVisitor` to visit the markdown file that you will be writing the comments to.
-      * Since you can only return one visitor, you'll have to create an instance of one visitor type and then call `.visit(...)` on it from within the `visit(...)` method of the visitor that you will return.
-   * The visitor for the plain text will be similar to the previous exercise to check if the markdown file already exists.
-   * In the `JavaIsoVisitor`, you will be looking for any instances of a comment in the LST.
-      * The Java LST has a `Comment` element that can be of either type `TextComment` or `JavadocComment`. You can choose to handle both if you'd like, but for the purposes of this exercise, collecting `TextComment`s only is just fine.
-   * For every comment that you find, you'll want to store it in the list defined in your `TodoComments` accumulator class.
-4. Add code inside `generate()` to create the `TODO.md` file if it doesn't already exist.
-   * Use the `generate()` code from the `AppendToReleaseNotes` example in the previous exercise as a reference. This code will be extremely similar to that.
-5. Finally, write the code for the `getVisitor()` method to transform the collected comments to the markdown file.
-   * Again, this will be similar to the previous example since you are also writing to a plain text file.
-   * You can use the `.withText(...)` method to return a plain text file with a given `String`, but you'll need to build the `String` from the list of comments in your accumulator. It should contain the full contents of the markdown to write to the file.
-6. Build your project and run the tests.
-   * All tests should pass, and you should see a message that the project was successfully built.
-   * If one or more of the tests fail, use the description of the failure to try to find where the problem is.
-7. In case you get completely stuck or just need a reference, [here's an example of a completed `TrackJavaTodosFile.java` file](https://github.com/moderneinc/rewrite-recipe-starter/blob/workshop-solutions/src/main/java/com/yourorg/TrackJavaTodosFile.java).
+1. Open the unit test [`TrackJavaTodosFileTest.java`](https://github.com/moderneinc/rewrite-recipe-starter/blob/main/src/test/java/com/yourorg/TrackJavaTodosFileTest.java), read through the cases you need to cover, then remove the `@Disabled` annotations and run the tests to see them fail.
+2. Open the scanning recipe template [`TrackJavaTodosFile.java`](https://github.com/moderneinc/rewrite-recipe-starter/blob/main/src/main/java/com/yourorg/TrackJavaTodosFile.java). Using Exercise 3a and the test requirements, write a scanning recipe that collects all `TODO` comments into a file called `TODO.md`.
+   * You'll override `getScanner()`, `generate()`, and `getVisitor()`. The `TodoComments` accumulator and `getInitialValue()` are already defined for you. `TodoComments` has a `boolean` for whether `TODO.md` exists and a list of strings for the collected comments, plus an option for a `String` markdown header.
+3. In `getScanner()`, use two visitors: a `JavaIsoVisitor` to visit Java source files and a `TreeVisitor` for the markdown file. Since you can only return one visitor, create one and call `.visit(...)` on it from within the `visit(...)` of the visitor you return.
+   * The plain-text visitor checks whether `TODO.md` already exists (as in Exercise 3a).
+   * In the `JavaIsoVisitor`, look for `Comment` elements and store each match in the accumulator's list. A `Comment` is either a `TextComment` or `JavadocComment`; collecting only `TextComment`s is fine here.
+4. In `generate()`, create `TODO.md` if it doesn't already exist — this is nearly identical to the `AppendToReleaseNotes` `generate()` from Exercise 3a.
+5. In `getVisitor()`, write the collected comments to the markdown file. Use `.withText(...)` to return the plain-text file, building the full markdown `String` from the accumulator's list of comments.
+6. Build your project and run the tests. They should all pass. If any fail, use the failure description to locate the problem.
+7. If you get stuck, see the [completed `TrackJavaTodosFile.java`](https://github.com/moderneinc/rewrite-recipe-starter/blob/workshop-solutions/src/main/java/com/yourorg/TrackJavaTodosFile.java) for reference.
 
 ### Takeaways
 

--- a/docs/hands-on-learning/advanced/module-4-traits.md
+++ b/docs/hands-on-learning/advanced/module-4-traits.md
@@ -1,9 +1,13 @@
 ---
-sidebar_label: "Module 4: Traits"
+sidebar_label: "Bonus: Traits"
 description: How to use traits to match semantically related elements.
 ---
 
-# Module 4: Traits
+# Bonus module: Traits
+
+:::info
+This is an optional bonus module that builds directly on the scanning recipe you wrote in [Module 3](./module-3-scanning-recipes.md). Modules 1–3 cover the core advanced workshop content — complete those first, then come back here if you want to go further.
+:::
 
 Traits are a powerful abstraction that allow you to define higher-level semantic groupings in OpenRewrite’s LSTs (Lossless Syntax Trees). They let you build reusable logic for elements that are semantically similar but structurally different. Instead of embedding utility logic in unrelated classes or expanding the core LST APIs, traits act as opt-in behavior layers. This keeps your recipes modular, discoverable, and semantically rich.
 

--- a/docs/hands-on-learning/advanced/module-4-traits.md
+++ b/docs/hands-on-learning/advanced/module-4-traits.md
@@ -11,7 +11,7 @@ This is an optional bonus module that builds directly on the scanning recipe you
 
 Traits are a higher-level abstraction over OpenRewrite's LSTs (Lossless Semantic Trees) that let you build reusable logic for elements that are semantically similar but structurally different. Instead of embedding utility logic in unrelated classes or expanding the core LST APIs, traits act as opt-in behavior layers — keeping your recipes modular, discoverable, and semantically rich. For example, to operate on every class annotated with `@Bean` regardless of structure or placement, a trait can define a single matcher that groups them all together. You'll work through that example next.
 
-## Exercise 4a: Explore a recipe that uses Traits
+## Exercise A: Explore a recipe that uses Traits
 
 In this exercise, you'll use the `Annotated.Matcher` trait that the [`FindSpringBeans`](https://github.com/moderneinc/rewrite-recipe-starter/blob/main/src/main/java/com/yourorg/FindSpringBeans.java) recipe uses to identify classes annotated with `@Bean` and marks them using `SearchResult.found`.
 
@@ -32,7 +32,7 @@ In this exercise, you'll use the `Annotated.Matcher` trait that the [`FindSpring
 * Recipes that use traits can be more modular and maintainable.
 
 
-## Exercise 4b: Write a recipe using traits
+## Exercise B: Write a recipe using traits
 
 The Java-only `TODO` scanning recipe from [Module 3](./module-3-scanning-recipes.md) could be extended to handle XML and YAML by adding more visitors and matching rules, but a trait is a cleaner fit — it encapsulates the cross-language match logic in one reusable place. In this exercise, you'll write a `TodoComment` trait that matches `TODO` comments across Java, YAML, and XML, then build a recipe that uses it to collect those comments into a file and a data table.
 

--- a/docs/hands-on-learning/advanced/module-4-traits.md
+++ b/docs/hands-on-learning/advanced/module-4-traits.md
@@ -9,9 +9,7 @@ description: How to use traits to match semantically related elements.
 This is an optional bonus module that builds directly on the scanning recipe you wrote in [Module 3](./module-3-scanning-recipes.md). Modules 1–3 cover the core advanced workshop content — complete those first, then come back here if you want to go further.
 :::
 
-Traits are a powerful abstraction that allow you to define higher-level semantic groupings in OpenRewrite’s LSTs (Lossless Syntax Trees). They let you build reusable logic for elements that are semantically similar but structurally different. Instead of embedding utility logic in unrelated classes or expanding the core LST APIs, traits act as opt-in behavior layers. This keeps your recipes modular, discoverable, and semantically rich.
-
-For example, if you want to operate on all classes annotated with `@Bean`, regardless of their structure or placement, traits allow you to define a matcher that groups those together. You will look at this example in this module.
+Traits are a higher-level abstraction over OpenRewrite's LSTs (Lossless Semantic Trees) that let you build reusable logic for elements that are semantically similar but structurally different. Instead of embedding utility logic in unrelated classes or expanding the core LST APIs, traits act as opt-in behavior layers — keeping your recipes modular, discoverable, and semantically rich. For example, to operate on every class annotated with `@Bean` regardless of structure or placement, a trait can define a single matcher that groups them all together. You'll work through that example next.
 
 ## Exercise 4a: Explore a recipe that uses Traits
 
@@ -24,15 +22,8 @@ In this exercise, you'll use the `Annotated.Matcher` trait that the [`FindSpring
 
 ### Steps
 
-1. With the [`rewrite-recipe-starter`](https://github.com/moderneinc/rewrite-recipe-starter) still open in IntelliJ, open the `FindSpringBeans` recipe.
-   * You can find this recipe in [src/main/java/com/yourorg/FindSpringBeans.java](https://github.com/moderneinc/rewrite-recipe-starter/blob/main/src/main/java/com/yourorg/FindSpringBeans.java).
-2. Review the `FindSpringBeans` recipe and note the comments in the file that describe how traits are being used.
-   * Notice that the `getVisitor()` method returns an `Annotated.Matcher`. The `Annotated` trait provided by OpenRewrite allows for matching annotations or annotated elements. `SearchResult.found` is used to return a modified LST element with an added search result marker for matches. 
-   * Notice how a `SearchResult` is returned. This will add a special marker comment to the code. This code also uses a data table to store the matches that it finds.
-3. Now open the unit tests for `FindSpringBeans`.
-   * You can find them in [src/test/java/com/yourorg/FindSpringBeansTest.java](https://github.com/moderneinc/rewrite-recipe-starter/blob/main/src/test/java/com/yourorg/FindSpringBeansTest.java).
-   * See what the special comments that the `SearchResult` add look like in the expected after code: `/*~~(bean)~~>*/`.
-   * You will also see an additional `RecipeSpec` provided with an `assertThat` statement. This is testing for the presence of the expected data table. You will learn more about how to test data tables in the next module.
+1. In the `rewrite-recipe-starter` project, open [`FindSpringBeans.java`](https://github.com/moderneinc/rewrite-recipe-starter/blob/main/src/main/java/com/yourorg/FindSpringBeans.java) and read the comments describing how traits are used. Note that `getVisitor()` returns an `Annotated.Matcher` (OpenRewrite's `Annotated` trait matches annotations and annotated elements) and `SearchResult.found` is used to mark matches and write them to a data table.
+2. Open [`FindSpringBeansTest.java`](https://github.com/moderneinc/rewrite-recipe-starter/blob/main/src/test/java/com/yourorg/FindSpringBeansTest.java) and note the `SearchResult` marker syntax in the expected after-blocks (`/*~~(bean)~~>*/`), plus the `RecipeSpec` `assertThat` that verifies the data table contents (data tables are covered in [Module 2](./module-2-data-tables.md)).
 
 ### Takeaways
 
@@ -43,9 +34,7 @@ In this exercise, you'll use the `Annotated.Matcher` trait that the [`FindSpring
 
 ## Exercise 4b: Write a recipe using traits
 
-In the last exercise, you wrote a scanning recipe to track `TODO` comments in Java source files. What if you wanted to find these comments across not only Java, but also any XML and YAML files in your projects? It is possible to write different matching rules and then just expand your scanner and visitor methods to use those as they navigate the XML and YAML LSTs to find the comments. However, this is a good example of where using a trait can help simplify the recipe code and also create an opportunity for reuse in similar use cases.
-
-In this exercise, you will write the code for a `TodoComment` trait that defines how to match `TODO` comments across Java, YAML, and XML source files. Then you will write a recipe that builds upon your Java-only recipe but instead uses this new trait to collect the comments from across all three different file types and capture it both in a file and a data table.
+The Java-only `TODO` scanning recipe from [Module 3](./module-3-scanning-recipes.md) could be extended to handle XML and YAML by adding more visitors and matching rules, but a trait is a cleaner fit — it encapsulates the cross-language match logic in one reusable place. In this exercise, you'll write a `TodoComment` trait that matches `TODO` comments across Java, YAML, and XML, then build a recipe that uses it to collect those comments into a file and a data table.
 
 ### Goals for this exercise
 
@@ -55,28 +44,15 @@ In this exercise, you will write the code for a `TodoComment` trait that defines
 
 ### Steps
 
-1. Open the unit test [src/test/java/com/yourorg/TrackTodosTest.java](https://github.com/moderneinc/rewrite-recipe-starter/blob/main/src/test/java/com/yourorg/TrackTodosTest.java) in IntelliJ IDEA.
-   * The first two tests should look familiar since they are the same as the tests from your exercise in the last modules.
-   * Read through the additional tests, to get a feel for the new cases that need to be covered.
-   * Notice how the `SourceSpecs` specify what kind of file is being tested (`java`, `yaml`, or `xml`).
-   * Remove the `@Disabled` annotations, and run the tests to see that they fail. 
-2. Now open the [src/main/java/com/yourorg/trait/TodoComment.java](https://github.com/moderneinc/rewrite-recipe-starter/blob/main/src/main/java/com/yourorg/trait/TodoComment.java) file.
-   * You will see some of the code has been started for you. The `TodoComment` class implements a `Trait` with `cursor` and `todos` members to use while searching for values in the `Matcher` class that extends `SimpleTraitMatcher`.
-   * The `test(Cursor cursor)` method has been overridden and partially filled in to help get you started. It starts by getting the value of the cursor that is passed in and then checking to see what type the value is to determine how you will need to match a comment depending on what kind of file it is.
-3. Fill in the code for each section to match a `TODO` comment similarly to how you did in the last module, but for each different file type.
-   * For the Java type, you can borrow some code from `JavaIsoVisitor` in the `getScanner(...)` method from `TrackJavaTodosFile.java` that you wrote in the last module.  
-   * For the Xml and Yaml types, you'll have to explore the LST model a bit to determine how to match a comment.
-      * The debugger or `TreeVisitingPrinter()` you learned about in the first module will help you understand more about the different LST models.
-      * Hint: For Yaml, take a look at the `getPrefix(...)` method. For Xml, look at the `getMisc()` method in `Xml.Prolog` and the `getContent()` method in `Xml.Tag`.     
-4. Now open the recipe template [src/main/java/com/yourorg/TrackTodos.java](https://github.com/moderneinc/rewrite-recipe-starter/blob/main/src/main/java/com/yourorg/TrackTodos.java).
-   * Using the knowledge gained in Exercise 4a, and the requirements from the new tests, write a new version of a scanning recipe that collects all the `TODO` comments from all Java, XML, and YAML files and copies them in to the `TODO.md` file. For each comment found, also add it to a data table similarly to how you did in Module 2.
-   * The code for the `getScanner()` method should be a lot simpler since you won't need to use two visitor types.
-   * You'll still have similar code for handling the `TODO.md` file, but now instead of using two visitors to traverse both Java and text files, you can use a single `TreeVisitor` that uses `TodoComment.Matcher()` to match `TODO` comments regardless of what kind the file type (as long as it's Java, XML, or YAML).
-   * Your `generate()` method will be the same as in your `TrackJavaTodosFile.java` file from the last module. Even `getVisitor()` should be almost identical. (The only difference is that you'll have a little bit of extra work to unravel your list of comments since it will now be a list of lists.)
-5. Build your project and run the tests.
-   * All tests should pass, and you should see a message that the project was successfully built.
-   * If one or more of the tests fail, use the description of the failure to try to find where the problem is.
-6. In case you get completely stuck or just need a reference, here's an example of a [completed `TrackTodos.java` file](https://github.com/moderneinc/rewrite-recipe-starter/blob/workshop-solutions/src/main/java/com/yourorg/TrackTodos.java), and a [completed `TodoComment.java` traits file](https://github.com/moderneinc/rewrite-recipe-starter/blob/workshop-solutions/src/main/java/com/yourorg/trait/TodoComment.java).
+1. Open the unit test [`TrackTodosTest.java`](https://github.com/moderneinc/rewrite-recipe-starter/blob/main/src/test/java/com/yourorg/TrackTodosTest.java). The first two tests should look familiar from Module 3; the additional tests cover XML and YAML cases, and the `SourceSpecs` indicate which file type (`java`, `yaml`, or `xml`) is being tested. Remove the `@Disabled` annotations and run the tests — they fail.
+2. Open [`trait/TodoComment.java`](https://github.com/moderneinc/rewrite-recipe-starter/blob/main/src/main/java/com/yourorg/trait/TodoComment.java) — a `Trait` with `cursor` and `todos` members and a nested `Matcher` extending `SimpleTraitMatcher`. The `test(Cursor cursor)` method is partially filled in: it reads the cursor's value and branches on its LST type to decide how to match a comment.
+3. Fill in each section to match `TODO` comments for that file type. For Java, you can borrow the `JavaIsoVisitor` logic from `TrackJavaTodosFile.getScanner(...)` (Module 3). For XML and YAML, explore the LST model with the debugger or `TreeVisitingPrinter` from Module 1.
+   * Hint: For YAML, look at `getPrefix(...)`. For XML, look at `Xml.Prolog.getMisc()` and `Xml.Tag.getContent()`.
+4. Open the recipe template [`TrackTodos.java`](https://github.com/moderneinc/rewrite-recipe-starter/blob/main/src/main/java/com/yourorg/TrackTodos.java) and write a scanning recipe that collects `TODO` comments from Java, XML, and YAML files into `TODO.md` and also records each comment in a data table (as in [Module 2](./module-2-data-tables.md)).
+   * `getScanner()` is simpler than in Module 3: a single `TreeVisitor` using `TodoComment.Matcher()` handles all three file types, so you no longer need two visitor types.
+   * `generate()` is identical to `TrackJavaTodosFile.generate()` from Module 3, and `getVisitor()` is nearly identical — you'll just need to flatten what is now a list of lists of comments.
+5. Build your project and run the tests. They should all pass. If any fail, use the failure description to locate the problem.
+6. If you get stuck, see the completed [`TrackTodos.java`](https://github.com/moderneinc/rewrite-recipe-starter/blob/workshop-solutions/src/main/java/com/yourorg/TrackTodos.java) and [`TodoComment.java`](https://github.com/moderneinc/rewrite-recipe-starter/blob/workshop-solutions/src/main/java/com/yourorg/trait/TodoComment.java) for reference.
 
 ### Takeaways
 

--- a/docs/hands-on-learning/advanced/workshop-overview.md
+++ b/docs/hands-on-learning/advanced/workshop-overview.md
@@ -7,7 +7,7 @@ description: A high-level overview of what this workshop will entail.
 
 This workshop builds on the foundations covered in the [Fundamentals of OpenRewrite recipe development](../fundamentals/workshop-overview.md) workshop and focuses on deeper, more powerful features of the OpenRewrite and Moderne ecosystem.
 
-You will gain experience with advanced recipe development tooling, understand how to extract insights using data tables, write scanning recipes that reason across multiple files, use traits for abstraction and generalization, and compose powerful imperative workflows that combine existing recipes and generate new code. This workshop is designed to be hands-on, so you can follow along with the examples in your own environment. The workshop consists of a series of modules that highlight key concepts, each with one or more exercises to help you practice what you've learned.
+You will gain experience with advanced recipe development tooling, learn to debug recipes with the IntelliJ plugin and CLI, understand how to extract insights using data tables, and write scanning recipes that reason across multiple files. This workshop is designed to be hands-on, so you can follow along with the examples in your own environment. The workshop consists of a series of modules that highlight key concepts, each with one or more exercises to help you practice what you've learned.
 
 Be sure to also follow the links to the [OpenRewrite documentation](https://docs.openrewrite.org/) for more in-depth information. Feel free to skip around to the sections that interest you most, based on your needs and experience level.
 
@@ -15,12 +15,10 @@ If you get stuck or have questions, feel free to ask in the [OpenRewrite Slack](
 
 ## What you'll learn
 
-* How to set up and optimize your development environment for recipe authoring
 * Debugging techniques using both the CLI and the IntelliJ plugin
-* How to build scanning recipes that analyze multiple files across a codebase
-* Using traits to model higher-level abstractions in recipes
 * Writing and analyzing data tables to extract insights from source code
-* Generating code and composing imperative workflows from existing recipes
+* How to build scanning recipes that analyze and generate files across a codebase
+* Using traits to model higher-level abstractions in recipes (covered in the optional bonus module)
 
 ## Prerequisites
 
@@ -31,3 +29,10 @@ To get the most out of this workshop, you should be comfortable with:
 * Java and build tools like Maven or Gradle
 
 If you haven’t been through the [Fundamentals of OpenRewrite recipe development](../fundamentals/workshop-overview.md) workshop yet, we recommend completing it first before returning here.
+
+## Workshop modules
+
+1. [Module 1: Development environment and debugging](./module-1-recipe-development-environment.md)
+2. [Module 2: Data tables](./module-2-data-tables.md)
+3. [Module 3: Scanning recipes](./module-3-scanning-recipes.md)
+4. [Bonus: Traits](./module-4-traits.md) — an optional deeper dive that builds on Module 3


### PR DESCRIPTION
We have a 2-hour version of the advanced recipe course scheduled for June, so this tightens the advanced recipe development workshop so the core (Modules 1–3) fits a ~2 hour scope while still reading naturally for self-paced doc visitors. No time durations were added to the docs themselves; the 2-hour framing stays a delivery concern.

I compressed the steps to be less verbose, removed redundancies in Module 1, and made Module 4 Traits optional:

## Changes

* **Module 1** — Keep standalone but defer environment setup to Fundamentals Module 1 (cloning the starter, installing the plugin/CLI, running tests). Collapse the redundant CLI `--active-recipe` re-teach into a single linked step. Tighten the plugin search/generate flow and fold debugging sub-bullets into their parent steps. Dedupe a goal bullet and fix a stray typo in the info callout.
* **Module 2** — Heavily trim the guided explore exercise (2a) and tighten the write-your-own (2b). Fix a wrong `src/test/java` path in the `TodoCommentsReport` link.
* **Module 3** — Heavily trim 3a and tighten 3b. Fix the garbled "three overrides: `generate()` and `getScanner()`" description (was three overrides but listed two) and normalize a heading-level inconsistency.
* **Module 4 (Traits)** — Reframed as an optional bonus that builds on Module 3. Sidebar label, H1, and info callout updated. **Content preserved and URL unchanged**, so inbound links stay stable.
* **Workshop overview** — Rewrote the scope paragraph and "What you'll learn" to match the actual modules (dropped the inaccurate "imperative workflows" bullet that had no module behind it). Added a Workshop modules list consistent with the Fundamentals overview.

## Validation

* `yarn build` passes locally with no errors and no broken links.