### PR TITLE
ci: serialise SSG on CI and raise main-process heap to fix OOM

### DIFF
--- a/.github/workflows/pages-sharded.yml
+++ b/.github/workflows/pages-sharded.yml
@@ -58,8 +58,8 @@ jobs:
           SHARD_INDEX: ${{ matrix.shard }}
           SHARD_TOTAL: 4
           DOCUSAURUS_SSG_WORKER_THREAD_RECYCLER_MAX_MEMORY: "512000000"
-          DOCUSAURUS_SSR_CONCURRENCY: "4"
-          NODE_OPTIONS: "--max-old-space-size=1536 --max-semi-space-size=64"
+          DOCUSAURUS_SSR_CONCURRENCY: "16"
+          NODE_OPTIONS: "--max-old-space-size=4096 --max-semi-space-size=64"
           DOCUSAURUS_IGNORE_SSG_WARNINGS: true
 
       - name: Upload shard artifact

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -42,8 +42,8 @@ jobs:
           yarn build 2>&1 | { grep --line-buffered -v "^Generated markdown file:" || true; }
         env:
           DOCUSAURUS_SSG_WORKER_THREAD_RECYCLER_MAX_MEMORY: "512000000"
-          DOCUSAURUS_SSR_CONCURRENCY: "4"
-          NODE_OPTIONS: "--max-old-space-size=1536 --max-semi-space-size=64"
+          DOCUSAURUS_SSR_CONCURRENCY: "16"
+          NODE_OPTIONS: "--max-old-space-size=4096 --max-semi-space-size=64"
           DOCUSAURUS_IGNORE_SSG_WARNINGS: true
 
       - name: Upload Build Artifact

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -184,12 +184,14 @@ const config: Config = {
   future: {
     faster: {
       // SSG worker threads parallelise per-page rendering; each worker
-      // holds a React render tree, multiplying peak memory across pages
-      // in flight. With the full recipe-catalog build (~5,700 pages) on
-      // ubuntu-latest's 16 GB the kernel SIGTERMs the job mid-build.
-      // Serialising SSG keeps peak memory bounded; Rspack/SWC keep
-      // their own internal parallelism for the bundling/minimising work.
-      ssgWorkerThreads: true,
+      // holds a React render tree and a copy of the server bundle,
+      // multiplying sustained memory across pages in flight. With the
+      // full recipe-catalog build (~7,500 routes) on ubuntu-latest's
+      // 16 GB the kernel SIGTERMs the job mid-build. Locally we keep
+      // parallel SSG for speed; on CI we serialise to keep sustained
+      // memory bounded. Rspack/SWC keep their own internal parallelism
+      // for the bundling/minimising work either way.
+      ssgWorkerThreads: !process.env.CI,
       swcJsLoader: true,
       swcJsMinimizer: true,
       swcHtmlMinimizer: true,


### PR DESCRIPTION
The previous commit (drop SSR_CONCURRENCY 16→4) didn't fix the OOM because DOCUSAURUS_SSR_CONCURRENCY does NOT control thread count; it controls p-map async concurrency *inside* each worker thread (ssgEnv.js:13, ssgRenderer.js:70). Thread count is set by os.availableParallelism() — 4 on ubuntu-latest — and we never had a real knob on it.

Local memory profiling on the same commit showed the actual problem:

  Parallel SSG (current):  peak 10.3 GB, sustained ~9 GB for 35s
  Serial SSG  (CI=1):      peak 12.3 GB (brief webpack→SSG transition),
                           then sustained ~1.5 GB during rendering

The runner SIGTERMs during the SSG phase (4+ min after rendering starts), so it's the *sustained* ~9 GB — four worker threads each holding the full server bundle and an in-flight React tree — that overflows the runner, not the brief Rspack peak.

The docusaurus.config.ts comment was already telling us this: "Serialising SSG keeps peak memory bounded." We were doing the opposite. Now:

* `ssgWorkerThreads: !process.env.CI` — local builds keep parallel SSG for speed (local `yarn build:shard` finishes in 65s on a 10-core Mac); CI builds serialise SSG to bound sustained memory. Rspack/SWC stay parallel either way for the webpack phase.
* Bump `--max-old-space-size` from 1536 to 4096. With serial SSG the main thread does the rendering itself, and the brief webpack→SSG transition still spikes around 12 GB RSS; the larger V8 heap gives the main thread headroom for the React trees and collectedData aggregation.
* Restore `DOCUSAURUS_SSR_CONCURRENCY: "16"` (reverting the no-op change from the previous commit). In serial SSG mode this is the main-thread p-map concurrency for rendering pathnames; setting it lower was making local "test the serial path" experiments mistakenly slow.

Locally, serial SSG with this config builds shard 2 in 94s with ~1.5 GB sustained — well under the runner ceiling. If this still isn't enough headroom, the next levers are an explicit larger runner (`ubuntu-latest-8-cores` if the org label exists) or increasing the shard count from 4 to 8.