### PR TITLE
Use Java best practices recipe in proof of value pages

### DIFF
--- a/docs/user-documentation/moderne-platform-v1/getting-started/proof-of-value.md
+++ b/docs/user-documentation/moderne-platform-v1/getting-started/proof-of-value.md
@@ -623,14 +623,14 @@ mod study . --last-recipe-run --data-table SourcesFileResults
 
 Major migrations are complex transformations that typically automate 80-90% of the work, with the remainder requiring manual developer intervention. They are typically composed of multiple, complex recipes.
 
-### [Java best practices](https://app.moderne.io/recipes/org.openrewrite.java.migrate.JavaBestPractices)
+### [Migrate to Java 25](https://app.moderne.io/recipes/org.openrewrite.java.migrate.UpgradeToJava25)
 
-> Applies opinionated best practices for Java projects targeting Java 25. Includes the full Java 25 upgrade chain plus additional improvements to code style, API usage, and third-party dependency reduction that go beyond what the version migration recipes apply.
+> Comprehensive migration from Java 8/11 to Java 25. Updates build files for Java 25 target/source, replaces deprecated APIs, adopts new language features, upgrades plugins to Java 25 compatible versions, and updates GitHub Actions configurations. Swap in the recipe for another target version (such as `org.openrewrite.java.migrate.UpgradeToJava17`) when you need to land on an earlier release.
 
 #### CLI commands
 
 ```bash
-mod run . --recipe org.openrewrite.java.migrate.JavaBestPractices
+mod run . --recipe org.openrewrite.java.migrate.UpgradeToJava25
 mod study . --last-recipe-run --data-table SourcesFileResults
 ```
 
@@ -647,6 +647,17 @@ mod study . --last-recipe-run --data-table SourcesFileResults
     <figcaption>_Fixing deprecated methods_</figcaption>
   </figure>
 </div>
+
+### [Java best practices](https://app.moderne.io/recipes/org.openrewrite.java.migrate.JavaBestPractices)
+
+> Applies opinionated best practices for Java projects targeting Java 25. Includes the full Java 25 upgrade chain plus additional improvements to code style, API usage, and third-party dependency reduction that go beyond what the version migration recipes apply.
+
+#### CLI commands
+
+```bash
+mod run . --recipe org.openrewrite.java.migrate.JavaBestPractices
+mod study . --last-recipe-run --data-table SourcesFileResults
+```
 
 ### [Spring Boot 3.5 best practices](https://app.moderne.io/recipes/io.moderne.java.spring.boot3.SpringBoot3BestPractices)
 

--- a/docs/user-documentation/moderne-platform-v1/getting-started/proof-of-value.md
+++ b/docs/user-documentation/moderne-platform-v1/getting-started/proof-of-value.md
@@ -623,14 +623,14 @@ mod study . --last-recipe-run --data-table SourcesFileResults
 
 Major migrations are complex transformations that typically automate 80-90% of the work, with the remainder requiring manual developer intervention. They are typically composed of multiple, complex recipes.
 
-### [Migrate to Java 25](https://app.moderne.io/recipes/org.openrewrite.java.migrate.UpgradeToJava25)
+### [Java best practices](https://app.moderne.io/recipes/org.openrewrite.java.migrate.JavaBestPractices)
 
-> Comprehensive migration from Java 8/11 to Java 25. Updates build files for Java 25 target/source, replaces deprecated APIs, adopts new language features, upgrades plugins to Java 25 compatible versions, and updates GitHub Actions configurations.
+> Applies opinionated best practices for Java projects targeting Java 25. Includes the full Java 25 upgrade chain plus additional improvements to code style, API usage, and third-party dependency reduction that go beyond what the version migration recipes apply.
 
 #### CLI commands
 
 ```bash
-mod run . --recipe org.openrewrite.java.migrate.UpgradeToJava25
+mod run . --recipe org.openrewrite.java.migrate.JavaBestPractices
 mod study . --last-recipe-run --data-table SourcesFileResults
 ```
 

