### PR TITLE
ci: aggregate broken-links report across shards

### DIFF
--- a/.github/workflows/pages-sharded.yml
+++ b/.github/workflows/pages-sharded.yml
@@ -95,8 +95,29 @@ jobs:
           done
           ls -la
 
+      - name: Install dependencies (for broken-links aggregator)
+        run: yarn install --frozen-lockfile
+
       - name: Merge shards
         run: node scripts/merge-shards.js
+
+      - name: Aggregate broken-links report
+        run: |
+          node scripts/broken-links-report.js \
+            build-shards/shard-*/_shard-meta.json \
+            --out broken-links-summary.md
+
+      - name: Append report to job summary
+        run: cat broken-links-summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload broken-links summary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: broken-links-summary
+          path: |
+            broken-links-summary.md
+            broken-links-summary.md.json
+          retention-days: 30
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v5

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ package-lock.json
 # Production
 /build
 /build-shards
+/broken-links-summary.md
+/broken-links-summary.md.json
 
 # Generated files
 .docusaurus

--- a/scripts/broken-links-report.js
+++ b/scripts/broken-links-report.js
@@ -1,0 +1,264 @@
+#!/usr/bin/env node
+// Aggregates per-shard collected link/anchor data and runs a single,
+// cross-shard broken-link check — eliminating the cross-shard anchor
+// false-positives each shard would otherwise produce on its own.
+//
+// Usage:
+//   node scripts/broken-links-report.js <shard-meta.json>... [--out <file.md>]
+//
+// Writes a Markdown report to <file.md> (default: broken-links-summary.md).
+// Exit code is always 0 so the workflow step never fails on warnings; callers
+// can grep the report or use the JSON sidecar (`<file.md>.json`) for gating.
+//
+// The check logic is ported from @docusaurus/core/lib/server/brokenLinks
+// (private API, not exported). Keep in sync on Docusaurus upgrades.
+
+const fs = require('fs');
+const path = require('path');
+const _ = require('lodash');
+const { matchRoutes } = require('react-router-config');
+const {
+  parseURLPath,
+  serializeURLPath,
+  flattenRoutes,
+} = require('@docusaurus/utils');
+const {
+  addTrailingSlash,
+  removeTrailingSlash,
+} = require('@docusaurus/utils-common');
+
+const args = process.argv.slice(2);
+const outIdx = args.indexOf('--out');
+const outPath =
+  outIdx >= 0 ? args.splice(outIdx, 2)[1] : 'broken-links-summary.md';
+const inputs = args;
+
+if (inputs.length === 0) {
+  console.error(
+    'Usage: broken-links-report.js <shard-meta.json>... [--out <file.md>]',
+  );
+  process.exit(2);
+}
+
+const merged = mergeShardMeta(inputs);
+const brokenLinks = getBrokenLinks(merged.collectedLinks, merged.flatRoutes);
+const { brokenPaths, brokenAnchors } = splitBrokenLinks(brokenLinks);
+
+writeMarkdown(outPath, { brokenPaths, brokenAnchors, merged, inputs });
+writeJsonSidecar(outPath, { brokenPaths, brokenAnchors });
+
+const summary = `Found ${countTargets(brokenPaths)} broken paths across ${Object.keys(brokenPaths).length} pages, ${countTargets(brokenAnchors)} broken anchors across ${Object.keys(brokenAnchors).length} pages.`;
+console.log(`[broken-links-report] ${summary}`);
+console.log(`[broken-links-report] wrote ${outPath}`);
+
+// ---------------------------------------------------------------------------
+// Merge per-shard meta files
+// ---------------------------------------------------------------------------
+
+function mergeShardMeta(files) {
+  let flatRoutes = null;
+  const collectedLinks = {};
+  const shardIndices = [];
+
+  for (const f of files) {
+    const data = JSON.parse(fs.readFileSync(f, 'utf8'));
+    shardIndices.push(data.shardIndex);
+    if (flatRoutes === null) flatRoutes = data.flatRoutes;
+    Object.assign(collectedLinks, data.collectedLinks);
+  }
+
+  return {
+    collectedLinks,
+    flatRoutes,
+    shardIndices: shardIndices.sort((a, b) => a - b),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Broken-link check (ported from @docusaurus/core/lib/server/brokenLinks)
+// ---------------------------------------------------------------------------
+
+function normalizeCollectedLinks(collectedLinks) {
+  const result = new Map();
+  for (const [pathname, page] of Object.entries(collectedLinks)) {
+    result.set(pathname, {
+      links: new Set((page.links || []).filter((l) => typeof l === 'string')),
+      anchors: new Set(
+        (page.anchors || [])
+          .filter((a) => typeof a === 'string')
+          .map((a) => (a.startsWith('#') ? a.slice(1) : a)),
+      ),
+    });
+  }
+  return result;
+}
+
+function filterIntermediateRoutes(routes) {
+  return flattenRoutes(routes.filter((r) => r.path !== '*'));
+}
+
+function createHelper({ collectedLinks, routes }) {
+  const validPathnames = new Set(collectedLinks.keys());
+  const [validPathnameRoutes, otherRoutes] = _.partition(
+    routes,
+    (r) => r.exact && validPathnames.has(r.path),
+  );
+  for (const r of validPathnameRoutes) {
+    if (!r.strict) {
+      validPathnames.add(addTrailingSlash(r.path));
+      validPathnames.add(removeTrailingSlash(r.path));
+    }
+  }
+
+  function isPathnameMatchingAnyRoute(pathname) {
+    if (matchRoutes(otherRoutes, pathname).length > 0) {
+      validPathnames.add(pathname);
+      return true;
+    }
+    return false;
+  }
+
+  function isPathBrokenLink(linkPath) {
+    const candidates = [linkPath.pathname, decodeURI(linkPath.pathname)];
+    if (candidates.some((p) => validPathnames.has(p))) return false;
+    if (candidates.some(isPathnameMatchingAnyRoute)) return false;
+    return true;
+  }
+
+  function isAnchorBrokenLink(linkPath) {
+    const { pathname, hash } = linkPath;
+    if (hash === undefined || hash === '') return false;
+    const targetPage =
+      collectedLinks.get(pathname) ||
+      collectedLinks.get(decodeURI(pathname)) ||
+      collectedLinks.get(addTrailingSlash(pathname)) ||
+      collectedLinks.get(addTrailingSlash(decodeURI(pathname))) ||
+      collectedLinks.get(removeTrailingSlash(pathname)) ||
+      collectedLinks.get(removeTrailingSlash(decodeURI(pathname)));
+    if (!targetPage) return true;
+    if (
+      targetPage.anchors.has(hash) ||
+      targetPage.anchors.has(decodeURIComponent(hash))
+    ) {
+      return false;
+    }
+    return true;
+  }
+
+  return { collectedLinks, isPathBrokenLink, isAnchorBrokenLink };
+}
+
+function getBrokenLinks(collectedLinksObj, routes) {
+  const normalized = normalizeCollectedLinks(collectedLinksObj);
+  const helper = createHelper({
+    collectedLinks: normalized,
+    routes: filterIntermediateRoutes(routes),
+  });
+
+  const result = {};
+  for (const pagePath of normalized.keys()) {
+    const pageData = normalized.get(pagePath);
+    const pageBroken = [];
+    for (const link of pageData.links) {
+      const linkPath = parseURLPath(link, pagePath);
+      if (helper.isPathBrokenLink(linkPath)) {
+        pageBroken.push({
+          link,
+          resolvedLink: serializeURLPath(linkPath),
+          anchor: false,
+        });
+      } else if (helper.isAnchorBrokenLink(linkPath)) {
+        pageBroken.push({
+          link,
+          resolvedLink: serializeURLPath(linkPath),
+          anchor: true,
+        });
+      }
+    }
+    if (pageBroken.length > 0) result[pagePath] = pageBroken;
+  }
+  return result;
+}
+
+function splitBrokenLinks(brokenLinks) {
+  const brokenPaths = {};
+  const brokenAnchors = {};
+  for (const [pathname, links] of Object.entries(brokenLinks)) {
+    const [anchors, paths] = _.partition(links, (l) => l.anchor);
+    if (paths.length > 0) brokenPaths[pathname] = paths;
+    if (anchors.length > 0) brokenAnchors[pathname] = anchors;
+  }
+  return { brokenPaths, brokenAnchors };
+}
+
+// ---------------------------------------------------------------------------
+// Markdown formatting
+// ---------------------------------------------------------------------------
+
+function countTargets(byPage) {
+  return Object.values(byPage).reduce((sum, arr) => sum + arr.length, 0);
+}
+
+function frequentTargets(byPage, threshold = 5) {
+  const counts = {};
+  for (const links of Object.values(byPage)) {
+    for (const { link } of links) {
+      counts[link] = (counts[link] || 0) + 1;
+    }
+  }
+  return Object.entries(counts)
+    .filter(([, n]) => n >= threshold)
+    .sort((a, b) => b[1] - a[1]);
+}
+
+function renderSection(title, byPage) {
+  const pages = Object.keys(byPage).sort();
+  if (pages.length === 0) {
+    return `## ${title}\n\nNone. ✓\n`;
+  }
+
+  const total = countTargets(byPage);
+  let md = `## ${title}\n\n`;
+  md += `**${total}** broken target${total === 1 ? '' : 's'} across **${pages.length}** source page${pages.length === 1 ? '' : 's'}.\n\n`;
+
+  const frequent = frequentTargets(byPage);
+  if (frequent.length > 0) {
+    md += `### Most-linked broken targets\n\n`;
+    md += `| Count | Target |\n|------:|:-------|\n`;
+    for (const [link, count] of frequent.slice(0, 10)) {
+      md += `| ${count} | \`${link}\` |\n`;
+    }
+    md += '\n';
+  }
+
+  md += `<details><summary>All broken targets by source page</summary>\n\n`;
+  for (const page of pages) {
+    md += `**\`${page}\`**\n\n`;
+    for (const { link, resolvedLink } of byPage[page]) {
+      const display =
+        link === resolvedLink
+          ? `\`${link}\``
+          : `\`${link}\` (resolved as \`${resolvedLink}\`)`;
+      md += `* ${display}\n`;
+    }
+    md += '\n';
+  }
+  md += `</details>\n`;
+  return md;
+}
+
+function writeMarkdown(outPath, { brokenPaths, brokenAnchors, merged, inputs }) {
+  let md = `# Broken links report\n\n`;
+  md += `Aggregated from ${inputs.length} shard${inputs.length === 1 ? '' : 's'} (`;
+  md += merged.shardIndices.map((i) => `shard-${i}`).join(', ');
+  md += `) covering **${Object.keys(merged.collectedLinks).length}** rendered routes and **${merged.flatRoutes.length}** total routes.\n\n`;
+  md += renderSection('Broken paths', brokenPaths);
+  md += '\n';
+  md += renderSection('Broken anchors', brokenAnchors);
+  fs.writeFileSync(outPath, md);
+}
+
+function writeJsonSidecar(outPath, payload) {
+  const jsonPath = outPath + '.json';
+  fs.writeFileSync(jsonPath, JSON.stringify(payload, null, 2));
+}

--- a/scripts/build-shard-patch.js
+++ b/scripts/build-shard-patch.js
@@ -1,5 +1,9 @@
 // Node --require hook that monkey-patches Docusaurus's SSG executor to render
-// only a subset of routes per shard. Loaded via scripts/build-shard.js.
+// only a subset of routes per shard, serializes per-shard link/anchor data for
+// cross-shard broken-link aggregation, and suppresses the per-shard
+// broken-link check (the combine job runs an aggregated check instead).
+//
+// Loaded via scripts/build-shard.js.
 
 const SHARD_INDEX = parseInt(process.env.SHARD_INDEX ?? '', 10);
 const SHARD_TOTAL = parseInt(process.env.SHARD_TOTAL ?? '', 10);
@@ -14,7 +18,11 @@ if (SHARD_TOTAL < 1 || SHARD_INDEX < 0 || SHARD_INDEX >= SHARD_TOTAL) {
   );
 }
 
+const fs = require('fs');
+const path = require('path');
 const ssgExecutor = require('@docusaurus/core/lib/ssg/ssgExecutor');
+const { flattenRoutes } = require('@docusaurus/utils');
+
 const originalExecuteSSG = ssgExecutor.executeSSG;
 
 ssgExecutor.executeSSG = async function shardedExecuteSSG(opts) {
@@ -24,8 +32,48 @@ ssgExecutor.executeSSG = async function shardedExecuteSSG(opts) {
     `[shard ${SHARD_INDEX}/${SHARD_TOTAL}] rendering ${mine.length} of ${allPaths.length} routes`,
   );
   opts.props.routesPaths = mine;
-  return originalExecuteSSG.call(this, opts);
+
+  const result = await originalExecuteSSG.call(this, opts);
+
+  serializeShardMeta(result, opts);
+
+  // Suppress the per-shard broken-link check; cross-shard aggregation
+  // happens in the combine job using the serialized meta.
+  opts.props.siteConfig.onBrokenLinks = 'ignore';
+  opts.props.siteConfig.onBrokenAnchors = 'ignore';
+
+  return result;
 };
+
+function serializeShardMeta(result, opts) {
+  const collectedLinks = {};
+  for (const [route, data] of Object.entries(result.collectedData)) {
+    collectedLinks[route] = {
+      links: data.links || [],
+      anchors: data.anchors || [],
+    };
+  }
+
+  const flatRoutes = flattenRoutes(opts.props.routes)
+    .filter((r) => r.path !== '*')
+    .map((r) => ({ path: r.path, exact: !!r.exact, strict: !!r.strict }));
+
+  const metaPath = path.join(opts.props.outDir, '_shard-meta.json');
+  fs.writeFileSync(
+    metaPath,
+    JSON.stringify({
+      shardIndex: SHARD_INDEX,
+      shardTotal: SHARD_TOTAL,
+      onBrokenLinks: opts.props.siteConfig.onBrokenLinks,
+      onBrokenAnchors: opts.props.siteConfig.onBrokenAnchors,
+      flatRoutes,
+      collectedLinks,
+    }),
+  );
+  console.log(
+    `[shard-patch] wrote ${metaPath} — ${Object.keys(collectedLinks).length} routes, ${flatRoutes.length} total`,
+  );
+}
 
 console.log(
   `[shard-patch] active — shard ${SHARD_INDEX} of ${SHARD_TOTAL}`,

--- a/scripts/merge-shards.js
+++ b/scripts/merge-shards.js
@@ -37,8 +37,13 @@ let otherCount = 0;
 let overwriteCount = 0;
 const htmlOwners = new Map();
 
+// Files emitted by the shard patch for cross-shard aggregation; not part of
+// the deployed site.
+const META_FILES = new Set(['_shard-meta.json']);
+
 function copyTree(srcDir, destDir, shardName) {
   for (const entry of fs.readdirSync(srcDir, { withFileTypes: true })) {
+    if (META_FILES.has(entry.name)) continue;
     const src = path.join(srcDir, entry.name);
     const dest = path.join(destDir, entry.name);
     if (entry.isDirectory()) {


### PR DESCRIPTION
## Summary

* Each shard now serializes its `collectedLinks` (per-route links + anchors) and the flat route list to a `_shard-meta.json` sidecar
* Each shard's own broken-link check is **suppressed** (it sees only a slice of pages and produces cross-shard anchor false-positives)
* The `combine` job runs a single broken-link check against the **merged** dataset and emits a Markdown report
* The report is appended to **`\$GITHUB_STEP_SUMMARY`** (renders inline on the workflow run page) and uploaded as a **`broken-links-summary`** artifact (`.md` + `.json` sidecar, 30-day retention)

## Why merged vs. per-shard

A page's anchor-link check needs to see the target page's anchors. A single shard only renders ~1/N of pages, so any link from shard A to an anchor on a page rendered in shard B looks broken to shard A even though it isn't. Merging shard data before running the check eliminates these false positives.

## Local verification

Compared aggregator output against two ground-truth sources:

| Build mode | Broken paths | Broken anchors |
|------------|-------------:|---------------:|
| Non-sharded baseline (`SKIP_RECIPE_CATALOG=1`) | 19 pages / 10,622 targets | 0 |
| Sharded aggregator (`SKIP_RECIPE_CATALOG=1`) | 19 pages / 10,623 targets | 0 |
| Non-sharded baseline (full) | 0 | 0 |
| Sharded aggregator (full) | **0** | **0** |
- | Old prod run #26270202100 (single-job `pages.yml`) | **0** | **0** |

Full-build aggregator output matches the old prod run exactly. The 1-link delta in the SKIP test (10,623 vs 10,622) appears only when whole content directories are excluded; the full build has no such discrepancy.

## How the patch hooks in

`scripts/build-shard-patch.js` now does two more things after the original SSG executor returns:

1. **Serializes** `{ collectedLinks, flatRoutes }` to `build-shards/shard-N/_shard-meta.json` (excluded from the deployed `build/` by the merge script).
2. **Sets** `props.siteConfig.onBrokenLinks` and `onBrokenAnchors` to `'ignore'` so the per-shard check doesn't run.

`scripts/broken-links-report.js` ports ~80 lines of check logic from `@docusaurus/core/lib/server/brokenLinks` (the `getBrokenLinks` function is not exported, so we replicate it). Reuses the public utilities (`parseURLPath`, `flattenRoutes`, etc.) and `react-router-config.matchRoutes`.

## Known caveats

* Per-shard `_shard-meta.json` is ~120 MB on the full ~7k-route site (~10% of the shard build artifact). Acceptable but worth knowing.
* The aggregator's check logic is a copy from a private Docusaurus path. Add to upgrade fragility notes in `CLAUDE.md` if we keep this past the prototype — kept in sync alongside the existing `ssgExecutor` patch.
* Exit code is always 0 (no failing on warnings) to match current `pages.yml` behavior. A future change could gate the workflow on the JSON sidecar if strict mode is wanted.

## Test plan

- [ ] Manually dispatch the sharded workflow (or wait for the next push to main)
- [ ] Confirm the run summary page renders the broken-links Markdown
- [ ] Download the `broken-links-summary` artifact and inspect both `.md` and `.md.json`
- [ ] Confirm the live site is unaffected — this PR doesn't touch render/deploy paths