### PR TITLE
Update Spring Boot migration

### DIFF
--- a/docs/hands-on-learning/spring-boot-migration/module-2-wave-planning.md
+++ b/docs/hands-on-learning/spring-boot-migration/module-2-wave-planning.md
@@ -107,7 +107,12 @@ mod config recipes jar install \
   org.openrewrite:rewrite-maven \
   io.moderne.recipe:rewrite-devcenter \
   org.openrewrite.recipe:rewrite-spring \
-  org.openrewrite.recipe:rewrite-testing-frameworks
+  org.openrewrite.recipe:rewrite-testing-frameworks \
+  org.openrewrite.recipe:rewrite-apache \
+  org.openrewrite.recipe:rewrite-openapi \
+  org.openrewrite.recipe:rewrite-hibernate \
+  org.openrewrite.recipe:rewrite-micrometer \
+  org.openrewrite.recipe:rewrite-jackson
 ```
 
 :::info

--- a/docs/hands-on-learning/spring-boot-migration/module-3-establish-baseline.md
+++ b/docs/hands-on-learning/spring-boot-migration/module-3-establish-baseline.md
@@ -32,12 +32,14 @@ You saw from the analysis earlier that these projects all use a variety of Sprin
    * **`Apache Maven best practices`** ([`org.openrewrite.maven.BestPractices`](https://docs.openrewrite.org/recipes/maven/bestpractices))
    * **`Migrate to Java 8`** ([`org.openrewrite.java.migrate.UpgradeToJava8`](https://docs.openrewrite.org/recipes/java/migrate/upgradetojava8))
    * **`Migrate to Spring Boot 2.7`** ([`org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_7`](https://docs.openrewrite.org/recipes/java/spring/boot2/upgradespringboot_2_7))
+   * **`Exclude Maven dependency`** ([`org.openrewrite.maven.ExcludeDependency`](https://docs.openrewrite.org/recipes/maven/excludedependency))
+      * **groupId:** `org.hibernate.javax.persistence`
+      * **artifactId:** `hibernate-jpa-2.0-api`
+      * **scope:** `compile`
    * **`Change Maven dependency`** ([`org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId`](https://docs.openrewrite.org/recipes/maven/changedependencygroupidandartifactid))
-4. Configure the dependency change:
-   * **Old groupId:** `org.springframework.cloud`
-   * **Old artifactId:** `spring-cloud-starter-zipkin`
-   * **New groupId:** `org.springframework.cloud`
-   * **New artifactId:** `spring-cloud-sleuth-zipkin`
+      * **Old groupId:** `org.springframework.cloud`
+      * **Old artifactId:** `spring-cloud-starter-zipkin`
+      * **New artifactId:** `spring-cloud-sleuth-zipkin`
 
 <figure>
   ![Baseline recipe list with Maven best practices, Java 8, Spring Boot 2.7, and dependency change](./assets/migration-baseline-recipe.png)


### PR DESCRIPTION
This pull request updates the documentation for the Spring Boot migration hands-on learning modules by expanding the list of OpenRewrite recipes used in the migration process and clarifying the steps for excluding specific Maven dependencies. The changes provide additional automation options for code and configuration migration, and make the migration instructions more explicit.

**Enhancements to migration automation:**

* Expanded the list of OpenRewrite recipes in the migration instructions to include `rewrite-apache`, `rewrite-openapi`, `rewrite-hibernate`, `rewrite-micrometer`, and `rewrite-jackson`, allowing for broader automated code and configuration migration coverage.

**Documentation improvements:**

* Added explicit instructions for using the `Exclude Maven dependency` recipe to exclude the `org.hibernate.javax.persistence:hibernate-jpa-2.0-api` dependency with `compile` scope, making the migration steps clearer for users.