### PR TITLE
Include SDL as download option on GraphQL API reference page

### DIFF
--- a/.github/workflows/update-graphql-docs.yml
+++ b/.github/workflows/update-graphql-docs.yml
@@ -34,9 +34,14 @@ jobs:
           APOLLO_KEY: ${{ secrets.APOLLO_KEY }}
         run: rover graph fetch Moderne-SaaS-API@SaaS-v2 --format json > /tmp/schema.json
 
+      - name: Extract SDL
+        run: |
+          mkdir -p static/graphql
+          jq -r '.data.sdl.contents' /tmp/schema.json > static/graphql/schema.graphql
+
       - name: Generate GraphQL API reference
         run: |
-          node scripts/generate_graphql_docs.mjs /tmp/schema.json \
+          node scripts/generate_graphql_docs.mjs /tmp/schema.json --sdl-path /graphql/schema.graphql \
             > docs/user-documentation/moderne-platform/references/graphql-api-reference.md
 
       - name: Commit and push
@@ -44,6 +49,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
           git add docs/user-documentation/moderne-platform/references/graphql-api-reference.md
+          git add static/graphql/schema.graphql
           git diff --cached --quiet && echo "No changes — skipping commit." && exit 0
           git commit -m "[Auto] Update GraphQL API reference as of $(date +'%Y-%m-%dT%H%M')"
           for attempt in 1 2 3; do

--- a/scripts/check-file-types.js
+++ b/scripts/check-file-types.js
@@ -3,7 +3,7 @@ const { execSync } = require('child_process');
 const path = require('path');
 
 const ALLOWED_EXTENSIONS = new Set([
-  '.md', '.mdx', '.tsx', '.ts', '.js', '.mjs', '.css', '.json',
+  '.md', '.mdx', '.tsx', '.ts', '.js', '.mjs', '.css', '.json', '.graphql',
   '.png', '.gif', '.jpg', '.jpeg', '.svg', '.ico',
   '.yaml', '.yml', '.toml', '.lock', '.txt', '.excalidraw',
 ]);

--- a/scripts/generate_graphql_docs.mjs
+++ b/scripts/generate_graphql_docs.mjs
@@ -176,7 +176,7 @@ function cell(text) {
   return mdxEscape(text.replace(/\n+/g, ' ')).replace(/\|/g, '\\|');
 }
 
-export function generateMarkdown(ops, types) {
+export function generateMarkdown(ops, types, sdlPath = null) {
   const known = new Set(types.map(t => t.name));
   const lines = [
     '---',
@@ -189,6 +189,9 @@ export function generateMarkdown(ops, types) {
     '*This page is auto-generated from the Moderne GraphQL schema. Do not edit manually.*',
     '',
   ];
+  if (sdlPath) {
+    lines.push(`[Download schema (SDL)](${sdlPath})`, '');
+  }
 
   for (const kind of ['query', 'mutation', 'subscription']) {
     const group = ops.filter(o => o.kind === kind).sort((a, b) => a.name.localeCompare(b.name));
@@ -242,11 +245,13 @@ export function generateMarkdown(ops, types) {
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
   if (process.argv.length < 3) {
-    process.stderr.write(`Usage: node ${process.argv[1]} <rover-output.json>\n`);
+    process.stderr.write(`Usage: node ${process.argv[1]} <rover-output.json> [--sdl-path <url>]\n`);
     process.exit(1);
   }
+  const sdlPathIdx = process.argv.indexOf('--sdl-path');
+  const sdlPath = sdlPathIdx !== -1 ? process.argv[sdlPathIdx + 1] : null;
   const raw = readFileSync(process.argv[2], 'utf-8');
   const sdl = JSON.parse(raw).data.sdl.contents;
   const { ops, types } = parseSchema(sdl);
-  process.stdout.write(generateMarkdown(ops, types));
+  process.stdout.write(generateMarkdown(ops, types, sdlPath));
 }

--- a/scripts/generate_graphql_docs.test.mjs
+++ b/scripts/generate_graphql_docs.test.mjs
@@ -223,8 +223,8 @@ describe('generateMarkdown', () => {
     const out = md();
     expect(out).toContain('### Enums');
     expect(out).toContain('##### `UserRole`');
-    expect(out).toContain('- `ADMIN`');
-    expect(out).toContain('- `MEMBER`');
+    expect(out).toContain('* `ADMIN`');
+    expect(out).toContain('* `MEMBER`');
   });
 
   it('renders union members', () => {

--- a/scripts/generate_graphql_docs.test.mjs
+++ b/scripts/generate_graphql_docs.test.mjs
@@ -244,4 +244,16 @@ describe('generateMarkdown', () => {
     const userSection = out.slice(out.indexOf('#### `user`'), out.indexOf('#### `users`'));
     expect(userSection).not.toContain('Deprecated');
   });
+
+  it('includes SDL download link when sdlPath is provided', () => {
+    const { ops, types } = parseSchema(SAMPLE_SDL);
+    const out = generateMarkdown(ops, types, '/graphql/schema.graphql');
+    expect(out).toContain('[Download schema (SDL)](/graphql/schema.graphql)');
+  });
+
+  it('omits SDL download link when sdlPath is not provided', () => {
+    const { ops, types } = parseSchema(SAMPLE_SDL);
+    const out = generateMarkdown(ops, types);
+    expect(out).not.toContain('Download schema');
+  });
 });

--- a/static/graphql/schema.graphql
+++ b/static/graphql/schema.graphql
@@ -1,0 +1,1 @@
+# Placeholder — regenerated daily by the update-graphql-docs workflow.


### PR DESCRIPTION
## Summary

* Adds a daily-regenerated `static/graphql/schema.graphql` file served at `/graphql/schema.graphql` so users can download the raw Moderne GraphQL schema.
* Extends `scripts/generate_graphql_docs.mjs` with an optional `--sdl-path <url>` argument; when provided, a plain download link is injected into the generated Markdown just below the "do not edit" notice.
* Updates `.github/workflows/update-graphql-docs.yml` to extract the SDL with `jq`, write it to `static/graphql/schema.graphql`, pass `--sdl-path` to the generator, and stage the file alongside the Markdown in the auto-commit step.
* Adds a placeholder `static/graphql/schema.graphql` so the path resolves in the built site before the first workflow run.
* Fixes a pre-existing test assertion that expected dash-style bullets (`-`) for enum values when the generator emits asterisks (`*`), bringing the suite to 33/33 passing.

## Test plan

- [ ] All 33 unit tests pass (`yarn test:run scripts/generate_graphql_docs.test.mjs`)
- [ ] Confirm the download link `[Download schema (SDL)](/graphql/schema.graphql)` appears near the top of the rendered GraphQL API reference page after the next workflow run
- [ ] Confirm `static/graphql/schema.graphql` is updated by the next scheduled `Update GraphQL API docs` workflow run and contains valid SDL