--- a/docs/user-documentation/moderne-platform/getting-started/proof-of-value.md
+++ b/docs/user-documentation/moderne-platform/getting-started/proof-of-value.md
@@ -621,14 +621,14 @@ mod study . --last-recipe-run --data-table SourcesFileResults
 
 Major migrations are complex transformations that typically automate 80-90% of the work, with the remainder requiring manual developer intervention. They are typically composed of multiple, complex recipes.
 
-### [Migrate to Java 25](https://app.moderne.io/recipes/org.openrewrite.java.migrate.UpgradeToJava25)
+### [Java best practices](https://app.moderne.io/recipes/org.openrewrite.java.migrate.JavaBestPractices)
 
-> Comprehensive migration from Java 8/11 to Java 25. Updates build files for Java 25 target/source, replaces deprecated APIs, adopts new language features, upgrades plugins to Java 25 compatible versions, and updates GitHub Actions configurations.
+> Applies opinionated best practices for Java projects targeting Java 25. Includes the full Java 25 upgrade chain plus additional improvements to code style, API usage, and third-party dependency reduction that go beyond what the version migration recipes apply.
 
 #### CLI commands
 
 ```bash
-mod run . --recipe org.openrewrite.java.migrate.UpgradeToJava25
+mod run . --recipe org.openrewrite.java.migrate.JavaBestPractices
 mod study . --last-recipe-run --data-table SourcesFileResults
 ```
 

--- a/docs/user-documentation/moderne-platform/getting-started/proof-of-value.md
+++ b/docs/user-documentation/moderne-platform/getting-started/proof-of-value.md
@@ -621,14 +621,14 @@ mod study . --last-recipe-run --data-table SourcesFileResults
 
 Major migrations are complex transformations that typically automate 80-90% of the work, with the remainder requiring manual developer intervention. They are typically composed of multiple, complex recipes.
 
-### [Java best practices](https://app.moderne.io/recipes/org.openrewrite.java.migrate.JavaBestPractices)
+### [Migrate to Java 25](https://app.moderne.io/recipes/org.openrewrite.java.migrate.UpgradeToJava25)
 
-> Applies opinionated best practices for Java projects targeting Java 25. Includes the full Java 25 upgrade chain plus additional improvements to code style, API usage, and third-party dependency reduction that go beyond what the version migration recipes apply.
+> Comprehensive migration from Java 8/11 to Java 25. Updates build files for Java 25 target/source, replaces deprecated APIs, adopts new language features, upgrades plugins to Java 25 compatible versions, and updates GitHub Actions configurations. Swap in the recipe for another target version (such as `org.openrewrite.java.migrate.UpgradeToJava17`) when you need to land on an earlier release.
 
 #### CLI commands
 
 ```bash
-mod run . --recipe org.openrewrite.java.migrate.JavaBestPractices
+mod run . --recipe org.openrewrite.java.migrate.UpgradeToJava25
 mod study . --last-recipe-run --data-table SourcesFileResults
 ```
 
@@ -645,6 +645,17 @@ mod study . --last-recipe-run --data-table SourcesFileResults
     <figcaption>_Fixing deprecated methods_</figcaption>
   </figure>
 </div>
+
+### [Java best practices](https://app.moderne.io/recipes/org.openrewrite.java.migrate.JavaBestPractices)
+
+> Applies opinionated best practices for Java projects targeting Java 25. Includes the full Java 25 upgrade chain plus additional improvements to code style, API usage, and third-party dependency reduction that go beyond what the version migration recipes apply.
+
+#### CLI commands
+
+```bash
+mod run . --recipe org.openrewrite.java.migrate.JavaBestPractices
+mod study . --last-recipe-run --data-table SourcesFileResults
+```
 
 ### [Spring Boot 4 best practices](https://app.moderne.io/recipes/io.moderne.java.spring.boot4.SpringBoot4BestPractices)
 


### PR DESCRIPTION
Replaces the **Migrate to Java 25** entry under "Major migrations" with the new expanded **Java best practices** recipe (`org.openrewrite.java.migrate.JavaBestPractices`) in both the moderne-platform and moderne-platform-v1 proof of value pages. Updates the heading, link, description, and CLI command accordingly; the existing recipe-result figures are retained since the new recipe includes the full Java 25 upgrade chain.