### PR TITLE
ci: set up node 24 in combine job

### DIFF
--- a/.github/workflows/pages-sharded.yml
+++ b/.github/workflows/pages-sharded.yml
@@ -77,6 +77,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: yarn
 
       - name: Download all shard artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary

* Fixes the combine job failing on \`yarn install --frozen-lockfile\` with \`error moderne-docs@1.0.0: The engine "node" is incompatible with this module. Expected version ">=24.0". Got "22.22.3"\`
* The \`build-shard\` jobs already set up Node 24 via \`actions/setup-node@v6\`; the \`combine\` job was missing the same step and was hitting the runner default (22.x), failing the engines check in our package.json
* Adds the same \`actions/setup-node@v6 (node-version: 24, cache: yarn)\` block to combine

## Test plan

- [ ] Manually dispatch the sharded workflow and confirm the combine job's \`yarn install\` step passes
- [ ] Confirm the aggregator step runs and the broken-links report appears in the job summary