### PR TITLE
ci: promote sharded build to primary deploy

### DIFF
--- a/.github/workflows/pages-sharded.yml
+++ b/.github/workflows/pages-sharded.yml
@@ -1,10 +1,17 @@
-# Sharded build prototype: splits SSG across N parallel jobs, then merges
-# the per-shard build outputs and deploys to GitHub Pages.
-# Once validated, this is intended to replace pages.yml.
+# Sharded production deploy: splits SSG across N parallel jobs, then merges
+# the per-shard build outputs and deploys to GitHub Pages. Replaces the
+# single-job pages.yml (kept as a workflow_dispatch-only emergency fallback).
 name: Deploy Moderne docs to Pages (sharded)
 
 on:
   workflow_dispatch:
+  workflow_run:
+    workflows: ["Update docs"]
+    types:
+      - completed
+  push:
+    branches:
+      - main
 
 concurrency:
   group: "pages"
@@ -91,33 +98,22 @@ jobs:
       - name: Merge shards
         run: node scripts/merge-shards.js
 
-      - name: Upload combined build (for inspection)
-        uses: actions/upload-artifact@v4
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v5
         with:
-          name: combined-build
           path: build
-          retention-days: 3
-          if-no-files-found: error
 
-# Deploy step disabled while validating on this branch. Re-enable before
-# cutting over from pages.yml.
-#
-#      - name: Upload Pages artifact
-#        uses: actions/upload-pages-artifact@v5
-#        with:
-#          path: build
-#
-#  deploy:
-#    name: Deploy to GitHub Pages
-#    needs: combine
-#    permissions:
-#      pages: write
-#      id-token: write
-#    environment:
-#      name: github-pages
-#      url: ${{ steps.deployment.outputs.page_url }}
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Deploy to GitHub Pages
-#        id: deployment
-#        uses: actions/deploy-pages@v5
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: combine
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,15 +1,10 @@
-# Simple workflow for deploying static content to GitHub Pages
-name: Deploy Moderne docs to Pages
+# Emergency fallback: single-job deploy. Superseded by pages-sharded.yml as
+# the primary deploy path; kept here as a manually-dispatched backup in case
+# the sharded build needs to be bypassed.
+name: Deploy Moderne docs to Pages (emergency fallback)
 
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: ["Update docs"]
-    types:
-      - completed
-  push:
-    branches:
-      - main
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.


### PR DESCRIPTION
## Summary

* **Re-enables the deploy step** in `pages-sharded.yml` and wires it to the production triggers (`push` to main, `workflow_run` on Update docs, `workflow_dispatch`)
* **Demotes `pages.yml`** to `workflow_dispatch`-only — kept as a one-click emergency fallback if the sharded build ever needs to be bypassed
* Both workflows share `concurrency: pages`, so they cannot deploy simultaneously

## Changes

* `pages-sharded.yml`
  * Added the same `workflow_run` / `push: main` triggers `pages.yml` used to have
  * Replaced the `combined-build` inspection artifact with `upload-pages-artifact`
  * Re-enabled the `deploy` job (uncommented from the branch-testing PR)
  * Updated header comment to reflect its new primary role
* `pages.yml`
  * Removed `workflow_run` and `push: main` triggers; kept only `workflow_dispatch`
  * Renamed workflow display name to `Deploy Moderne docs to Pages (emergency fallback)` so it's obvious in the Actions tab
  * Job definition unchanged so it remains a working rescue path

## Test plan

- [ ] Merge this PR
- [ ] Confirm the first push to main after merge triggers `pages-sharded` (not `pages`)
- [ ] Confirm the sharded deploy publishes to https://docs.moderne.io successfully
- [ ] Spot-check several pages from different shards on the live site
- [ ] (Optional) Manually dispatch `pages.yml` to confirm the fallback still works