### PR TITLE
ci: fix sharded deploy OOM by dropping docusaurus-8-32 and isolating all-recipes

### DIFF
--- a/.github/workflows/pages-sharded.yml
+++ b/.github/workflows/pages-sharded.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   lint:
     name: Lint markdown
-    runs-on: docusaurus-8-32
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -88,7 +88,7 @@ jobs:
   combine:
     name: Combine shards
     needs: build-shard
-    runs-on: docusaurus-8-32
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
@@ -152,7 +152,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: docusaurus-8-32
+    runs-on: ubuntu-latest
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/pages-sharded.yml
+++ b/.github/workflows/pages-sharded.yml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  SHARD_TOTAL: 8
+  SHARD_TOTAL: 5
 
 jobs:
   lint:
@@ -36,14 +36,14 @@ jobs:
         run: yarn lint:markdown
 
   build-shard:
-    name: Build shard ${{ matrix.shard }}/${{ vars.SHARD_TOTAL || 8 }}
+    name: Build shard ${{ matrix.shard }}/${{ vars.SHARD_TOTAL || 5 }}
     needs: lint
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: true
       matrix:
-        shard: [0, 1, 2, 3, 4, 5, 6, 7]
+        shard: [0, 1, 2, 3, 4]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -71,7 +71,7 @@ jobs:
           yarn build:shard 2>&1 | { grep --line-buffered -v "^Generated markdown file:" || true; }
         env:
           SHARD_INDEX: ${{ matrix.shard }}
-          SHARD_TOTAL: 8
+          SHARD_TOTAL: 5
           DOCUSAURUS_SSG_WORKER_THREAD_RECYCLER_MAX_MEMORY: "512000000"
           DOCUSAURUS_SSR_CONCURRENCY: "16"
           NODE_OPTIONS: "--max-old-space-size=4096 --max-semi-space-size=64"

--- a/.github/workflows/pages-sharded.yml
+++ b/.github/workflows/pages-sharded.yml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  SHARD_TOTAL: 4
+  SHARD_TOTAL: 8
 
 jobs:
   lint:
@@ -36,14 +36,14 @@ jobs:
         run: yarn lint:markdown
 
   build-shard:
-    name: Build shard ${{ matrix.shard }}/${{ vars.SHARD_TOTAL || 4 }}
+    name: Build shard ${{ matrix.shard }}/${{ vars.SHARD_TOTAL || 8 }}
     needs: lint
-    runs-on: docusaurus-8-32
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: true
       matrix:
-        shard: [0, 1, 2, 3]
+        shard: [0, 1, 2, 3, 4, 5, 6, 7]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -71,7 +71,7 @@ jobs:
           yarn build:shard 2>&1 | { grep --line-buffered -v "^Generated markdown file:" || true; }
         env:
           SHARD_INDEX: ${{ matrix.shard }}
-          SHARD_TOTAL: 4
+          SHARD_TOTAL: 8
           DOCUSAURUS_SSG_WORKER_THREAD_RECYCLER_MAX_MEMORY: "512000000"
           DOCUSAURUS_SSR_CONCURRENCY: "16"
           NODE_OPTIONS: "--max-old-space-size=4096 --max-semi-space-size=64"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   build:
     name: Build Docusaurus
-    runs-on: docusaurus-8-32
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -65,7 +65,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
 
-    runs-on: docusaurus-8-32
+    runs-on: ubuntu-latest
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   build:
     name: Update docs
-    runs-on: docusaurus-8-32
+    runs-on: ubuntu-latest
     env:
       LATEST_VERSIONS_ONLY: ${{ github.event_name != 'workflow_dispatch' || inputs.latest-versions-only }}
     timeout-minutes: 30

--- a/scripts/build-shard-patch.js
+++ b/scripts/build-shard-patch.js
@@ -25,11 +25,32 @@ const { flattenRoutes } = require('@docusaurus/utils');
 
 const originalExecuteSSG = ssgExecutor.executeSSG;
 
+// Routes matched here are pulled out of the normal modulo pool and rendered
+// exclusively by the last shard, giving them an isolated memory budget.
+const HEAVY_ROUTE_PATTERNS = [
+  '/user-documentation/recipes/lists/all-recipes',
+];
+
 ssgExecutor.executeSSG = async function shardedExecuteSSG(opts) {
   const allPaths = [...opts.props.routesPaths].sort();
-  const mine = allPaths.filter((_, i) => i % SHARD_TOTAL === SHARD_INDEX);
+  const DEDICATED_SHARD = SHARD_TOTAL - 1;
+
+  const isHeavy = (p) => HEAVY_ROUTE_PATTERNS.some((pat) => p === pat || p.startsWith(pat + '/'));
+  const heavyPaths = allPaths.filter(isHeavy);
+  const normalPaths = allPaths.filter((p) => !isHeavy(p));
+
+  let mine;
+  if (SHARD_INDEX === DEDICATED_SHARD) {
+    // Last shard: only the heavy routes
+    mine = heavyPaths;
+  } else {
+    // All other shards: split normal routes across SHARD_TOTAL - 1 buckets
+    mine = normalPaths.filter((_, i) => i % (SHARD_TOTAL - 1) === SHARD_INDEX);
+  }
+
   console.log(
-    `[shard ${SHARD_INDEX}/${SHARD_TOTAL}] rendering ${mine.length} of ${allPaths.length} routes`,
+    `[shard ${SHARD_INDEX}/${SHARD_TOTAL}] rendering ${mine.length} of ${allPaths.length} routes` +
+    (SHARD_INDEX === DEDICATED_SHARD ? ' (dedicated heavy shard)' : ''),
   );
   opts.props.routesPaths = mine;
 


### PR DESCRIPTION
## Problem

Two compounding issues were preventing the sharded deploy from running:

1. **`docusaurus-8-32` runner was never usable** — every job queued indefinitely. This runner was introduced in the latest commit on `main` to address OOM failures, but the runner was never properly provisioned.

2. **`all-recipes.md` (2.7 MB) caused OOM during SSG** — this single file is 22x larger than the next biggest doc and was causing exit code 143 (SIGTERM/OOM kill) on `ubuntu-latest` whenever it landed in a shard.

## Solution

**Switch all jobs to `ubuntu-latest`** — lightweight jobs (lint, combine, deploy) never needed a larger runner. For shard builds, `ubuntu-latest` has 16 GB RAM which is sufficient given the serial SSG already in place from #714.

**Isolate `all-recipes` in a dedicated shard** — modified `build-shard-patch.js` to pull heavy routes out of the normal modulo pool and assign them exclusively to the last shard (`SHARD_TOTAL - 1`). Normal shards split the remaining routes across `SHARD_TOTAL - 1` buckets. Adding future heavy pages is a one-line change to `HEAVY_ROUTE_PATTERNS`.

**5 shards total** (down from the attempted 8, back to 4 normal + 1 dedicated):
* Shards 0–3: normal routes via `i % 4`
* Shard 4: dedicated to heavy routes (`all-recipes` and future additions)

## Verified

Run [#26527186325](https://github.com/moderneinc/moderne-docs/actions/runs/26527186325) — all 5 shards and combine passed on `ubuntu-latest`. Deploy step failed as expected (GitHub Pages environment restricts deploys to `main`).