### PR TITLE
Update Trigrep docs for CLI v4.3.0 (.zoekt shards, full type chain)

### DIFF
--- a/docs/hands-on-learning/agent-tools/module-4-trigrep.md
+++ b/docs/hands-on-learning/agent-tools/module-4-trigrep.md
@@ -1,59 +1,32 @@
 ---
 sidebar_label: "Module 4: Trigrep"
-description: Build a trigram search index with mod postbuild search index, then explore literal, regex, and structural queries across your workspace.
+description: Explore the trigram search index produced inline by mod build using literal, regex, and structural queries across your workspace.
 draft: true
 ---
 
 # Module 4: Trigrep
 
-In this module, you'll build a trigram search index across the workspace from [Module 1](./module-1-cli-and-lsts.md) and explore what indexed search makes possible. You'll run literal queries, regex, and Comby-style structural patterns, and you'll see how Trigrep's Java-aware filters (`visibility:`, `extends:`, `returns:`, etc.) push beyond what `grep` can do.
+In this module, you'll explore the trigram search index that `mod build` already produced across the workspace from [Module 1](./module-1-cli-and-lsts.md). You'll run literal queries, regex, and Comby-style structural patterns, and you'll see how Trigrep's Java-aware filters (`visibility:`, `extends:`, `returns:`, etc.) push beyond what `grep` can do.
 
 For the deep reference on syntax and semantics, see [Moderne Trigrep](../../user-documentation/agent-tools/trigrep.md). This module is hands-on practice.
 
-## Exercise 4-1: Build the search index
+## Exercise 4-1: Confirm the search index exists
 
 ### Goals for this exercise
 
-* Generate a trigram index over every repository in your workspace
-* Understand what `mod postbuild search index` produces and where it's stored
+* Understand where Trigrep's index files live
+* Confirm your workspace has them so the rest of the module works
 
 ### Steps
 
-#### Step 1: Build the index
+#### Step 1: How the index gets built
 
-From your workspace root:
+The trigram index is produced inline by `mod build`, alongside each repository's V3 LST. There is no separate indexing step. If you ran `mod build` in [Module 1](./module-1-cli-and-lsts.md), the index already exists.
 
-```bash
-mod postbuild search index .
-```
-
-The CLI walks every repository with an LST and produces a trigram index per repo. Indexes live in `.moderne/mcp/search/` inside each repository and use the `.zoekt` extension. Index size is roughly 10-20% of the source size.
-
-<details>
-<summary>Sample output</summary>
-
-```text
-● Generating search indexes
-  ...
-  9% (3s)     ▶ awslabs/aws-saas-boost@main (no LST)
-  9% (3s)         Skipped: no LST artifact
- 18% (3s)     ▶ finos/messageml-utils@main
- 18% (3s)         ✓ Indexed
- ...
-100% (4s)     Done
-
-Generated search indexes: 10 indexed, 1 skipped, 0 failed
-
-● What to do next
-    > 1 repository have no LST artifact. Run mod build first.
-```
-
-The `1 skipped` count corresponds to the same `awslabs/aws-saas-boost` repo whose LST failed to download in [Module 1](./module-1-cli-and-lsts.md). Without an LST, there's nothing to index.
-
-</details>
+The index is split into one `.tri` file per source file, written under `.moderne/build/{buildId}/objects/{xx}/{rest}.tri` next to the matching V3 LST `.body` file. The `.tri` files do not store source content — at search time, Trigrep reads the matched line from the sibling `.body`, which keeps the disk overhead small (~12% over the LST itself on Spring PetClinic).
 
 :::tip
-Re-run the same command after significant code changes (or after a fresh `mod build`). Add `--force` if you want to regenerate even when the index already exists.
+To regenerate after significant code changes, just re-run `mod build`. There is no `--force` flag specific to the index, and no separate `mod postbuild` step (the legacy `mod postbuild search index` command is now a deprecated no-op).
 :::
 
 #### Step 2: Run a sanity-check search
@@ -82,7 +55,7 @@ Notice how each search returns in well under a second, even though the workspace
   0% (1s)     ▶ apache/maven-doxia@master
   0% (1s)         ✓ No matches
   9% (1s)     ▶ awslabs/aws-saas-boost@main
-  9% (1s)         No search index
+  9% (1s)         No trigram sidecars (rebuild with latest V3)
   ...
  27% (1s)     ▶ finos/spring-bot@spring-bot-master
  27% (1s)         ● File(libs/.../BotController.java)
