### PR TITLE
ci: extend heavy shard matching to cover all-recipes-* per-groupId pages

### DIFF
--- a/scripts/build-shard-patch.js
+++ b/scripts/build-shard-patch.js
@@ -27,6 +27,7 @@ const originalExecuteSSG = ssgExecutor.executeSSG;
 
 // Routes matched here are pulled out of the normal modulo pool and rendered
 // exclusively by the last shard, giving them an isolated memory budget.
+// Matches all-recipes.md (index) and all-recipes-<groupId>.md per-groupId pages.
 const HEAVY_ROUTE_PATTERNS = [
   '/user-documentation/recipes/lists/all-recipes',
 ];
@@ -35,7 +36,7 @@ ssgExecutor.executeSSG = async function shardedExecuteSSG(opts) {
   const allPaths = [...opts.props.routesPaths].sort();
   const DEDICATED_SHARD = SHARD_TOTAL - 1;
 
-  const isHeavy = (p) => HEAVY_ROUTE_PATTERNS.some((pat) => p === pat || p.startsWith(pat + '/'));
+  const isHeavy = (p) => HEAVY_ROUTE_PATTERNS.some((pat) => p === pat || p.startsWith(pat + '/') || p.startsWith(pat + '-'));
   const heavyPaths = allPaths.filter(isHeavy);
   const normalPaths = allPaths.filter((p) => !isHeavy(p));
 


### PR DESCRIPTION
## Summary

- * Follows up on #724 (dedicated heavy shard for large recipe pages)
- * [openrewrite/rewrite-recipe-markdown-generator#328](https://github.com/openrewrite/rewrite-recipe-markdown-generator/pull/328) splits `all-recipes.md` (2.7 MB) into a slim index + one `all-recipes-<groupId>.md` per groupId
* The existing `HEAVY_ROUTE_PATTERNS` exact/sub-path match (`/` separator) didn't catch the new sibling pages (`-` separator) — they would have fallen back into the normal shard pool
* Adds `p.startsWith(pat + '-')` to `isHeavy` so all `all-recipes*` routes (index and per-groupId) are routed to the dedicated shard

## Test plan

- * [ ] Merge after openrewrite/rewrite-recipe-markdown-generator#328 lands and `update-docs` has run to generate the new per-groupId files
* [ ] Confirm shard 4 (dedicated) picks up `all-recipes` index + all `all-recipes-*` pages
* [ ] Confirm shards 0–3 complete without OOM