### PR TITLE
ci: isolate entire recipes/lists/ directory in dedicated shard

### DIFF
--- a/scripts/build-shard-patch.js
+++ b/scripts/build-shard-patch.js
@@ -27,16 +27,16 @@ const originalExecuteSSG = ssgExecutor.executeSSG;
 
 // Routes matched here are pulled out of the normal modulo pool and rendered
 // exclusively by the last shard, giving them an isolated memory budget.
-// Matches all-recipes.md (index) and all-recipes-<groupId>.md per-groupId pages.
+// All auto-generated lists/ pages are large and prone to OOM in normal shards.
 const HEAVY_ROUTE_PATTERNS = [
-  '/user-documentation/recipes/lists/all-recipes',
+  '/user-documentation/recipes/lists',
 ];
 
 ssgExecutor.executeSSG = async function shardedExecuteSSG(opts) {
   const allPaths = [...opts.props.routesPaths].sort();
   const DEDICATED_SHARD = SHARD_TOTAL - 1;
 
-  const isHeavy = (p) => HEAVY_ROUTE_PATTERNS.some((pat) => p === pat || p.startsWith(pat + '/') || p.startsWith(pat + '-'));
+  const isHeavy = (p) => HEAVY_ROUTE_PATTERNS.some((pat) => p === pat || p.startsWith(pat + '/'));
   const heavyPaths = allPaths.filter(isHeavy);
   const normalPaths = allPaths.filter((p) => !isHeavy(p));
 


### PR DESCRIPTION
## Problem

- After the all-recipes split (#725), the other large auto-generated files in `recipes/lists/` are causing OOM kills in normal shards:

| File | Size | Shard |
|------|------|-------|
| `recipes-by-tag.md` | 1,509 KB | 3 |
| `recipes-with-data-tables.md` | 488 KB | 0 |
| `standalone-recipes.md` | 484 KB | 2 ← currently failing |
| `scanning-recipes.md` | 100 KB | 1 |

Shard 2 is already failing on this run. Shard 3 will be next.

## Fix

Widen `HEAVY_ROUTE_PATTERNS` from the specific `all-recipes` path to the entire `/user-documentation/recipes/lists` directory. All files here are auto-generated and large — isolating the whole directory in the dedicated shard is simpler and future-proof.

- Also removes the hyphen-suffix workaround from #725 since `startsWith(pat + '/')` now covers all files under `lists/`.

## Test plan

* [ ] Confirm shards 0–3 complete without OOM
* [ ] Confirm shard 4 (dedicated) picks up all `lists/` routes