### PR TITLE
ci: drop DOCUSAURUS_SSR_CONCURRENCY from 16 to 4 to fix OOM on shards

### DIFF
--- a/.github/workflows/pages-sharded.yml
+++ b/.github/workflows/pages-sharded.yml
@@ -58,7 +58,7 @@ jobs:
           SHARD_INDEX: ${{ matrix.shard }}
           SHARD_TOTAL: 4
           DOCUSAURUS_SSG_WORKER_THREAD_RECYCLER_MAX_MEMORY: "512000000"
-          DOCUSAURUS_SSR_CONCURRENCY: "16"
+          DOCUSAURUS_SSR_CONCURRENCY: "4"
           NODE_OPTIONS: "--max-old-space-size=1536 --max-semi-space-size=64"
           DOCUSAURUS_IGNORE_SSG_WARNINGS: true
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -42,7 +42,7 @@ jobs:
           yarn build 2>&1 | { grep --line-buffered -v "^Generated markdown file:" || true; }
         env:
           DOCUSAURUS_SSG_WORKER_THREAD_RECYCLER_MAX_MEMORY: "512000000"
-          DOCUSAURUS_SSR_CONCURRENCY: "16"
+          DOCUSAURUS_SSR_CONCURRENCY: "4"
           NODE_OPTIONS: "--max-old-space-size=1536 --max-semi-space-size=64"
           DOCUSAURUS_IGNORE_SSG_WARNINGS: true
 


### PR DESCRIPTION
- After PR #700 reapply (1349 new recipe pages, ~183K insertions), the sharded GitHub Pages build started failing on every shard with exit code 143 ("runner has received a shutdown signal") — classic OOM on the ubuntu-latest runner.

Every shard reached "rendering 1891 of 7564 routes", logged 4 worker recycler events in rapid succession, then sat silent until the host SIGTERMed the runner. Shard 2 happened to hit a memory-heavy route first, dying at 1m02s and triggering fail-fast cancellation of the others.

Reproduced locally with the exact CI env (SSR_CONCURRENCY=16, max-old-space-size=1536): the build completes on a 32 GB Mac but fires the worker recycler 10 times in a 70-second run. Repeating with SSR_CONCURRENCY=4 takes 153s with no recycler pressure.

Root cause: ubuntu-latest has 4 cores. Running 16 SSR workers was 4x CPU oversubscription with no throughput benefit and linearly multiplied peak memory. Several recipe pages now render to 500 KB–1 MB of HTML each; workers spike well above the 512 MB recycler threshold before they're killed, so peak resident memory across 16 concurrent workers exceeds the runner's ~16 GB limit.

Setting concurrency to match the runner's core count gives a stable build with no throughput regression. If memory pressure returns, the next dial is DOCUSAURUS_SSG_WORKER_THREAD_RECYCLER_MAX_MEMORY (currently 512 MB → try 256 MB).