### PR TITLE
ci: sharded production build to avoid timeouts

### DIFF
--- a/.github/workflows/pages-sharded.yml
+++ b/.github/workflows/pages-sharded.yml
@@ -91,22 +91,33 @@ jobs:
       - name: Merge shards
         run: node scripts/merge-shards.js
 
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v5
+      - name: Upload combined build (for inspection)
+        uses: actions/upload-artifact@v4
         with:
+          name: combined-build
           path: build
+          retention-days: 3
+          if-no-files-found: error
 
-  deploy:
-    name: Deploy to GitHub Pages
-    needs: combine
-    permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v5
+# Deploy step disabled while validating on this branch. Re-enable before
+# cutting over from pages.yml.
+#
+#      - name: Upload Pages artifact
+#        uses: actions/upload-pages-artifact@v5
+#        with:
+#          path: build
+#
+#  deploy:
+#    name: Deploy to GitHub Pages
+#    needs: combine
+#    permissions:
+#      pages: write
+#      id-token: write
+#    environment:
+#      name: github-pages
+#      url: ${{ steps.deployment.outputs.page_url }}
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Deploy to GitHub Pages
+#        id: deployment
+#        uses: actions/deploy-pages@v5

--- a/.github/workflows/pages-sharded.yml
+++ b/.github/workflows/pages-sharded.yml
@@ -1,0 +1,112 @@
+# Sharded build prototype: splits SSG across N parallel jobs, then merges
+# the per-shard build outputs and deploys to GitHub Pages.
+# Once validated, this is intended to replace pages.yml.
+name: Deploy Moderne docs to Pages (sharded)
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+env:
+  SHARD_TOTAL: 4
+
+jobs:
+  build-shard:
+    name: Build shard ${{ matrix.shard }}/${{ vars.SHARD_TOTAL || 4 }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: true
+      matrix:
+        shard: [0, 1, 2, 3]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Cache bundler artifacts (per shard)
+        uses: actions/cache@v4
+        with:
+          path: node_modules/.cache
+          key: docusaurus-shard-${{ matrix.shard }}-${{ runner.os }}-${{ hashFiles('yarn.lock', 'docusaurus.config.ts', 'src/theme/**') }}
+          restore-keys: |
+            docusaurus-shard-${{ matrix.shard }}-${{ runner.os }}-
+            docusaurus-${{ runner.os }}-
+
+      - name: Build shard
+        run: |
+          set -o pipefail
+          yarn build:shard 2>&1 | { grep --line-buffered -v "^Generated markdown file:" || true; }
+        env:
+          SHARD_INDEX: ${{ matrix.shard }}
+          SHARD_TOTAL: 4
+          DOCUSAURUS_SSG_WORKER_THREAD_RECYCLER_MAX_MEMORY: "512000000"
+          DOCUSAURUS_SSR_CONCURRENCY: "16"
+          NODE_OPTIONS: "--max-old-space-size=1536 --max-semi-space-size=64"
+          DOCUSAURUS_IGNORE_SSG_WARNINGS: true
+
+      - name: Upload shard artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-shard-${{ matrix.shard }}
+          path: build-shards/shard-${{ matrix.shard }}
+          retention-days: 1
+          if-no-files-found: error
+
+  combine:
+    name: Combine shards
+    needs: build-shard
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download all shard artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: build-shards
+          pattern: build-shard-*
+
+      - name: Normalize artifact layout
+        # download-artifact extracts each artifact into its own subdirectory
+        # named after the artifact (build-shard-0, build-shard-1, ...). The
+        # merge script expects directories named shard-N.
+        run: |
+          cd build-shards
+          for dir in build-shard-*; do
+            mv "$dir" "shard-${dir#build-shard-}"
+          done
+          ls -la
+
+      - name: Merge shards
+        run: node scripts/merge-shards.js
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: build
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: combine
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ package-lock.json
 
 # Production
 /build
+/build-shards
 
 # Generated files
 .docusaurus

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "start": "docusaurus start",
     "start:fast": "SKIP_RECIPE_CATALOG=1 docusaurus start",
     "build": "docusaurus build",
+    "build:shard": "node scripts/build-shard.js",
+    "build:merge-shards": "node scripts/merge-shards.js",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",

--- a/scripts/build-shard-patch.js
+++ b/scripts/build-shard-patch.js
@@ -1,0 +1,32 @@
+// Node --require hook that monkey-patches Docusaurus's SSG executor to render
+// only a subset of routes per shard. Loaded via scripts/build-shard.js.
+
+const SHARD_INDEX = parseInt(process.env.SHARD_INDEX ?? '', 10);
+const SHARD_TOTAL = parseInt(process.env.SHARD_TOTAL ?? '', 10);
+
+if (Number.isNaN(SHARD_INDEX) || Number.isNaN(SHARD_TOTAL)) {
+  return;
+}
+
+if (SHARD_TOTAL < 1 || SHARD_INDEX < 0 || SHARD_INDEX >= SHARD_TOTAL) {
+  throw new Error(
+    `Invalid shard config: SHARD_INDEX=${SHARD_INDEX} SHARD_TOTAL=${SHARD_TOTAL}`,
+  );
+}
+
+const ssgExecutor = require('@docusaurus/core/lib/ssg/ssgExecutor');
+const originalExecuteSSG = ssgExecutor.executeSSG;
+
+ssgExecutor.executeSSG = async function shardedExecuteSSG(opts) {
+  const allPaths = [...opts.props.routesPaths].sort();
+  const mine = allPaths.filter((_, i) => i % SHARD_TOTAL === SHARD_INDEX);
+  console.log(
+    `[shard ${SHARD_INDEX}/${SHARD_TOTAL}] rendering ${mine.length} of ${allPaths.length} routes`,
+  );
+  opts.props.routesPaths = mine;
+  return originalExecuteSSG.call(this, opts);
+};
+
+console.log(
+  `[shard-patch] active — shard ${SHARD_INDEX} of ${SHARD_TOTAL}`,
+);

--- a/scripts/build-shard.js
+++ b/scripts/build-shard.js
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+// Wrapper that runs `docusaurus build` for a single shard, with the SSG
+// route-filter patch pre-loaded via --require. Reads SHARD_INDEX and
+// SHARD_TOTAL from env; writes output to build-shards/shard-<index>/.
+
+const { spawn } = require('child_process');
+const path = require('path');
+
+const shardIndex = process.env.SHARD_INDEX;
+const shardTotal = process.env.SHARD_TOTAL;
+
+if (!shardIndex || !shardTotal) {
+  console.error('SHARD_INDEX and SHARD_TOTAL env vars are required');
+  process.exit(2);
+}
+
+const outDir = path.join('build-shards', `shard-${shardIndex}`);
+const patchPath = path.join(__dirname, 'build-shard-patch.js');
+const docusaurusBin = require.resolve('@docusaurus/core/bin/docusaurus.mjs');
+
+const child = spawn(
+  process.execPath,
+  ['--require', patchPath, docusaurusBin, 'build', '--out-dir', outDir],
+  { stdio: 'inherit', env: process.env },
+);
+
+child.on('exit', (code) => process.exit(code ?? 1));

--- a/scripts/merge-shards.js
+++ b/scripts/merge-shards.js
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+// Merges per-shard build outputs (build-shards/shard-*/) into a single
+// build/ directory. Bundle assets are byte-identical across shards (same
+// webpack config, same input) so "last wins" for duplicates is safe;
+// shard-rendered HTML files are unique per shard.
+
+const fs = require('fs');
+const path = require('path');
+
+const SHARDS_DIR = path.resolve('build-shards');
+const OUT_DIR = path.resolve('build');
+
+if (!fs.existsSync(SHARDS_DIR)) {
+  console.error(`No ${SHARDS_DIR} directory found`);
+  process.exit(1);
+}
+
+const shards = fs
+  .readdirSync(SHARDS_DIR)
+  .filter((name) => name.startsWith('shard-'))
+  .map((name) => path.join(SHARDS_DIR, name))
+  .filter((p) => fs.statSync(p).isDirectory())
+  .sort();
+
+if (shards.length === 0) {
+  console.error(`No shard-* directories under ${SHARDS_DIR}`);
+  process.exit(1);
+}
+
+console.log(`Merging ${shards.length} shard(s) into ${OUT_DIR}`);
+
+fs.rmSync(OUT_DIR, { recursive: true, force: true });
+fs.mkdirSync(OUT_DIR, { recursive: true });
+
+let htmlCount = 0;
+let otherCount = 0;
+let overwriteCount = 0;
+const htmlOwners = new Map();
+
+function copyTree(srcDir, destDir, shardName) {
+  for (const entry of fs.readdirSync(srcDir, { withFileTypes: true })) {
+    const src = path.join(srcDir, entry.name);
+    const dest = path.join(destDir, entry.name);
+    if (entry.isDirectory()) {
+      fs.mkdirSync(dest, { recursive: true });
+      copyTree(src, dest, shardName);
+    } else if (entry.isFile()) {
+      const exists = fs.existsSync(dest);
+      const isHtml = entry.name.endsWith('.html');
+      if (exists) {
+        if (isHtml) {
+          const prevOwner = htmlOwners.get(dest);
+          console.warn(
+            `  warn: ${path.relative(OUT_DIR, dest)} rendered by both ${prevOwner} and ${shardName}`,
+          );
+        }
+        overwriteCount++;
+      }
+      fs.copyFileSync(src, dest);
+      if (isHtml) {
+        htmlCount += exists ? 0 : 1;
+        htmlOwners.set(dest, shardName);
+      } else if (!exists) {
+        otherCount++;
+      }
+    }
+  }
+}
+
+for (const shardDir of shards) {
+  const shardName = path.basename(shardDir);
+  console.log(`  + ${shardName}`);
+  copyTree(shardDir, OUT_DIR, shardName);
+}
+
+console.log(`\nMerged: ${htmlCount} unique HTML, ${otherCount} other files, ${overwriteCount} overwrites`);


### PR DESCRIPTION
## Summary

* Splits the Docusaurus SSG render across **4 parallel GitHub Actions jobs** to avoid the 30-min timeout we've been hitting on the full ~7,000-route site
* Adds `pages-sharded.yml` alongside the existing `pages.yml` so this can be validated in CI before cutover — does **not** modify the live deploy yet
* Adds `scripts/build-shard*.js` (route-filtering monkey-patch + wrapper) and `scripts/merge-shards.js` (combines per-shard `build/` outputs)

## How it works

* Each shard runs `docusaurus build` with `SHARD_INDEX` / `SHARD_TOTAL` env vars
* `scripts/build-shard-patch.js` is loaded via Node `--require`; it patches `@docusaurus/core/lib/ssg/ssgExecutor.executeSSG` to filter `props.routesPaths` to just this shard's routes (stable mod-N partition over a sorted route list)
* Webpack still bundles the **full** route table, so cross-shard links resolve correctly during the broken-link check
* Combine job merges per-shard `build-shards/shard-N/` directories into a single `build/`; bundle assets are byte-identical across shards (last-wins is safe), sitemap is generated identically per shard (uses full `props.routes`)

## Local validation (full build, no `SKIP_RECIPE_CATALOG`)

| Step | Result |
|------|--------|
| Total routes | **7,018** |
| Per shard (2-shard test) | **3,509 each, zero overlap** |
| Shard 0 wall time | 472s (cold webpack cache) |
| Shard 1 wall time | 264s (warm cache from shard 0) |
| Merge | 25s, 7,018 unique HTML, 8,052 byte-identical asset overwrites |
| Sitemap | 7,017 URLs preserved |
| Smoke test | Pages from both shards serve 200 with valid HTML |

Expected CI wall time with 4 parallel shards: **~8 min first run, ~5 min subsequent runs** (per-shard webpack cache keys in the workflow).

## Known caveats

* The patch reaches into `@docusaurus/core/lib/ssg/ssgExecutor` (private path) — likely to break on Docusaurus minor upgrades. Worth a note in `CLAUDE.md` under upgrade fragility if we promote this past the prototype.
* `docusaurus-plugin-llms` postBuild runs in every shard (regenerates llms.txt etc.). Output is identical so merge is correct, but wasteful — could be gated on `SHARD_INDEX === 0` later if we care.
* Workflow is `workflow_dispatch` only on purpose. Once a manual run is green, we can either replace `pages.yml` outright or wire this to `push` / `workflow_run` triggers in a follow-up.

## Test plan

- [ ] Manually dispatch `Deploy Moderne docs to Pages (sharded)` from the Actions tab
- [ ] Confirm all 4 shards succeed within ~8 min wall time
- [ ] Confirm combine job produces a `build/` artifact with ~7,000 HTML files
- [ ] Deploy step should publish to the same `github-pages` environment (will overlap with the live `pages.yml` deploy — coordinate timing)
- [ ] Spot-check several deployed pages from different shards