### PR TITLE
Improve wording & example around unsupported "run without the wrapper"

### DIFF
--- a/docs/user-documentation/moderne-cli/how-to-guides/cli-wrapper.md
+++ b/docs/user-documentation/moderne-cli/how-to-guides/cli-wrapper.md
@@ -262,19 +262,27 @@ The list below covers what is currently known to break. It is not exhaustive. Th
 
 ### If you really must run without the wrapper
 
-This path is unsupported. If your environment makes the wrapper genuinely impractical, you can run the CLI JAR directly, but you take on responsibility for setting the JVM arguments the wrapper would have set, and for tracking what changes between CLI versions. At minimum, mirror whatever is in your `~/.moderne/moderne.yml` to `-D` flags on the `java` command line:
+This path is unsupported. `java -jar moderne-cli.jar` will start the CLI and works for many commands, but it can fail on others (recipe runs especially), which is why we do not support it. The safer invocation is to extract the nested JARs out of the fat JAR once and launch `io.moderne.cli.commands.Mod` against the extracted classpath. Mirror whatever is in your `~/.moderne/moderne.yml` to `-D` flags on the `java` command line so HTTPS calls and the corporate proxy work:
 
 ```bash
+EXTRACTED="$HOME/.moderne/cli/dist/classpath/<version>"
+MOD_JAR="$HOME/.moderne/cli/dist/lib/moderne-cli.jar"
+
+# Extract nested JARs (only needed when the JAR changes)
+java -cp "$MOD_JAR" io.moderne.cli.launcher.ModerneLauncher --extract-only
+
+# Run the CLI
 java \
-  -Djavax.net.ssl.trustStore=/path/to/truststore.jks \
-  -Djavax.net.ssl.trustStorePassword=changeit \
-  -Dhttp.proxyHost=proxy.example.com -Dhttp.proxyPort=3128 \
-  -Dhttps.proxyHost=proxy.example.com -Dhttps.proxyPort=3128 \
-  -Dhttp.nonProxyHosts="*.example.com" \
-  -jar moderne-cli.jar <command>
+    -Djavax.net.ssl.trustStore=/path/to/truststore.jks \
+    -Djavax.net.ssl.trustStorePassword=changeit \
+    -Dhttp.proxyHost=proxy.example.com -Dhttp.proxyPort=3128 \
+    -Dhttps.proxyHost=proxy.example.com -Dhttps.proxyPort=3128 \
+    -Dhttp.nonProxyHosts="*.example.com" \
+    -cp "$MOD_JAR:$EXTRACTED/META-INF/cli/*:$EXTRACTED/META-INF/lib/*:$EXTRACTED" \
+    io.moderne.cli.commands.Mod "$@"
 ```
 
