### PR TITLE
docs(connector): correct recipe marketplace fallback claim

### DIFF
--- a/docs/administrator-documentation/moderne-platform/how-to-guides/connector-configuration/configure-recipe-marketplace-repositories.md
+++ b/docs/administrator-documentation/moderne-platform/how-to-guides/connector-configuration/configure-recipe-marketplace-repositories.md
@@ -19,8 +19,8 @@ Recipe marketplace repositories are configured under the `moderne.recipe.marketp
 
 The variables/arguments in the tables below must be combined with ones found in other steps in the [Configuring the Moderne Connector guide](./connector-config.md).
 
-:::info[Defaults and override behavior]
-If no Maven recipe marketplace repositories are configured, the Moderne Platform falls back to Maven Central (`https://repo.maven.apache.org/maven2`, releases only) and Sonatype snapshots (`https://central.sonatype.com/repository/maven-snapshots/`, snapshots only). Once you configure one or more Maven repositories below, only those are searched — the defaults are not merged in, so you will need to list Maven Central and Sonatype snapshots explicitly to keep them. PyPI, NuGet, and NPM have no defaults.
+:::info[At least one Maven repository is required]
+The Moderne Platform does not fall back to Maven Central or any other public registry. You must explicitly configure at least one Maven repository below that hosts every recipe artifact (and its transitive dependencies) you intend to deploy. If you are using OpenRewrite recipes, that typically means configuring Maven Central (`https://repo.maven.apache.org/maven2/`, releases) and Sonatype snapshots (`https://central.sonatype.com/repository/maven-snapshots/`, snapshots), or an internal Nexus or Artifactory that mirrors them. PyPI, NuGet, and NPM have no defaults either: each ecosystem must be explicitly configured.
 :::
 
 ## Recommended OpenRewrite packages

--- a/docs/administrator-documentation/moderne-platform/how-to-guides/connector-configuration/connector-config.md
+++ b/docs/administrator-documentation/moderne-platform/how-to-guides/connector-configuration/connector-config.md
@@ -445,13 +445,15 @@ Moderne supports the following recipe marketplace registry types:
 * **NuGet** feeds
 * **PyPI** indexes
 
-:::info[Defaults and override behavior]
-If no Maven recipe marketplace repositories are configured, Moderne SaaS falls back to the following defaults:
+:::info[At least one Maven repository is required]
+Moderne does not fall back to Maven Central or any other public registry. You must explicitly configure at least one Maven recipe marketplace repository that hosts every recipe artifact (and its transitive dependencies) you intend to deploy.
 
-* `https://repo.maven.apache.org/maven2` (Maven Central — releases only)
-* `https://central.sonatype.com/repository/maven-snapshots/` (Sonatype — snapshots only)
+For recipes published by OpenRewrite (for example, `org.openrewrite:rewrite-core`), the simplest options are:
 
-Once you configure one or more Maven repositories, only those are searched — the defaults above are not merged in, so you will need to list Maven Central and Sonatype snapshots explicitly to keep them. PyPI, NuGet, and NPM have no defaults.
+* Maven Central: `https://repo.maven.apache.org/maven2/` (releases)
+* Sonatype snapshots: `https://central.sonatype.com/repository/maven-snapshots/` (snapshots)
+
+If you proxy public artifacts through an internal Nexus or Artifactory, point the Connector at that mirror instead. PyPI, NuGet, and NPM also have no defaults: each ecosystem must be explicitly configured.
 :::
 
 For the full list of variables/arguments, please see the [recipe marketplace repositories guide](./configure-recipe-marketplace-repositories.md).


### PR DESCRIPTION
Updating the documentation as we no longer default `Maven Central` or `Sonatype` any more

- PR for reference https://github.com/moderneinc/moderne-saas/issues/626