### PR TITLE
Update PoV guide to Spring Boot 4 best practices recipe

### DIFF
--- a/docs/user-documentation/moderne-platform/getting-started/proof-of-value.md
+++ b/docs/user-documentation/moderne-platform/getting-started/proof-of-value.md
@@ -645,14 +645,14 @@ mod study . --last-recipe-run --data-table SourcesFileResults
   </figure>
 </div>
 
-### [Spring Boot 3.5 best practices](https://app.moderne.io/recipes/io.moderne.java.spring.boot3.SpringBoot3BestPractices)
+### [Spring Boot 4 best practices](https://app.moderne.io/recipes/io.moderne.java.spring.boot4.SpringBoot4BestPractices)
 
-> Migrates to Spring Boot 3.5 and applies best practices. Includes upgrades from prior Spring Boot versions with configuration updates and dependency alignment.
+> Migrates to Spring Boot 4 and applies best practices. Includes upgrades from prior Spring Boot versions with configuration updates and dependency alignment.
 
 #### CLI commands
 
 ```bash
-mod run . --recipe io.moderne.java.spring.boot3.SpringBoot3BestPractices
+mod run . --recipe io.moderne.java.spring.boot4.SpringBoot4BestPractices
 mod study . --last-recipe-run --data-table SourcesFileResults
 ```
 


### PR DESCRIPTION
## Summary

* Updates the Spring Boot best practices section of the proof-of-value guide to point to the newer `io.moderne.java.spring.boot4.SpringBoot4BestPractices` recipe (previously `io.moderne.java.spring.boot3.SpringBoot3BestPractices`).
* Updates the section header, description, recipe link, and `mod run` CLI command accordingly.

File: `docs/user-documentation/moderne-platform/getting-started/proof-of-value.md`

## Test plan

- * [ ] `yarn build` completes for the proof-of-value page (note: `main` currently fails to build due to an unrelated regression tracked in #740; this change itself introduces no new errors or broken links).
* [ ] Verify the recipe link resolves: https://app.moderne.io/recipes/io.moderne.java.spring.boot4.SpringBoot4BestPractices