### PR TITLE
Fix double h1 warnings

### DIFF
--- a/scripts/check-markdown.mjs
+++ b/scripts/check-markdown.mjs
@@ -24,7 +24,7 @@ import remarkLint from 'remark-lint';
 import { lintRule } from 'unified-lint-rule';
 import remarkLintUnorderedListMarkerStyle from 'remark-lint-unordered-list-marker-style';
 import remarkLintNoConsecutiveBlankLines from 'remark-lint-no-consecutive-blank-lines';
-import { visit } from 'unist-util-visit';
+import { visit, EXIT } from 'unist-util-visit';
 import { VFile } from 'vfile';
 import { readFileSync } from 'fs';
 import { resolve, relative } from 'path';
@@ -61,20 +61,36 @@ const noBareExpression = lintRule(
 // ---------------------------------------------------------------------------
 // Custom rule: no-h1-in-body
 //
-// Docusaurus renders the frontmatter `title` field as the page <h1>. A
-// # heading in the document body creates a double-h1, breaking page layout.
+// A Docusaurus page has exactly one h1. Its mdx-loader takes the first heading
+// in the document — the first heading/thematic-break node, even when JSX such
+// as <VersionBanner> precedes it — and, if it's an h1, wraps it in <header> as
+// the page title. When there's no leading h1, Docusaurus synthesizes the page
+// h1 from the frontmatter `title:` (falling back to the slug). Either way that
+// first h1 is fine; any *additional* # h1 renders as a raw, duplicate h1. So we
+// flag every h1 except the one Docusaurus turns into the page title.
 // ---------------------------------------------------------------------------
 
 const noH1InBody = lintRule(
   { origin: 'remark-lint:no-h1-in-body' },
   (tree, file) => {
-    const frontmatter = tree.children.find(n => n.type === 'yaml');
-    if (!frontmatter || !/^title:/m.test(frontmatter.value)) return;
+    // The page-title h1 is the first heading/thematic-break node in document
+    // order, but only when that node is itself an h1 (mirrors Docusaurus's
+    // contentTitle remark plugin, which stops at the first such node).
+    let firstBlock = null;
+    visit(tree, ['heading', 'thematicBreak'], (node) => {
+      firstBlock = node;
+      return EXIT;
+    });
+    const pageTitleH1 =
+      firstBlock && firstBlock.type === 'heading' && firstBlock.depth === 1
+        ? firstBlock
+        : null;
     visit(tree, 'heading', (node) => {
-      if (node.depth === 1) {
+      if (node.depth === 1 && node !== pageTitleH1) {
         file.message(
-          'Do not use # h1 headings when frontmatter has title:. ' +
-          'Docusaurus injects the frontmatter title as h1, creating a double-h1.',
+          'Extra # h1 heading. Docusaurus renders only one page h1 (the first ' +
+          'heading, or the frontmatter title:); additional # headings become ' +
+          'duplicate h1s. Use ## or lower for in-page sections.',
           node,
         );
       }

--- a/scripts/check-markdown.test.mjs
+++ b/scripts/check-markdown.test.mjs
@@ -85,32 +85,52 @@ describe('no-bare-mdx-expression', () => {
 // ---------------------------------------------------------------------------
 // Rule: no-h1-in-body
 //
-// Docusaurus renders the frontmatter `title` as the page <h1>. A # heading
-// in the document body creates a double-h1, breaking page layout.
+// A Docusaurus page has exactly one h1: the first heading (wrapped in <header>)
+// or, when there's no leading h1, a synthetic h1 from the frontmatter title:
+// (falling back to the slug). That first h1 is fine; any *additional* # h1
+// renders as a duplicate. The rule flags every h1 except the page-title one.
 // ---------------------------------------------------------------------------
 
 describe('no-h1-in-body', () => {
-  it('flags a # h1 when frontmatter also has title: (double-h1 bug)', async () => {
+  it('does not flag a single leading # h1 — it becomes the page title', async () => {
     const md = ['---', 'title: My Page', '---', '', '# My Page'].join('\n');
     const issues = await checkMarkdown(md, 'test.md');
-    expect(issues.filter(i => i.rule === 'no-h1-in-body')).toHaveLength(1);
-    expect(issues.find(i => i.rule === 'no-h1-in-body')).toMatchObject({ severity: 'warning' });
+    expect(issues.filter(i => i.rule === 'no-h1-in-body')).toHaveLength(0);
   });
 
-  it('does not flag # h1 when frontmatter has no title (body h1 is the page title)', async () => {
-    const md = ['---', 'description: A description.', '---', '', '# My Page'].join('\n');
+  it('does not flag a single # h1 preceded by leading JSX (Docusaurus still extracts it)', async () => {
+    const md = [
+      '---', 'title: FAQ', '---', '',
+      "import VersionBanner from '@site/src/components/VersionBanner';", '',
+      '<VersionBanner version="v1" linkPath="/faq" />', '',
+      '# FAQ',
+    ].join('\n');
     const issues = await checkMarkdown(md, 'test.md');
     expect(issues.filter(i => i.rule === 'no-h1-in-body')).toHaveLength(0);
   });
 
-  it('does not flag # h1 with no frontmatter at all', async () => {
-    const md = '# My Page\n\nContent here.';
-    const issues = await checkMarkdown(md, 'test.md');
-    expect(issues.filter(i => i.rule === 'no-h1-in-body')).toHaveLength(0);
+  it('flags a second # h1 in the body as a duplicate page h1', async () => {
+    const md = ['# First', '', 'Body.', '', '# Second'].join('\n');
+    const issues = (await checkMarkdown(md, 'test.md')).filter(i => i.rule === 'no-h1-in-body');
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({ line: 5, severity: 'warning' });
   });
 
-  it('does not flag ## h2 headings even with title in frontmatter', async () => {
+  it('flags a body # h1 when the first heading is an h2 (page h1 comes from title:/slug)', async () => {
+    const md = ['---', 'title: My Page', '---', '', '## Intro', '', '# Late h1'].join('\n');
+    const issues = (await checkMarkdown(md, 'test.md')).filter(i => i.rule === 'no-h1-in-body');
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({ line: 7 });
+  });
+
+  it('does not flag ## h2 headings', async () => {
     const md = ['---', 'title: My Page', '---', '', '## Section heading'].join('\n');
+    const issues = await checkMarkdown(md, 'test.md');
+    expect(issues.filter(i => i.rule === 'no-h1-in-body')).toHaveLength(0);
+  });
+
+  it('does not flag a single # h1 with no frontmatter', async () => {
+    const md = '# My Page\n\nContent here.';
     const issues = await checkMarkdown(md, 'test.md');
     expect(issues.filter(i => i.rule === 'no-h1-in-body')).toHaveLength(0);
   });


### PR DESCRIPTION
The previous linter incorrectly warned about title + h1.