@@ -93,10 +66,10 @@ Notice how each search returns in well under a second, even though the workspace
 Found 12 matches in 12 files across 10 repositories.
 
 ● What to do next
-    > 1 repository has no search index. Run mod postbuild search index to generate indexes from existing LSTs.
+    > 1 repository has no trigram sidecars (legacy or unindexed LST). Rebuild with mod build to generate a current V3 LST with .tri sidecars.
 ```
 
-The `No search index` line for `awslabs/aws-saas-boost` is expected — that repo's LST didn't sync (see [Module 1 Step 2](./module-1-cli-and-lsts.md)), so the index couldn't be built. The other 10 repos searched fine.
+The `No trigram sidecars` line for `awslabs/aws-saas-boost` is expected — that repo's LST didn't sync (see [Module 1 Step 2](./module-1-cli-and-lsts.md)), so there's nothing to search against. ("Sidecar" here is just how the CLI labels the per-file `.tri` index files.) The other 10 repos searched fine.
 
 </details>
 
@@ -106,8 +79,8 @@ Zero matches just means none of these repos use the keyword — for example, the
 
 ### Takeaways
 
-* `mod postbuild search index` is a one-time setup step per workspace (run again after big code changes).
-* Indexes are local — there's no server to manage.
+* The trigram index is produced inline by `mod build` — no separate indexing step. Re-run `mod build` to refresh after big code changes.
+* The index is local — there's no server to manage.
 
 ---
 

--- a/docs/hands-on-learning/agent-tools/module-4-trigrep.md
+++ b/docs/hands-on-learning/agent-tools/module-4-trigrep.md
@@ -23,7 +23,7 @@ For the deep reference on syntax and semantics, see [Moderne Trigrep](../../user
 
 The trigram index is produced inline by `mod build`, alongside each repository's V3 LST. There is no separate indexing step. If you ran `mod build` in [Module 1](./module-1-cli-and-lsts.md), the index already exists.
 
-The index is split into one `.tri` file per source file, written under `.moderne/build/{buildId}/objects/{xx}/{rest}.tri` next to the matching V3 LST `.body` file. The `.tri` files do not store source content — at search time, Trigrep reads the matched line from the sibling `.body`, which keeps the disk overhead small (~12% over the LST itself on Spring PetClinic).
+Each source set writes its own `.zoekt` shard under `.moderne/build/{buildId}/sources/{sourceSet}/shard-*.zoekt`, and `mod build` then assembles them into a single repo-level index under `.moderne/build/{buildId}/index/merged-*.zoekt` (size-bounded chunks, plus `assembly.csv` and a `.complete` sentinel written last). The shards carry the document's printed-LST content, so a search reads matched lines straight from the shard.
 
 :::tip
 To regenerate after significant code changes, just re-run `mod build`. There is no `--force` flag specific to the index, and no separate `mod postbuild` step (the legacy `mod postbuild search index` command is now a deprecated no-op).
@@ -55,7 +55,7 @@ Notice how each search returns in well under a second, even though the workspace
   0% (1s)     ▶ apache/maven-doxia@master
   0% (1s)         ✓ No matches
   9% (1s)     ▶ awslabs/aws-saas-boost@main
-  9% (1s)         No trigram sidecars (rebuild with latest V3)
+  9% (1s)         No trigram shards (rebuild)
   ...
  27% (1s)     ▶ finos/spring-bot@spring-bot-master
  27% (1s)         ● File(libs/.../BotController.java)
@@ -66,10 +66,10 @@ Notice how each search returns in well under a second, even though the workspace
 Found 12 matches in 12 files across 10 repositories.
 
 ● What to do next
-    > 1 repository has no trigram sidecars (legacy or unindexed LST). Rebuild with mod build to generate a current V3 LST with .tri sidecars.
+    > 1 repository has no trigram shards (legacy or unindexed LST). Rebuild with mod build to generate a current V3 LST with .zoekt shards.
 ```
 
-The `No trigram sidecars` line for `awslabs/aws-saas-boost` is expected — that repo's LST didn't sync (see [Module 1 Step 2](./module-1-cli-and-lsts.md)), so there's nothing to search against. ("Sidecar" here is just how the CLI labels the per-file `.tri` index files.) The other 10 repos searched fine.
+The `No trigram shards` line for `awslabs/aws-saas-boost` is expected — that repo's LST didn't sync (see [Module 1 Step 2](./module-1-cli-and-lsts.md)), so there's nothing to search against. The other 10 repos searched fine.
 
 </details>
 

