### PR TITLE
Fix admonition titles

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -553,7 +553,9 @@ html[data-theme='dark'] .markdown :not(pre) > code {
   color: var(--neo-grey-100);
 }
 
-/* Replit-style admonitions: rounded, subtle border, icon inline with text */
+/* Replit-style admonitions: rounded, subtle border, icon inline with text.
+   When a title is present (`:::info[My title]`), the container stacks vertically
+   so the heading row sits above the content. */
 .theme-admonition {
   border: 1px solid;
   border-radius: var(--neo-border-radius-m);
@@ -566,15 +568,22 @@ html[data-theme='dark'] .markdown :not(pre) > code {
   margin-bottom: var(--neo-spacing_3);
 }
 
+.theme-admonition:has([class*='admonitionTitle_']) {
+  flex-direction: column;
+  gap: var(--neo-spacing_1_2);
+}
+
 .theme-admonition [class*='admonitionHeading_'] {
   margin: 0;
-  font-size: 0;
   line-height: 1;
   flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--neo-spacing_1);
+  text-transform: none;
 }
 
 .theme-admonition [class*='admonitionHeading_'] [class*='admonitionIcon_'] {
-  font-size: initial;
   margin-right: 0;
   display: inline-flex;
   align-items: center;
@@ -583,6 +592,13 @@ html[data-theme='dark'] .markdown :not(pre) > code {
 .theme-admonition [class*='admonitionHeading_'] [class*='admonitionIcon_'] svg {
   fill: none;
   stroke: currentColor;
+}
+
+.theme-admonition [class*='admonitionTitle_'] {
+  font-family: var(--neo-font-family-heading);
+  font-weight: var(--neo-font-weight-semi-bold);
+  font-size: var(--neo-font-size-h5);
+  line-height: 1.3;
 }
 
 .theme-admonition [class*='admonitionContent_'] {

--- a/src/theme/Admonition/Layout/index.tsx
+++ b/src/theme/Admonition/Layout/index.tsx
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, {type ReactNode} from 'react';
+import clsx from 'clsx';
+import {ThemeClassNames} from '@docusaurus/theme-common';
+
+import type {Props} from '@theme/Admonition/Layout';
+
+import styles from './styles.module.css';
+
+function AdmonitionContainer({
+  type,
+  className,
+  children,
+  id,
+}: Pick<Props, 'type' | 'className' | 'id'> & {children: ReactNode}) {
+  return (
+    <div
+      className={clsx(
+        ThemeClassNames.common.admonition,
+        ThemeClassNames.common.admonitionType(type),
+        styles.admonition,
+        className,
+      )}
+      id={id}>
+      {children}
+    </div>
+  );
+}
+
+function AdmonitionHeading({icon, title}: Pick<Props, 'icon' | 'title'>) {
+  return (
+    <div className={styles.admonitionHeading}>
+      <span className={styles.admonitionIcon}>{icon}</span>
+      {title ? <span className={styles.admonitionTitle}>{title}</span> : null}
+    </div>
+  );
+}
+
+function AdmonitionContent({children}: Pick<Props, 'children'>) {
+  return children ? (
+    <div className={styles.admonitionContent}>{children}</div>
+  ) : null;
+}
+
+export default function AdmonitionLayout(props: Props): ReactNode {
+  const {type, icon, title, children, className, id} = props;
+  return (
+    <AdmonitionContainer type={type} className={className} id={id}>
+      {title || icon ? <AdmonitionHeading title={title} icon={icon} /> : null}
+      <AdmonitionContent>{children}</AdmonitionContent>
+    </AdmonitionContainer>
+  );
+}

--- a/src/theme/Admonition/Layout/styles.module.css
+++ b/src/theme/Admonition/Layout/styles.module.css
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+.admonition {
+  margin-bottom: 1em;
+}
+
+.admonitionHeading {
+  font: var(--ifm-heading-font-weight) var(--ifm-h5-font-size) /
+    var(--ifm-heading-line-height) var(--ifm-heading-font-family);
+  text-transform: uppercase;
+}
+
+/* Heading alone without content (does not handle fragment content) */
+.admonitionHeading:not(:last-child) {
+  margin-bottom: 0.3rem;
+}
+
+.admonitionHeading code {
+  text-transform: none;
+}
+
+.admonitionIcon {
+  display: inline-block;
+  vertical-align: middle;
+  margin-right: 0.4em;
+}
+
+.admonitionIcon svg {
+  display: inline-block;
+  height: 1.6em;
+  width: 1.6em;
+  fill: var(--ifm-alert-foreground-color);
+}
+
+.admonitionTitle {
+  display: inline;
+}
+
+.admonitionContent > :last-child {
+  margin-bottom: 0;
+}

--- a/src/theme/Admonition/Type/Caution.tsx
+++ b/src/theme/Admonition/Type/Caution.tsx
@@ -8,7 +8,6 @@ const infimaClassName = 'alert alert--warning';
 
 const defaultProps = {
   icon: <TriangleAlert size={18} strokeWidth={2} />,
-  title: 'caution',
 };
 
 export default function AdmonitionTypeCaution(

--- a/src/theme/Admonition/Type/Danger.tsx
+++ b/src/theme/Admonition/Type/Danger.tsx
@@ -8,7 +8,6 @@ const infimaClassName = 'alert alert--danger';
 
 const defaultProps = {
   icon: <OctagonAlert size={18} strokeWidth={2} />,
-  title: 'danger',
 };
 
 export default function AdmonitionTypeDanger(

--- a/src/theme/Admonition/Type/Info.tsx
+++ b/src/theme/Admonition/Type/Info.tsx
@@ -8,7 +8,6 @@ const infimaClassName = 'alert alert--info';
 
 const defaultProps = {
   icon: <Info size={18} strokeWidth={2} />,
-  title: 'info',
 };
 
 export default function AdmonitionTypeInfo(

--- a/src/theme/Admonition/Type/Note.tsx
+++ b/src/theme/Admonition/Type/Note.tsx
@@ -8,7 +8,6 @@ const infimaClassName = 'alert alert--secondary';
 
 const defaultProps = {
   icon: <NotebookPen size={18} strokeWidth={2} />,
-  title: 'note',
 };
 
 export default function AdmonitionTypeNote(

--- a/src/theme/Admonition/Type/Tip.tsx
+++ b/src/theme/Admonition/Type/Tip.tsx
@@ -8,7 +8,6 @@ const infimaClassName = 'alert alert--success';
 
 const defaultProps = {
   icon: <Lightbulb size={18} strokeWidth={2} />,
-  title: 'tip',
 };
 
 export default function AdmonitionTypeTip(

--- a/src/theme/Admonition/Type/Warning.tsx
+++ b/src/theme/Admonition/Type/Warning.tsx
@@ -8,7 +8,6 @@ const infimaClassName = 'alert alert--warning';
 
 const defaultProps = {
   icon: <TriangleAlert size={18} strokeWidth={2} />,
-  title: 'warning',
 };
 
 export default function AdmonitionTypeWarning(


### PR DESCRIPTION
A previous design change removed the titles - but there were many cases where we relied on these titles for context. This adds them back - but removes the title text from some of the core ones to match that style.