-The full list of JVM arguments the wrapper sets today corresponds to what has been configured via [`mod config http proxy`](../cli-reference.md#mod-config-http-proxy), [`mod config http trust-store`](../cli-reference.md#mod-config-http-trust-store), and [`mod config http key-store`](../cli-reference.md#mod-config-http-key-store) and persisted to `moderne.yml`, plus the GC and AOT-cache flags `modw` selects for the JVM. This set is not part of any stable contract and can change between CLI versions. If you choose this path, treat the `modw` script shipped with each CLI release as the source of truth and diff it on every upgrade to see what new arguments need to be propagated.
+That gets you a working CLI with HTTPS, but it is still missing everything else in [What breaks without the wrapper](#what-breaks-without-the-wrapper): no AOT cache, no auto-update, and no GC tuning. None of the layout above is part of a stable contract: the extraction directory, the main class, the launcher class, the classpath shape, and the set of `-D` flags the wrapper sets can all change between CLI versions, and have changed multiple times already. If you choose this path, treat the `modw` script shipped with each CLI release as the source of truth and diff it on every upgrade.
 
 ### Migrating to the wrapper
 

--- a/docs/user-documentation/moderne-cli/how-to-guides/cli-wrapper.md
+++ b/docs/user-documentation/moderne-cli/how-to-guides/cli-wrapper.md
@@ -282,7 +282,7 @@ java \
     io.moderne.cli.commands.Mod "$@"
 ```
 
-That gets you a working CLI with HTTPS, but it is still missing everything else in [What breaks without the wrapper](#what-breaks-without-the-wrapper): no AOT cache, no auto-update, and no GC tuning. None of the layout above is part of a stable contract: the extraction directory, the main class, the launcher class, the classpath shape, and the set of `-D` flags the wrapper sets can all change between CLI versions, and have changed multiple times already. If you choose this path, treat the `modw` script shipped with each CLI release as the source of truth and diff it on every upgrade.
+That gets you a working CLI with HTTPS, but it is still missing everything else in [What breaks without the wrapper](#what-breaks-without-the-wrapper): no AOT cache, no auto-update, and no GC tuning. The `-D` flags shown above correspond to what has been configured via [`mod config http proxy`](../cli-reference.md#mod-config-http-proxy), [`mod config http trust-store`](../cli-reference.md#mod-config-http-trust-store), and [`mod config http key-store`](../cli-reference.md#mod-config-http-key-store) and persisted to `moderne.yml`. None of this is part of a stable contract: the extraction directory, the main class, the launcher class, the classpath shape, and the set of `-D` flags the wrapper sets can all change between CLI versions, and have changed multiple times already. If you choose this path, treat the `modw` script shipped with each CLI release as the source of truth and diff it on every upgrade to see what new arguments need to be propagated.
 
 ### Migrating to the wrapper
 

--- a/docs/user-documentation/moderne-cli/references/cli-4-0-0-changes.md
+++ b/docs/user-documentation/moderne-cli/references/cli-4-0-0-changes.md
@@ -147,7 +147,7 @@ Each `modw` uses the version defined in its neighboring properties file. You can
 
 ## Updating custom scripts
 
-After installation, `mod` is available as a symlink to `modw`, so most existing scripts will continue to work without changes. If you need to adjust paths or use direct Java invocation, here are the patterns:
+After installation, `mod` is available as a symlink to `modw`, so most existing scripts will continue to work without changes. If you need to invoke the CLI from a script that previously called the 3.x native binary, switch to the wrapper:
 
 **3.x pattern (native binary):**
 
@@ -158,12 +158,10 @@ After installation, `mod` is available as a symlink to `modw`, so most existing 
 **4.0 pattern:**
 
 ```bash
-# Option 1: Use modw (recommended)
 /path/to/modw run --recipe=SomeRecipe ...
-
-# Option 2: Direct java invocation
-java -jar /path/to/moderne-cli.jar run --recipe=SomeRecipe ...
 ```
+
+Calling `java -jar` against the CLI JAR directly is not a supported configuration. See [Running the CLI without the wrapper](../how-to-guides/cli-wrapper.md#running-the-cli-without-the-wrapper) for what breaks if you bypass `modw`.
 
 ### Environment variables
 


### PR DESCRIPTION
## Problem

- The "If you really must run without the wrapper" section showed a `java -jar moderne-cli.jar` example. That command does start the CLI through its bootstrap launcher, but it can fail on some operations (recipe runs especially), which is why we do not support it. Per [moderneinc/customer-requests#2433](https://github.com/moderneinc/customer-requests/issues/2433) we hold the line on "not supported", but the example we ship should give customers who insist on this route a starting point that runs reliably.

The 4.0 changelog had the same issue: "Option 1: modw (recommended)" next to "Option 2: java -jar ..." framed the two as peers.

## Solution

Replace the `java -jar` example with the minimum recipe that matches what modw actually does: extract the nested JARs via `ModerneLauncher --extract-only`, then launch with `java -cp $MOD_JAR:$EXTRACTED/META-INF/{cli,lib}/*:$EXTRACTED io.moderne.cli.commands.Mod`, keeping the SSL/proxy `-D` flags. Keep the framing that the path is unsupported, that AOT cache, auto-update, and GC tuning are still missing, and that modw is the source of truth to diff on every upgrade. Verified locally on CLI 4.2.9.

Collapse the Option 1 / Option 2 split in the 4.0 changelog to a single modw example, with a pointer to the cli-wrapper section for what direct invocation looks like.