### PR TITLE
Require s3:ListBucket for the Connector S3 organization source

### DIFF
--- a/docs/administrator-documentation/moderne-platform/how-to-guides/connector-configuration/configure-a-connector-with-s3-access.md
+++ b/docs/administrator-documentation/moderne-platform/how-to-guides/connector-configuration/configure-a-connector-with-s3-access.md
@@ -35,15 +35,19 @@ For background on how the Connector uses CSV sources and how S3 fits into the ov
         {
             "Effect": "Allow",
             "Action": [
-                "s3:GetObject"
+                "s3:GetObject",
+                "s3:ListBucket"
             ],
             "Resource": [
+                "arn:aws:s3:::my-bucket",
                 "arn:aws:s3:::my-bucket/repos.csv"
             ]
         }
     ]
 }
 ```
+
+The `s3:GetObject` permission applies to the CSV object and lets the Connector read it. The `s3:ListBucket` permission applies to the bucket itself and is required because the Connector verifies that it can reach the bucket as a startup connectivity check before it reads the object. The Connector fails to start if this check does not pass.
 
 ## Authentication options
 


### PR DESCRIPTION
## Background / problem

The S3 organization source guide for the Connector listed `s3:GetObject` as the only required permission, scoped to the CSV object. However, the Connector also runs a startup connectivity check that issues a `HeadBucket` call against the bucket, and `HeadBucket` is governed by `s3:ListBucket`. A role granted only `s3:GetObject` can read the CSV but fails that check, so the Connector aborts on startup with a connectivity verification error even though the object itself is reachable. Following the guide as written therefore produces a Connector that does not start.

## Solution

Updated the documented IAM policy to require `s3:ListBucket` on the bucket resource alongside `s3:GetObject` on the CSV object, mirroring the policy already documented for the v1 agent's S3 LST source. Added a short explanation of what each permission is for and noted that the Connector fails to start if the bucket connectivity check does not pass.