--- a/docs/hands-on-learning/agent-tools/module-5-mcp.md
+++ b/docs/hands-on-learning/agent-tools/module-5-mcp.md
@@ -245,7 +245,7 @@ You now have a working setup that combines:
 * Prethink-generated context (`.moderne/context/`) describing each repository's architecture and code quality
 * A trigram search index for sub-second whole-workspace search
 
-Point all of this at your own repositories and you'll get the same setup with your code. The same `mod git sync` / `mod build` / `mod run` / `mod postbuild search index` commands work whether you're targeting public Spring projects or your private monorepo.
+Point all of this at your own repositories and you'll get the same setup with your code. The same `mod git sync` / `mod build` / `mod run` commands work whether you're targeting public Spring projects or your private monorepo. The trigram search index is produced inline by `mod build` — there's no separate indexing step.
 
 ## Further reading
 

--- a/docs/hands-on-learning/agent-tools/workshop-overview.md
+++ b/docs/hands-on-learning/agent-tools/workshop-overview.md
@@ -63,5 +63,5 @@ Examples in this workshop demo with Claude Code (slash commands like `/moderne:c
 * [Module 1: CLI and LSTs](./module-1-cli-and-lsts.md) - Install the Moderne CLI, install the Prethink recipe modules, sync repositories, and build LSTs
 * [Module 2: Install agent tools](./module-2-install-agent-tools.md) - Install skills and the MCP server with `mod config agent-tools install`, and verify what each agent now exposes
 * [Module 3: Prethink](./module-3-prethink.md) - Run Prethink, apply the changes, inspect the generated context, and ask your agent to visualize the code quality metrics
-* [Module 4: Trigrep](./module-4-trigrep.md) - Build a search index with `mod postbuild search index` and explore literal, regex, and structural queries
+* [Module 4: Trigrep](./module-4-trigrep.md) - Explore literal, regex, and structural queries against the trigram search index produced inline by `mod build`
 * [Module 5: MCP server](./module-5-mcp.md) - Explore how the Moderne MCP server exposes semantic search, navigation, and refactoring tools to your agent

--- a/docs/user-documentation/agent-tools/mcp/security.md
+++ b/docs/user-documentation/agent-tools/mcp/security.md
@@ -116,7 +116,7 @@ The MCP server exposes two read-only status resources:
 
 * All repository source code (read for indexing and analysis; never transmitted)
 * The LST (written to `.moderne/mcp/lst/` inside the repository)
-* The trigram search index (written to `.moderne/mcp/search/` inside the repository)
+* The trigram search index (per-file `.tri` files written alongside LST `.body` files under `.moderne/build/{buildId}/objects/` inside the repository, produced inline by `mod build`)
 * Recipe run output and DataTables (written to `.moderne/mcp/run/` inside the repository; auto-deleted after one hour)
 * The tool-observations CSV (written to `~/.moderne/mcp/tool-observations.csv`)
 * All MCP protocol messages (carried over stdin/stdout; never over a network)
@@ -173,8 +173,9 @@ In a future release, the Moderne CLI will provide an opt-in feature to connect t
 | Repository working tree                                   | Source files read to build the LST, trigram search index, and execute recipe transformations.                                                                  |
 | `{repo}/.git/`                                            | Git metadata for detecting the repository root and worktree configurations.                                                                                    |
 | `{repo}/.moderne/recipes-v5.csv`                          | Per-repository recipe marketplace override, if present.                                                                                                        |
-| `{repo}/.moderne/mcp/search/*.zoekt`                      | Trigram search index shard files (read back after being written by the indexer).                                                                               |
-| `{repo}/.moderne/mcp/lst/`                                | Cached LST files from prior builds.                                                                                                                            |
+| `{repo}/.moderne/build/{buildId}/objects/**/*.tri`        | Per-file trigram index files produced by `mod build`, read by `mod search` and the MCP search tools.                                                           |
+| `{repo}/.moderne/build/{buildId}/objects/**/*.body`       | V3 LST body files. The `.tri` files do not store file content; source bytes are resolved from the sibling `.body` at search time.                              |
+| `{repo}/.moderne/mcp/lst/`                                | Cached LST files from prior `mod mcp` builds.                                                                                                                  |
 | `~/.moderne/cli/recipes-v5.csv`                           | Global recipe marketplace catalog.                                                                                                                             |
 | `~/.moderne/tray/server.port`                             | Port number of the tray app's HTTP server (macOS/tray feature only).                                                                                           |
 | `~/.moderne/tray/server.lock`                             | Lock file for detecting whether the tray app is running (macOS/tray feature only).                                                                             |
@@ -185,8 +186,9 @@ In a future release, the Moderne CLI will provide an opt-in feature to connect t
 | Location                                              | Purpose                                                                           |
 |-------------------------------------------------------|-----------------------------------------------------------------------------------|
 | `{repo}/**` (arbitrary paths)                         | Source files modified, added, or deleted by refactoring recipes.                  |
-| `{repo}/.moderne/mcp/lst/`                            | Serialized LST files after each build.                                            |
-| `{repo}/.moderne/mcp/search/*.zoekt`                  | Trigram index shard files.                                                        |
+| `{repo}/.moderne/mcp/lst/`                            | Serialized LST files after each `mod mcp` build.                                  |
+| `{repo}/.moderne/build/{buildId}/objects/**/*.tri`    | Per-file trigram index files produced inline by `mod build`.                      |
+| `{repo}/.moderne/build/{buildId}/objects/**/*.body`   | V3 LST body files produced inline by `mod build`.                                 |
 | `{repo}/.moderne/mcp/run/{runId}/datatables/*.csv.gz` | DataTable files produced by recipe runs. Auto-deleted after one hour.             |
 | `{repo}/.moderne/mcp/lst/recipe.log`                  | Log of Maven artifact resolution activity during recipe preparation.              |
 | `{repo}/.moderne/mcp/lst/parsing-events.json`         | Cached parsing events, replayed to the tray app on restart.                       |

--- a/docs/user-documentation/agent-tools/mcp/security.md
+++ b/docs/user-documentation/agent-tools/mcp/security.md
@@ -116,7 +116,7 @@ The MCP server exposes two read-only status resources:
 
 * All repository source code (read for indexing and analysis; never transmitted)
 * The LST (written to `.moderne/mcp/lst/` inside the repository)
-* The trigram search index (per-file `.tri` files written alongside LST `.body` files under `.moderne/build/{buildId}/objects/` inside the repository, produced inline by `mod build`)
+* The trigram search index (`.zoekt` shards under `.moderne/build/{buildId}/sources/` and the assembled repo-level index under `.moderne/build/{buildId}/index/` inside the repository, produced inline by `mod build`)
 * Recipe run output and DataTables (written to `.moderne/mcp/run/` inside the repository; auto-deleted after one hour)
 * The tool-observations CSV (written to `~/.moderne/mcp/tool-observations.csv`)
 * All MCP protocol messages (carried over stdin/stdout; never over a network)
@@ -173,8 +173,8 @@ In a future release, the Moderne CLI will provide an opt-in feature to connect t
 | Repository working tree                                   | Source files read to build the LST, trigram search index, and execute recipe transformations.                                                                  |
 | `{repo}/.git/`                                            | Git metadata for detecting the repository root and worktree configurations.                                                                                    |
 | `{repo}/.moderne/recipes-v5.csv`                          | Per-repository recipe marketplace override, if present.                                                                                                        |
-| `{repo}/.moderne/build/{buildId}/objects/**/*.tri`        | Per-file trigram index files produced by `mod build`, read by `mod search` and the MCP search tools.                                                           |
-| `{repo}/.moderne/build/{buildId}/objects/**/*.body`       | V3 LST body files. The `.tri` files do not store file content; source bytes are resolved from the sibling `.body` at search time.                              |
+| `{repo}/.moderne/build/{buildId}/sources/**/*.zoekt`      | Per-source-set trigram index shards produced by `mod build`, read by `mod search` and the MCP search tools when no assembled index is present.                 |
+| `{repo}/.moderne/build/{buildId}/index/merged-*.zoekt`    | Repo-level assembled trigram index shards, plus `assembly.csv` (per-part digests) and a `.complete` sentinel. Preferred read source once `.complete` exists.   |
 | `{repo}/.moderne/mcp/lst/`                                | Cached LST files from prior `mod mcp` builds.                                                                                                                  |
 | `~/.moderne/cli/recipes-v5.csv`                           | Global recipe marketplace catalog.                                                                                                                             |
 | `~/.moderne/tray/server.port`                             | Port number of the tray app's HTTP server (macOS/tray feature only).                                                                                           |
@@ -187,8 +187,8 @@ In a future release, the Moderne CLI will provide an opt-in feature to connect t
 |-------------------------------------------------------|-----------------------------------------------------------------------------------|
 | `{repo}/**` (arbitrary paths)                         | Source files modified, added, or deleted by refactoring recipes.                  |
 | `{repo}/.moderne/mcp/lst/`                            | Serialized LST files after each `mod mcp` build.                                  |
-| `{repo}/.moderne/build/{buildId}/objects/**/*.tri`    | Per-file trigram index files produced inline by `mod build`.                      |
-| `{repo}/.moderne/build/{buildId}/objects/**/*.body`   | V3 LST body files produced inline by `mod build`.                                 |
+| `{repo}/.moderne/build/{buildId}/sources/**/*.zoekt`  | Per-source-set trigram index shards produced inline by `mod build`.               |
+| `{repo}/.moderne/build/{buildId}/index/merged-*.zoekt`| Repo-level assembled trigram shards (`assembly.csv` + `.complete` sentinel).      |
 | `{repo}/.moderne/mcp/run/{runId}/datatables/*.csv.gz` | DataTable files produced by recipe runs. Auto-deleted after one hour.             |
 | `{repo}/.moderne/mcp/lst/recipe.log`                  | Log of Maven artifact resolution activity during recipe preparation.              |
 | `{repo}/.moderne/mcp/lst/parsing-events.json`         | Cached parsing events, replayed to the tray app on restart.                       |

--- a/docs/user-documentation/agent-tools/trigrep.md
+++ b/docs/user-documentation/agent-tools/trigrep.md
@@ -291,7 +291,7 @@ Terms separated by space are implicitly ANDed. The `or` keyword creates disjunct
 | `lang:`        | Filter by language. Aliases: `language:`, `l:` (Sourcegraph)                                                                             | `lang:java`                  |
 | `case:`        | Control case sensitivity (`yes`/`no`)                                                                                                    | `case:yes findById`          |
 | `type:`        | Restrict matching surface: `file` (content, default), `path` (file names only), or `symbol` (symbol declarations only — literal terms; see note below) | `type:symbol Person`         |
-| `sym:`         | Match symbols by substring on their fully qualified name. Pass a FQN (`sym:java.util.Collection.add`) for a precise match; bare names (`sym:add`) match every symbol whose FQN contains the substring. Method calls are indexed under each supertype FQN in the receiver's static-type chain, so any FQN in the hierarchy matches. Zoekt-native; trigrep also accepts it in Sourcegraph mode. Alias: `symbol:` | `sym:UserRepository`         |
+| `sym:`         | Match symbols by substring on their fully qualified name. Pass a FQN (`sym:java.util.Collection.add`) for a precise match; bare names (`sym:add`) match every symbol whose FQN contains the substring. At index time, each method call is also recorded under every ancestor FQN that declares its own overload of the method by name and arity (resolved through the source set's type-table chain — JDK, dependencies, and the source set's own types), so a query against an ancestor FQN matches the subtype call site. Zoekt-native; trigrep also accepts it in Sourcegraph mode. Alias: `symbol:` | `sym:UserRepository`         |
 | `select:`      | Filter symbol matches by kind: `symbol.class`, `symbol.interface`, `symbol.enum`, `symbol.method`, `symbol.constructor`, `symbol.field`  | `select:symbol.method`       |
 | `count:`       | Cap total results returned by the query                                                                                                  | `count:500`                  |
 | `content:`     | Search file content explicitly (Sourcegraph). Pairs with `patternType:` and disambiguates literals that look like a filter prefix        | `content:"text"`             |
@@ -370,15 +370,11 @@ Moderne Trigrep is fast, but because it operates on text and indexed metadata ra
 
 ### Method reference searches
 
-`sym:` is precise when you pass a fully qualified name, but bare names (`sym:add`) match every symbol whose FQN contains the substring — there's no way to distinguish `java.util.List.add(Object)` from your own `ShoppingCart.add(Item)`. The supertype-expansion that lets a query against a supertype FQN match calls on a subtype only kicks in when the receiver's static type can be resolved at index time.
-
-If you need to match by full method signature (including overload resolution against the full LST), use the `org.openrewrite.java.search.FindMethods` recipe instead. It resolves types at every call site.
+`sym:` matches by substring on the symbol's FQN, not by full method signature. Bare names (`sym:add`) match every symbol whose FQN contains the substring — there's no way to distinguish `java.util.List.add(Object)` from your own `ShoppingCart.add(Item)`. Even an FQN-precise query can't pin to a specific overload by parameter types; an AspectJ-style pattern like `java.util.List add(..)` isn't expressible.
 
 ### Type hierarchy awareness
 
-The `extends:` and `implements:` filters depend on type attribution at index time. For classes whose supertypes can't be fully resolved during the build, Moderne Trigrep falls back to the syntactic supertype list — meaning a transitive ancestor reached through an unresolved type won't be matched.
-
-If you need a guarantee of full hierarchy coverage (including subtype references), use the `org.openrewrite.java.search.FindTypes` recipe instead. It finds all references to a type including its subtypes.
+`extends:` and `implements:` are class-definition filters: they identify whether a class has a given type in its ancestor closure, not where that type (or any subtype) is referenced elsewhere in the code. The closure itself is computed at index time over the source set's full type-table chain — JDK, every dependency, and the source set's own types — so ancestry reached through third-party library types is matched.
 
 ### Cross-reference and call graph analysis
 
@@ -427,9 +423,9 @@ During indexing, every position where each trigram appears is recorded. When you
 
 Even in a codebase with millions of files, the intersection of posting lists typically narrows the search to a handful of files that need actual verification. A typical trigram index runs about 10-20% of the original source code size.
 
-Moderne Trigrep generates its indexes from LSTs rather than raw source code, which gives the index access to symbol information, type data, and other semantic details that wouldn't be available from text alone. This is what powers semantic filters like `sym:`, `extends:`, and `visibility:`. Symbol metadata is itself trigram-indexed, so `sym:`, `extends:`, and `implements:` queries narrow the candidate file set before scanning rather than walking every file's symbol list.
+Moderne Trigrep generates its indexes from LSTs rather than raw source code, which gives the index access to symbol information, type data, and other semantic details that wouldn't be available from text alone. This is what powers semantic filters like `sym:`, `extends:`, and `visibility:`. Each symbol's related types are stored as compact V3 type-table slots (resolved at search time through the source set's type tables) rather than duplicated inline strings — so a query like `sym:`, `extends:`, or `implements:` narrows the candidate file set before any byte reads.
 
-The index is produced inline by `mod build` as per-file `.tri` files, written alongside the V3 LST `.body` files under `.moderne/build/{buildId}/objects/` within each repository. The `.tri` files do not store file content — source bytes are resolved at search time from the sibling LST `.body`, which keeps the on-disk overhead small. To regenerate the index after significant code changes, simply re-run `mod build`.
+The index is produced inline by `mod build` as `.zoekt` shards. Each source set writes its own shard under `.moderne/build/{buildId}/sources/{sourceSet}/shard-*.zoekt`, and `mod build` then assembles them into a single repo-level index at `.moderne/build/{buildId}/index/merged-*.zoekt` (split into size-bounded chunks) with a sidecar `assembly.csv` recording per-part content digests. A `.complete` sentinel is written last, so a search racing a build sees a complete index or none — never a partial one. Each shard stores the document's content as the LST's printed form (`SourceFile.printAll()`), with a checksum to catch any drift between the printer and the index. Only Java sources get structured symbol extraction today; other languages get a content-only document where full-text trigram search works but the symbol-aware filters don't apply. To regenerate the index after significant code changes, simply re-run `mod build`.
 
 </details>
 

--- a/docs/user-documentation/agent-tools/trigrep.md
+++ b/docs/user-documentation/agent-tools/trigrep.md
@@ -38,14 +38,14 @@ For example, consider the situation where you want to search for all public meth
 
 ## Getting started
 
-To get started with Moderne Trigrep, you'll first need to sync an organization to your local machine and then build the indexes on it. After that, you can search across all of the repositories in the working set:
+To get started with Moderne Trigrep, you'll first need to sync an organization to your local machine and then build the repositories. The trigram search index is produced inline by `mod build` alongside the LST artifacts. After that, you can search across all of the repositories in the working set:
 
 ```bash
 # Sync the Spring organization to the working-set directory
 mod git sync moderne working-set --organization Spring
 
-# Build the indexes on every repository in the working-set directory
-mod postbuild search index working-set
+# Build LSTs and trigram indexes for every repository in the working-set directory
+mod build working-set
 
 # Search for the term "KafkaTemplate" across them all
 mod search working-set "KafkaTemplate"
@@ -291,7 +291,7 @@ Terms separated by space are implicitly ANDed. The `or` keyword creates disjunct
 | `lang:`        | Filter by language. Aliases: `language:`, `l:` (Sourcegraph)                                                                             | `lang:java`                  |
 | `case:`        | Control case sensitivity (`yes`/`no`)                                                                                                    | `case:yes findById`          |
 | `type:`        | Restrict matching surface: `file` (content, default), `path` (file names only), or `symbol` (symbol declarations only — literal terms; see note below) | `type:symbol Person`         |
-| `sym:`         | Match symbols by substring on their fully qualified name. Zoekt-native; trigrep also accepts it in Sourcegraph mode. Alias: `symbol:`    | `sym:UserRepository`         |
+| `sym:`         | Match symbols by substring on their fully qualified name. Pass a FQN (`sym:java.util.Collection.add`) for a precise match; bare names (`sym:add`) match every symbol whose FQN contains the substring. Method calls are indexed under each supertype FQN in the receiver's static-type chain, so any FQN in the hierarchy matches. Zoekt-native; trigrep also accepts it in Sourcegraph mode. Alias: `symbol:` | `sym:UserRepository`         |
 | `select:`      | Filter symbol matches by kind: `symbol.class`, `symbol.interface`, `symbol.enum`, `symbol.method`, `symbol.constructor`, `symbol.field`  | `select:symbol.method`       |
 | `count:`       | Cap total results returned by the query                                                                                                  | `count:500`                  |
 | `content:`     | Search file content explicitly (Sourcegraph). Pairs with `patternType:` and disambiguates literals that look like a filter prefix        | `content:"text"`             |
@@ -300,8 +300,8 @@ Terms separated by space are implicitly ANDed. The `or` keyword creates disjunct
 | `static:`      | Filter for static modifier (`yes`/`no`)                                                                                                  | `static:yes`                 |
 | `final:`       | Filter for final modifier (`yes`/`no`)                                                                                                   | `final:yes`                  |
 | `abstract:`    | Filter for abstract modifier (`yes`/`no`)                                                                                                | `abstract:yes`               |
-| `extends:`     | Match classes extending a type                                                                                                           | `extends:BaseService`        |
-| `implements:`  | Match classes implementing an interface                                                                                                  | `implements:Repository`      |
+| `extends:`     | Match classes whose transitive ancestor chain (any `extends` link, computed at index time) includes the given type                       | `extends:BaseService`        |
+| `implements:`  | Match classes whose transitive interface closure (any `implements`/`extends` link, computed at index time) includes the given interface  | `implements:Repository`      |
 | `returns:`     | Match methods by return type                                                                                                             | `returns:List`               |
 | `throws:`      | Match methods by declared exceptions                                                                                                     | `throws:IOException`         |
 
@@ -370,15 +370,15 @@ Moderne Trigrep is fast, but because it operates on text and indexed metadata ra
 
 ### Method reference searches
 
-Moderne Trigrep can't find all call locations of a method by its full signature. For example, a query like `sym:add` finds symbols named `add`, but can't distinguish between `java.util.List.add(Object)`, `java.util.Set.add(Object)`, and your own `ShoppingCart.add(Item)`.
+`sym:` is precise when you pass a fully qualified name, but bare names (`sym:add`) match every symbol whose FQN contains the substring — there's no way to distinguish `java.util.List.add(Object)` from your own `ShoppingCart.add(Item)`. The supertype-expansion that lets a query against a supertype FQN match calls on a subtype only kicks in when the receiver's static type can be resolved at index time.
 
-If you need to find method invocations by their fully qualified signature, use the `org.openrewrite.java.search.FindMethods` recipe instead. It resolves types at every call site.
+If you need to match by full method signature (including overload resolution against the full LST), use the `org.openrewrite.java.search.FindMethods` recipe instead. It resolves types at every call site.
 
 ### Type hierarchy awareness
 
-The `extends:` and `implements:` filters only match declared relationships. For example, a search for `implements:List` finds classes that directly declare it, but misses classes that inherit `List` through a parent class.
+The `extends:` and `implements:` filters depend on type attribution at index time. For classes whose supertypes can't be fully resolved during the build, Moderne Trigrep falls back to the syntactic supertype list — meaning a transitive ancestor reached through an unresolved type won't be matched.
 
-If you need to search the full type hierarchy, use the `org.openrewrite.java.search.FindTypes` recipe instead. It finds all references to a type including its subtypes.
+If you need a guarantee of full hierarchy coverage (including subtype references), use the `org.openrewrite.java.search.FindTypes` recipe instead. It finds all references to a type including its subtypes.
 
 ### Cross-reference and call graph analysis
 
@@ -427,9 +427,9 @@ During indexing, every position where each trigram appears is recorded. When you
 
 Even in a codebase with millions of files, the intersection of posting lists typically narrows the search to a handful of files that need actual verification. A typical trigram index runs about 10-20% of the original source code size.
 
-Moderne Trigrep generates its indexes from LSTs rather than raw source code, which gives the index access to symbol information, type data, and other semantic details that wouldn't be available from text alone. This is what powers semantic filters like `sym:`, `extends:`, and `visibility:`.
+Moderne Trigrep generates its indexes from LSTs rather than raw source code, which gives the index access to symbol information, type data, and other semantic details that wouldn't be available from text alone. This is what powers semantic filters like `sym:`, `extends:`, and `visibility:`. Symbol metadata is itself trigram-indexed, so `sym:`, `extends:`, and `implements:` queries narrow the candidate file set before scanning rather than walking every file's symbol list.
 
-The index files use the `.zoekt` extension and live in the `.moderne/mcp/search/` directory within each repository. You can use the `--force` flag to regenerate indexes even if they already exist, which is useful after significant code changes.
+The index is produced inline by `mod build` as per-file `.tri` files, written alongside the V3 LST `.body` files under `.moderne/build/{buildId}/objects/` within each repository. The `.tri` files do not store file content — source bytes are resolved at search time from the sibling LST `.body`, which keeps the on-disk overhead small. To regenerate the index after significant code changes, simply re-run `mod build`.
 
 </details>
 


### PR DESCRIPTION
## Summary

Refresh the Trigrep-facing docs to match the CLI shipped in v4.3.0 / v4.3.1. Four moderne-cli PRs landed since the docs were last updated:

* [#3889](https://github.com/moderneinc/moderne-cli/pull/3889) — V3 integration, symbol search, trigram-indexed symbols
* [#4021](https://github.com/moderneinc/moderne-cli/pull/4021) — V3 partition-memory redesign + Trigrep rewire
* [#4032](https://github.com/moderneinc/moderne-cli/pull/4032) — Merged `.zoekt` shard search engine (replaces per-file `.tri`)
* [#4097](https://github.com/moderneinc/moderne-cli/pull/4097) — `mod build` assembles per-source-set shards into one repo-level index

### What changed in the docs

* **On-disk layout** (was: per-file `.tri` under `.moderne/build/<id>/objects/`) — now:
  * Per source set: `.moderne/build/<id>/sources/<sourceSet>/shard-*.zoekt`
  * Assembled repo-level index: `.moderne/build/<id>/index/merged-*.zoekt`
  * `index/assembly.csv` (per-part content digests)
  * `index/.complete` (atomic-visibility sentinel, written last)
* **Content model** — shards now carry the document's content as the LST's `printAll()` output (with a printer/index checksum) instead of being content-free with byte resolution from a sibling `.body`.
* **Symbol model** — symbol records reference V3 type-table slots (`SymbolRef.ofTypeTable`), resolved at search time via `TypeProvider`. Names live once, in the type table.
* **Receiver-supertype expansion** — uses the source set's full type-table chain (JDK + dependencies + the source set's own types) via `ChainResolver`, giving authoritative ancestry across third-party libraries.
* **Limitations section** — dropped the now-incorrect "only when receiver's static type resolves at index time" caveat and the `FindMethods` / `FindTypes` recipe pointers. The remaining real limits are spelled out plainly: `sym:` is FQN-substring (not full signature, no overload arity), and `extends:` / `implements:` identify class definitions (not code references to a type or subtype).
* **`sym:` / `extends:` / `implements:` filter rows** — clarified that the type-table chain backs the supertype-FQN expansion.
* **Java-only structured symbols** noted in the explainer block. Other languages still get full-text + regex via content-only documents.
* **Module 4 sample output** updated to match current CLI strings (`No trigram shards (rebuild)`, `... with .zoekt shards`).
* **MCP security doc** filesystem read/write tables updated to the new shard paths.

### Files

* `docs/user-documentation/agent-tools/trigrep.md`
* `docs/user-documentation/agent-tools/mcp/security.md`
* `docs/hands-on-learning/agent-tools/module-4-trigrep.md` (draft)
* `docs/hands-on-learning/agent-tools/module-5-mcp.md` (draft)
* `docs/hands-on-learning/agent-tools/workshop-overview.md` (draft)

## Test plan

- [ ] `yarn build` succeeds with no warnings or broken links (skipped locally — heavy build crashes other apps; relying on the CI `pr-validation` workflow)
- [ ] Spot-check the rendered Trigrep page, MCP security page, and (when un-drafted) the Module 4 / Module 5 / overview pages
- [ ] Verify no leftover references to `mod postbuild search index`, `.tri`, `.body`, `objects/`, or `.moderne/mcp/search/` in agent-tools docs

## References

* LSTv3 book ch. 6 (`core/serialization/book/manuscript/06-trigrep.md` in moderne-cli)
* Verified against `SearchIndexing.java`, `RepoIndexAssembler.java`, `BuildDirSearchIndex.java`, `Search.java`