### PR TITLE
node=24 for update-graphql-docs

### DIFF
--- a/.github/workflows/update-graphql-docs.yml
+++ b/.github/workflows/update-graphql-docs.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: 24
           cache: yarn
 
       - run: yarn install --frozen-lockfile


### PR DESCRIPTION
**What**:
- Bump the node version dependency of the new `update-graphql-docs` added in #691 to Node 24.

**Why**:
It's been failing with:
```
[1/5] Validating package.json...
error moderne-docs@1.0.0: The engine "node" is incompatible with this module. Expected version ">=24.0". Got "20.20.2"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
Error: Process completed with exit code 1.
```