### PR TITLE
Recipe detail: address review feedback (options, preconditions, accordion, Try tooltip, markdown toggle)

### DIFF
--- a/src/components/NeoButton/NeoButton.module.css
+++ b/src/components/NeoButton/NeoButton.module.css
@@ -55,6 +55,9 @@
 
   &:hover:not(:disabled) {
     background-color: var(--neo-buttons-primary-hover);
+    /* Pin the text color: when rendered as an <a> (href), Infima's global `a:hover` color
+       (higher specificity than the variant's resting color) would otherwise repaint it dark. */
+    color: var(--neo-grey-50);
   }
 
   &:active:not(:disabled) {
@@ -80,6 +83,8 @@
 
   &:hover:not(:disabled) {
     background-color: var(--neo-buttons-secondary-hover-background);
+    /* Pin the text color against Infima's `a:hover` override when rendered as a link. */
+    color: var(--neo-buttons-secondary-default);
   }
 
   &:active:not(:disabled) {

--- a/src/components/recipe/Accordion/Accordion.tsx
+++ b/src/components/recipe/Accordion/Accordion.tsx
@@ -25,8 +25,13 @@ export interface AccordionItem {
  * Every <details> keeps its body in the DOM when collapsed, so crawlers and the
  * .md / llms.txt export read all of it.
  */
-export const Accordion: FunctionComponent<{ items: AccordionItem[]; children: ReactNode }> = ({ items, children }) => {
-  const [open, setOpen] = useState<boolean[]>(() => items.map((_, i) => i === 0));
+export const Accordion: FunctionComponent<{
+  items: AccordionItem[];
+  children: ReactNode;
+  /** Which items start expanded: just the first (default, space-saving) or all of them. */
+  defaultOpen?: 'first' | 'all';
+}> = ({ items, children, defaultOpen = 'first' }) => {
+  const [open, setOpen] = useState<boolean[]>(() => items.map((_, i) => defaultOpen === 'all' || i === 0));
   const allOpen = open.length > 0 && open.every(Boolean);
 
   const toggleAll = () => setOpen(items.map(() => !allOpen));

--- a/src/components/recipe/MarkdownToggle/MarkdownToggle.module.css
+++ b/src/components/recipe/MarkdownToggle/MarkdownToggle.module.css
@@ -1,0 +1,66 @@
+/* MarkdownToggle (light + dark). Segmented control chrome mirrors the Before/After/Diff picker
+   (`.recipe .tabs` in ../shared/styles.module.css) so the page has one segmented-control language. */
+
+.toggle {
+display: inline-flex;
+  align-items: stretch;
+  width: fit-content;
+  border: 1px solid var(--neo-border-input);
+  border-radius: var(--neo-border-radius-button);
+  overflow: hidden;
+  background: var(--neo-surfaces-white);
+}
+
+.segment {
+display: inline-flex;
+  align-items: center;
+  gap: var(--neo-spacing_1);
+  padding: var(--neo-spacing_1_2) var(--neo-spacing_2);
+  border: none;
+  border-right: 1px solid var(--neo-border-input);
+  background: transparent;
+  font-family: var(--neo-font-family-body);
+  font-size: var(--neo-font-size-sm);
+  font-weight: var(--neo-font-weight-medium);
+  line-height: 1.4;
+  color: var(--neo-typography-tab-inactive);
+  cursor: pointer;
+}
+
+.segment:last-child {
+border-right: none;
+}
+
+.segment:hover {
+background: var(--neo-surfaces-list-hover);
+  color: var(--neo-typography-input-default);
+}
+
+.segment_active,
+.segment_active:hover {
+color: var(--neo-typography-tab-active);
+  background: var(--neo-surfaces-card);
+}
+
+html[data-theme='dark'] {
+.toggle {
+background: var(--neo-grey-900);
+  border-color: var(--neo-grey-700);
+}
+
+.segment {
+color: var(--neo-grey-400);
+  border-right-color: var(--neo-grey-700);
+}
+
+.segment:hover {
+background: var(--neo-grey-800);
+  color: var(--neo-surfaces-snackbar-dark-mode);
+}
+
+.segment_active,
+.segment_active:hover {
+background: var(--neo-grey-800);
+  color: var(--neo-digital-green-300);
+}
+}

--- a/src/components/recipe/MarkdownToggle/MarkdownToggle.stories.tsx
+++ b/src/components/recipe/MarkdownToggle/MarkdownToggle.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React, { useState } from 'react';
+import { MarkdownToggle, type MarkdownView } from './MarkdownToggle';
+import { StoryLayout } from '../shared/storyLayout';
+
+/** Page-level rendered ⇄ raw toggle (top-right corner of the recipe page). */
+const meta: Meta<typeof MarkdownToggle> = {
+  title: 'Recipe/MarkdownToggle',
+  component: MarkdownToggle,
+  parameters: { layout: 'fullscreen', maxWidth: 420 },
+  decorators: [StoryLayout],
+};
+export default meta;
+type Story = StoryObj<typeof MarkdownToggle>;
+
+export const Production: Story = {
+  render: () => {
+    const [view, setView] = useState<MarkdownView>('rendered');
+    return <MarkdownToggle value={view} onChange={setView} />;
+  },
+};

--- a/src/components/recipe/MarkdownToggle/MarkdownToggle.tsx
+++ b/src/components/recipe/MarkdownToggle/MarkdownToggle.tsx
@@ -1,0 +1,42 @@
+import React, { type FunctionComponent } from 'react';
+import clsx from 'clsx';
+import { Eye, Code } from 'lucide-react';
+import styles from './MarkdownToggle.module.css';
+
+export type MarkdownView = 'rendered' | 'raw';
+
+/**
+ * Page-level rendered ⇄ raw toggle, meant for the top-right corner of the recipe page — the spot
+ * IDEs put their preview/source switch. Replaces the old "View as Markdown" CTA, which is a "view"
+ * affordance, not a "do" action, so it doesn't belong next to "Try in Platform".
+ *
+ * A controlled segmented control (the page owns the view state). Its chrome matches the page's other
+ * segmented control — the Before/After/Diff picker in ExampleList.
+ */
+export const MarkdownToggle: FunctionComponent<{
+  value: MarkdownView;
+  onChange: (view: MarkdownView) => void;
+}> = ({ value, onChange }) => (
+  <div className={styles.toggle} role="tablist" aria-label="Recipe view">
+    <button
+      type="button"
+      role="tab"
+      aria-selected={value === 'rendered'}
+      className={clsx(styles.segment, value === 'rendered' && styles.segment_active)}
+      onClick={() => onChange('rendered')}
+    >
+      <Eye size={14} aria-hidden="true" />
+      Rendered
+    </button>
+    <button
+      type="button"
+      role="tab"
+      aria-selected={value === 'raw'}
+      className={clsx(styles.segment, value === 'raw' && styles.segment_active)}
+      onClick={() => onChange('raw')}
+    >
+      <Code size={14} aria-hidden="true" />
+      Raw
+    </button>
+  </div>
+);

--- a/src/components/recipe/MarkdownToggle/index.ts
+++ b/src/components/recipe/MarkdownToggle/index.ts
@@ -1,0 +1,1 @@
+export { MarkdownToggle, type MarkdownView } from './MarkdownToggle';

--- a/src/components/recipe/OptionsTable/OptionsTable.module.css
+++ b/src/components/recipe/OptionsTable/OptionsTable.module.css
@@ -45,21 +45,70 @@ background-color: var(--neo-typography-input-default);
 background-color: var(--neo-grey-400);
 }
 
+/* Horizontal padding insets the header rule + row dividers from the card border, so they don't run
+   edge-to-edge — matching the data table (a `shared.table` inside the accordion body's `spacing_2`
+   padding). Keeps row treatments consistent across the page. */
 .optionsCard {
 border: 1px solid var(--neo-border-card);
   border-radius: var(--neo-border-radius-card);
   overflow: hidden;
+  padding: 0 var(--neo-spacing_2);
+}
+
+/* Two-line option table. Line 1 (`.paramRow`) holds the scannable fields; line 2 (`.descRow`) holds
+   the description across all columns. Dividers go between options (`.optionDivider`), never between
+   an option's own two rows — so each option reads as one block. Cell chrome mirrors shared `.th`/`.td`
+   tokens but the divider lives here, decoupled from shared's `tbody tr + tr` row rule. */
+.optionsTable {
+width: 100%;
+  display: table;
+  border-collapse: collapse;
+}
+
+.headCell {
+text-align: left;
+  padding: var(--neo-spacing_1_1_2) var(--neo-spacing_1_1_2);
+  font-size: var(--neo-font-size-sm);
+  font-weight: var(--neo-font-weight-semi-bold);
+  color: var(--neo-typography-input-default);
+  background-color: transparent;
+  border: none;
+  border-bottom: 1px solid var(--neo-border-card);
+  white-space: nowrap;
+}
+
+/* Line 1: a touch of top room, tight to the description that follows. */
+.cell {
+text-align: left;
+  padding: var(--neo-spacing_2) var(--neo-spacing_1_1_2) var(--neo-spacing_1);
+  font-size: var(--neo-font-size-sm);
+  color: var(--neo-typography-input-default);
+  font-weight: var(--neo-font-weight-regular);
+  vertical-align: baseline;
+  border: none;
+}
+
+.paramCell {
+white-space: nowrap;
+}
+
+/* Line 2: no top padding (hugs line 1), bottom room before the next option. */
+.descCell {
+padding: 0 var(--neo-spacing_1_1_2) var(--neo-spacing_2);
+  border: none;
+}
+
+/* The one divider: a hairline above each option's line 1, except the first. Matches the header rule
+   and card edge (`--neo-border-card`) so every line in the card is one uniform weight — `--neo-border-secondary`
+   resolves to a semi-transparent navy that renders darker/cooler than the neutral borders. */
+.optionDivider .cell {
+border-top: 1px solid var(--neo-border-card);
 }
 
 /* `.optionName` / `.optionExample` compose shared `.inlineCode` (chrome + dark mode); these only
    add the per-cell deltas. */
 .optionName {
   font-weight: var(--neo-font-weight-semi-bold);
-}
-
-.optionDesc {
-font-size: var(--neo-font-size-sm);
-  color: var(--neo-typography-input-default);
 }
 
 .optionExample {
@@ -69,6 +118,19 @@ font-size: var(--neo-font-size-sm);
 
 .optionExampleNone {
 color: var(--neo-typography-body-secondary);
+}
+
+.optionDesc {
+font-size: var(--neo-font-size-sm);
+  color: var(--neo-typography-input-default);
+}
+
+/* Required marker: the same dot vocabulary as the section-header tally, paired with its label. */
+.requiredMarker {
+display: inline-flex;
+  align-items: center;
+  gap: var(--neo-spacing_1_2);
+  white-space: nowrap;
 }
 
 .optionRequired {
@@ -99,6 +161,19 @@ color: var(--neo-grey-400);
 
 .optionsCard {
 border-color: var(--neo-grey-700);
+}
+
+.headCell {
+color: var(--neo-surfaces-snackbar-dark-mode);
+    border-bottom-color: var(--neo-grey-700);
+}
+
+.cell {
+color: var(--neo-surfaces-snackbar-dark-mode);
+}
+
+.optionDivider .cell {
+border-top-color: var(--neo-grey-700);
 }
 
 .optionRequired {

--- a/src/components/recipe/OptionsTable/OptionsTable.stories.tsx
+++ b/src/components/recipe/OptionsTable/OptionsTable.stories.tsx
@@ -20,3 +20,49 @@ type Story = StoryObj<typeof OptionsTable>;
 export const Production: Story = {
   args: { options: content.options, children: <h2>Options</h2> },
 };
+
+/** A denser, mixed set — required + optional, with and without examples, short and long
+ *  descriptions — to show the two-line rhythm and the between-option dividers. */
+export const ManyOptions: Story = {
+  args: {
+    children: <h2>Options</h2>,
+    options: [
+      {
+        name: 'oldPackageName',
+        type: 'String',
+        required: true,
+        example: 'com.example.old',
+        description: 'The fully-qualified package name to replace.',
+      },
+      {
+        name: 'newPackageName',
+        type: 'String',
+        required: true,
+        example: 'com.example.new',
+        description: 'The fully-qualified package name to use instead.',
+      },
+      {
+        name: 'includeTestSources',
+        type: 'Boolean',
+        required: false,
+        example: 'true',
+        description:
+          'Changes only apply to main by default. `includeTestSources` will apply the recipe to `test` source files as well, which is useful when test code references the renamed package.',
+      },
+      {
+        name: 'recursive',
+        type: 'Boolean',
+        required: false,
+        description: 'Whether to also rename sub-packages nested beneath the target package.',
+      },
+      {
+        name: 'fileMatcher',
+        type: 'String',
+        required: false,
+        example: '**/*.java',
+        description:
+          'A glob applied to each source file path to narrow which files the recipe visits. When omitted, every matching source file is considered.',
+      },
+    ],
+  },
+};

--- a/src/components/recipe/OptionsTable/OptionsTable.tsx
+++ b/src/components/recipe/OptionsTable/OptionsTable.tsx
@@ -6,9 +6,13 @@ import styles from './OptionsTable.module.css';
 import shared from '../shared/styles.module.css';
 
 /**
- * Options as a structured card. Stays a semantic <table> (Parameter / Type /
- * Description / Example / Required) with every value as real text for crawlers
+ * Options as a structured card. Stays a semantic <table> with every value as real text for crawlers
  * and screen readers. Required options sort first.
+ *
+ * Each option spans two rows: line 1 is the scannable key facts — Parameter · Example · Type ·
+ * Required (the order you assign a value in an IDE / on the CLI) — and line 2 is the description
+ * across the full table width, so it gets room to breathe instead of a cramped column. A divider
+ * sits between options (above each option's line 1), never between an option's own two lines.
  *
  * Pass the section's markdown `## Options` heading as children: it renders in a section header row
  * with the metrics (parameter count + required/optional tally) on the right, and still feeds the
@@ -45,40 +49,58 @@ export const OptionsTable: FunctionComponent<{ options: RecipeOption[]; children
         </div>
       </div>
       <div className={styles.optionsCard}>
-      <div className={shared.tableScroll}>
-      <table className={shared.table}>
-        <thead>
-          <tr>
-            <th className={shared.th} scope="col">Parameter</th>
-            <th className={shared.th} scope="col">Type</th>
-            <th className={shared.th} scope="col">Description</th>
-            <th className={shared.th} scope="col">Example</th>
-            <th className={shared.th} scope="col">Required</th>
-          </tr>
-        </thead>
-        <tbody>
-          {sorted.map((opt) => (
-            <tr key={opt.name}>
-              <td className={shared.td}><code className={clsx(shared.inlineCode, styles.optionName)}>{opt.name}</code></td>
-              <td className={shared.td}><span className={shared.chip}>{opt.type}</span></td>
-              <td className={shared.td}><span className={styles.optionDesc}>{renderWithCode(opt.description, shared.inlineCode)}</span></td>
-              <td className={shared.td}>
-                {opt.example ? (
-                  <code className={clsx(shared.inlineCode, styles.optionExample)}>{opt.example}</code>
-                ) : (
-                  <span className={styles.optionExampleNone}>—</span>
-                )}
-              </td>
-              <td className={shared.td}>
-                <span className={opt.required ? styles.optionRequired : styles.optionOptional}>
-                  {opt.required ? 'Required' : 'Optional'}
-                </span>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-      </div>
+        <div className={shared.tableScroll}>
+          <table className={styles.optionsTable}>
+            <thead>
+              <tr>
+                <th className={styles.headCell} scope="col">Parameter</th>
+                <th className={styles.headCell} scope="col">Example</th>
+                <th className={styles.headCell} scope="col">Type</th>
+                <th className={styles.headCell} scope="col">Required</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sorted.map((opt, i) => (
+                <React.Fragment key={opt.name}>
+                  <tr className={clsx(styles.paramRow, i > 0 && styles.optionDivider)}>
+                    <th scope="row" className={clsx(styles.cell, styles.paramCell)}>
+                      <code className={clsx(shared.inlineCode, styles.optionName)}>{opt.name}</code>
+                    </th>
+                    <td className={styles.cell}>
+                      {opt.example ? (
+                        <code className={clsx(shared.inlineCode, styles.optionExample)}>{opt.example}</code>
+                      ) : (
+                        <span className={styles.optionExampleNone}>—</span>
+                      )}
+                    </td>
+                    <td className={styles.cell}>
+                      <span className={shared.chip}>{opt.type}</span>
+                    </td>
+                    <td className={styles.cell}>
+                      <span className={styles.requiredMarker}>
+                        <span
+                          className={clsx(
+                            styles.optionsSummaryDot,
+                            opt.required ? styles.optionsSummaryDot_req : styles.optionsSummaryDot_opt,
+                          )}
+                          aria-hidden="true"
+                        />
+                        <span className={opt.required ? styles.optionRequired : styles.optionOptional}>
+                          {opt.required ? 'Required' : 'Optional'}
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr className={styles.descRow}>
+                    <td className={styles.descCell} colSpan={4}>
+                      <span className={styles.optionDesc}>{renderWithCode(opt.description, shared.inlineCode)}</span>
+                    </td>
+                  </tr>
+                </React.Fragment>
+              ))}
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
   );

--- a/src/components/recipe/RecipeHeader/RecipeHeader.module.css
+++ b/src/components/recipe/RecipeHeader/RecipeHeader.module.css
@@ -155,6 +155,46 @@ display: flex;
   gap: var(--neo-spacing_1);
 }
 
+/* Lightweight expectation-setting tooltip on the "Try in Platform" CTA. Reveal + card chrome echo
+   the AccessInfoButton popover so the two info affordances read the same. */
+.tryWrap {
+position: relative;
+  display: inline-flex;
+}
+
+.tryTooltip {
+position: absolute;
+  top: calc(100% + var(--neo-spacing_1));
+  left: 0;
+  z-index: 40;
+  width: 280px;
+  max-width: 80vw;
+  padding: var(--neo-spacing_1_1_2) var(--neo-spacing_2);
+  font-size: var(--neo-font-size-sm);
+  line-height: 1.5;
+  color: var(--neo-typography-body-secondary);
+  background-color: var(--neo-surfaces-card);
+  border: 1px solid var(--neo-border-card);
+  border-radius: var(--neo-border-radius-input);
+  box-shadow: var(--neo-shadow-dropdown);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 0.12s ease;
+}
+
+.tryWrap:hover .tryTooltip,
+.tryWrap:focus-within .tryTooltip {
+opacity: 1;
+  visibility: visible;
+}
+
+html[data-theme='dark'] .tryTooltip {
+color: var(--neo-grey-400);
+  background-color: var(--neo-icons-default);
+  border-color: var(--neo-grey-700);
+}
+
 html[data-theme='dark'] {
 .codeChip {
 background-color: var(--neo-grey-900);

--- a/src/components/recipe/RecipeHeader/RecipeHeader.tsx
+++ b/src/components/recipe/RecipeHeader/RecipeHeader.tsx
@@ -1,6 +1,6 @@
 import React, { type FunctionComponent } from 'react';
 import clsx from 'clsx';
-import { FileText, ArrowRight } from 'lucide-react';
+import { ArrowRight } from 'lucide-react';
 import { NeoButton } from '@site/src/components/NeoButton';
 import { CopyButton } from '../CopyButton';
 import { AccessInfoButton } from '../AccessInfoButton';
@@ -19,7 +19,8 @@ export interface RecipeHeaderProps {
   /** Maven coordinates `groupId:artifactId`, shown as a second code-chip when present. */
   artifact?: string;
   appLink: string;
-  /** Raw markdown source URL (e.g. a raw.githubusercontent.com link) for "View as Markdown". */
+  /** Raw markdown source URL (e.g. a raw.githubusercontent.com link). Consumed by the page-level
+   *  rendered/raw MarkdownToggle, not the header itself. */
   markdownUrl: string;
   /** Proprietary recipe — shows the "Moderne Only" access badge + info popover instead of "Open source". */
   moderneOnly?: boolean;
@@ -34,7 +35,7 @@ const tagHref = (tag: string): string => {
 
 /** Header band for a recipe page: access badge, title, recipe-id/artifact code-chips, description, tags, CTAs. */
 export const RecipeHeader: FunctionComponent<RecipeHeaderProps> = ({
-  displayName, description, type, languages, tags, license, fqName, artifact, appLink, markdownUrl, moderneOnly = false,
+  displayName, description, type, languages, tags, license, fqName, artifact, appLink, moderneOnly = false,
 }) => (
   <header className={styles.header}>
     {/* Identity group: access badge, title, recipe-id/artifact chips — tight gaps within. */}
@@ -97,28 +98,25 @@ export const RecipeHeader: FunctionComponent<RecipeHeaderProps> = ({
 
     <div className={styles.actions}>
       <div className={styles.actionButtons}>
-        <NeoButton
-          variant="primary"
-          size="small"
-          href={appLink}
-          target="_blank"
-          rel="noopener noreferrer"
-          icon={<ArrowRight size={14} />}
-          iconPosition="right"
-        >
-          Try in Platform
-        </NeoButton>
-        <NeoButton
-          variant="outline"
-          size="small"
-          href={markdownUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          icon={<FileText size={14} />}
-          iconPosition="left"
-        >
-          View as Markdown
-        </NeoButton>
+        {/* Tooltip sets expectations: the platform is the hosted product and needs a Moderne
+            account — so prospects aren't surprised by a sign-in. Button itself is unchanged. */}
+        <span className={styles.tryWrap}>
+          <NeoButton
+            variant="primary"
+            size="small"
+            href={appLink}
+            target="_blank"
+            rel="noopener noreferrer"
+            icon={<ArrowRight size={14} />}
+            iconPosition="right"
+          >
+            Try in Platform
+          </NeoButton>
+          <span className={styles.tryTooltip} role="tooltip">
+            Try this recipe in the Moderne platform. Not a user yet? You’ll get a no-setup demo
+            environment, with nothing to install or configure.
+          </span>
+        </span>
       </div>
     </div>
   </header>

--- a/src/components/recipe/RecipeList/RecipeList.module.css
+++ b/src/components/recipe/RecipeList/RecipeList.module.css
@@ -1,16 +1,47 @@
-/* RecipeList styles (light + dark). */
+/* RecipeList styles (light + dark). Rendered through the shared Accordion: lists are borderless and
+   inset inside the accordion body, matching the data table (no inner card, dividers don't reach the
+   container edge). */
 
-.recipeList {
+/* Accordion-label count badge: violet for preconditions, neutral for the recipe list. */
+.itemLabel {
+display: inline-flex;
+  align-items: center;
+  gap: var(--neo-spacing_1);
+}
+
+.countBadge {
+display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 var(--neo-spacing_1_2);
+  border-radius: var(--neo-border-radius-full);
+  font-size: var(--neo-font-size-xs);
+  font-weight: var(--neo-font-weight-semi-bold);
+  line-height: 1;
+}
+
+.countBadge_violet {
+background-color: var(--neo-violet-200);
+  color: var(--neo-violet-700);
+}
+
+.countBadge_neutral {
+background-color: var(--neo-status-neutral-light);
+  color: var(--neo-status-neutral-dark);
+}
+
+/* Borderless, inset list of links. The accordion body's horizontal padding does the insetting, so the
+   row dividers stop short of the container edge — same as the data table. */
+.recipeRows {
 margin: 0;
   padding: 0;
   list-style: none;
-  border: 1px solid var(--neo-border-card);
-  border-radius: var(--neo-border-radius-input);
-  overflow: hidden;
 }
 
 .recipeListItem {
-padding: var(--neo-spacing_1_1_2) var(--neo-spacing_2);
+padding: var(--neo-spacing_1_1_2) var(--neo-spacing_1_1_2);
   font-size: var(--neo-font-size-sm);
   color: var(--neo-typography-input-default);
 }
@@ -62,18 +93,18 @@ flex-shrink: 0;
   white-space: nowrap;
 }
 
+/* No border: the scroll window flows inside the accordion body like the preconditions list, so its
+   row dividers inset the same way (no bounding box around the results). Stays scrollable. */
 .recipeListWindow {
 margin: 0;
   padding: 0;
   list-style: none;
   max-height: 300px;
   overflow-y: auto;
-  border: 1px solid var(--neo-border-card);
-  border-radius: var(--neo-border-radius-input);
 }
 
 .recipeListEmpty {
-padding: var(--neo-spacing_1_1_2) var(--neo-spacing_2);
+padding: var(--neo-spacing_1_1_2) var(--neo-spacing_1_1_2);
   font-size: var(--neo-font-size-sm);
   color: var(--neo-typography-body-secondary);
 }
@@ -115,16 +146,21 @@ color: var(--neo-surfaces-snackbar-dark-mode);
 color: var(--neo-grey-500);
 }
 
-.recipeList,
-.recipeListWindow {
-border-color: var(--neo-grey-700);
-}
-
 .recipeLink {
 color: var(--neo-digital-green-300);
 }
 
 .recipeLink:hover {
 color: var(--neo-digital-green-200);
+}
+
+.countBadge_violet {
+background-color: var(--neo-violet-800);
+    color: var(--neo-violet-200);
+}
+
+.countBadge_neutral {
+background-color: var(--neo-grey-800);
+    color: var(--neo-grey-300);
 }
 }

--- a/src/components/recipe/RecipeList/RecipeList.stories.tsx
+++ b/src/components/recipe/RecipeList/RecipeList.stories.tsx
@@ -14,10 +14,22 @@ const meta: Meta<typeof RecipeList> = {
 export default meta;
 type Story = StoryObj<typeof RecipeList>;
 
+const singleton = { name: 'Singleton', href: '/user-documentation/recipes/recipe-catalog/core/singleton' };
+const morePreconditions = [
+  singleton,
+  { name: 'Find missing types', href: '#' },
+  { name: 'Has Java version 17+', href: '#' },
+];
+
 export const ShortInline: Story = {
-  args: { recipes: content.subRecipes.slice(0, 6), children: <h2>Definition</h2> },
+  args: { recipes: content.subRecipes.slice(0, 6), preconditions: [singleton], children: <h2>Definition</h2> },
 };
 
 export const LongBounded: Story = {
-  args: { recipes: content.subRecipes, children: <h2>Definition</h2> }, // 73 → bounded + search
+  args: { recipes: content.subRecipes, preconditions: morePreconditions, children: <h2>Definition</h2> }, // 73 → bounded + search
+};
+
+/** No preconditions — the chips row simply doesn't render (the common case). */
+export const NoPreconditions: Story = {
+  args: { recipes: content.subRecipes.slice(0, 6), children: <h2>Definition</h2> },
 };

--- a/src/components/recipe/RecipeList/RecipeList.tsx
+++ b/src/components/recipe/RecipeList/RecipeList.tsx
@@ -1,5 +1,7 @@
 import React, { useMemo, useState, type FunctionComponent, type ReactNode } from 'react';
+import clsx from 'clsx';
 import { Search } from 'lucide-react';
+import { Accordion, type AccordionItem } from '../Accordion';
 import type { SubRecipe } from '../shared/types';
 import { renderWithCode } from '../shared/renderWithCode';
 import styles from './RecipeList.module.css';
@@ -13,17 +15,37 @@ const RecipeLink: FunctionComponent<{ recipe: SubRecipe }> = ({ recipe }) => (
   </li>
 );
 
-/**
- * Length-adaptive recipe list. 88% of composite lists have ≤10 sub-recipes, so
- * short lists render inline (no chrome); only the long tail gets a bounded
- * window + name search. The full list stays in the DOM in both modes (AI-readable).
- *
- * Pass the section's markdown `## Definition` heading as children: it renders in a section header row
- * (with the recipe count on the right) and still feeds the native TOC.
- */
+/** A count badge in an accordion label — violet for preconditions, neutral for the recipe list. */
+const CountBadge: FunctionComponent<{ count: number; tone: 'violet' | 'neutral' }> = ({ count, tone }) => (
+  <span className={clsx(styles.countBadge, tone === 'violet' ? styles.countBadge_violet : styles.countBadge_neutral)}>
+    {count}
+  </span>
+);
+
 const BOUNDED_THRESHOLD = 15;
 
-export const RecipeList: FunctionComponent<{ recipes: SubRecipe[]; children: ReactNode }> = ({ recipes, children }) => {
+/** Borderless, inset list of recipe links — matches the data table sitting in an accordion body. */
+const RecipeRows: FunctionComponent<{ recipes: SubRecipe[] }> = ({ recipes }) => (
+  <ul className={styles.recipeRows}>
+    {recipes.map((r) => (<RecipeLink key={r.href} recipe={r} />))}
+  </ul>
+);
+
+/**
+ * Definition: preconditions + the sub-recipe list, rendered through the shared Accordion (like
+ * Examples / Usage / Data tables) so the whole section folds away like the other space-saving
+ * blocks — but open by default. Preconditions carry a violet count badge; the recipe list shows a
+ * neutral count and, when long (88% are ≤10, only the tail is bounded), a name search + scroll window.
+ * Lists are borderless and inset inside the accordion body, matching the data table.
+ *
+ * Pass the section's markdown `## Definition` heading as children: it renders in the accordion header
+ * row and still feeds the native TOC.
+ */
+export const RecipeList: FunctionComponent<{ recipes: SubRecipe[]; preconditions?: SubRecipe[]; children: ReactNode }> = ({
+  recipes,
+  preconditions,
+  children,
+}) => {
   const [query, setQuery] = useState('');
   const bounded = recipes.length > BOUNDED_THRESHOLD;
 
@@ -32,52 +54,65 @@ export const RecipeList: FunctionComponent<{ recipes: SubRecipe[]; children: Rea
     return q ? recipes.filter((r) => r.name.toLowerCase().includes(q)) : recipes;
   }, [recipes, query]);
 
-  if (!recipes.length) return null;
+  if (!recipes.length && !preconditions?.length) return null;
 
-  const count = `${recipes.length} recipes`;
+  const items: AccordionItem[] = [];
 
-  // Short list → inline, with the count on the heading row.
-  if (!bounded) {
-    return (
-      <div className={shared.section}>
-        <div className={shared.sectionHeader}>
-          {children}
-          <span className={styles.recipeListCount}>{count}</span>
-        </div>
-        <ul className={styles.recipeList}>
-          {recipes.map((r) => (<RecipeLink key={r.href} recipe={r} />))}
-        </ul>
-      </div>
-    );
+  if (preconditions?.length) {
+    items.push({
+      key: 'preconditions',
+      label: (
+        <span className={styles.itemLabel}>
+          Preconditions
+          <CountBadge count={preconditions.length} tone="violet" />
+        </span>
+      ),
+      content: <RecipeRows recipes={preconditions} />,
+    });
   }
 
-  // Long list → bounded window + name search (count lives in the search row).
-  return (
-    <div className={shared.section}>
-      <div className={shared.sectionHeader}>{children}</div>
-      <div className={styles.recipeListBounded}>
-        <div className={styles.recipeListSearch}>
-          <Search size={15} className={styles.recipeListSearchIcon} />
-          <input
-            className={styles.recipeListInput}
-            type="text"
-            placeholder={`Search ${recipes.length} recipes…`}
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            aria-label="Search recipes in this list"
-          />
-          <span className={styles.recipeListCount}>
-            {query.trim() ? `${filtered.length} of ${recipes.length}` : count}
-          </span>
+  if (recipes.length) {
+    items.push({
+      key: 'recipes',
+      label: (
+        <span className={styles.itemLabel}>
+          Recipes
+          <CountBadge count={recipes.length} tone="neutral" />
+        </span>
+      ),
+      content: bounded ? (
+        <div className={styles.recipeListBounded}>
+          <div className={styles.recipeListSearch}>
+            <Search size={15} className={styles.recipeListSearchIcon} />
+            <input
+              className={styles.recipeListInput}
+              type="text"
+              placeholder={`Search ${recipes.length} recipes…`}
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              aria-label="Search recipes in this list"
+            />
+            <span className={styles.recipeListCount}>
+              {query.trim() ? `${filtered.length} of ${recipes.length}` : `${recipes.length} recipes`}
+            </span>
+          </div>
+          <ul className={styles.recipeListWindow} aria-label="Recipe list" tabIndex={0}>
+            {filtered.length ? (
+              filtered.map((r) => <RecipeLink key={r.href} recipe={r} />)
+            ) : (
+              <li className={styles.recipeListEmpty}>No recipes match “{query}”.</li>
+            )}
+          </ul>
         </div>
-        <ul className={styles.recipeListWindow} aria-label="Recipe list" tabIndex={0}>
-          {filtered.length ? (
-            filtered.map((r) => <RecipeLink key={r.href} recipe={r} />)
-          ) : (
-            <li className={styles.recipeListEmpty}>No recipes match “{query}”.</li>
-          )}
-        </ul>
-      </div>
-    </div>
+      ) : (
+        <RecipeRows recipes={recipes} />
+      ),
+    });
+  }
+
+  return (
+    <Accordion items={items} defaultOpen="all">
+      {children}
+    </Accordion>
   );
 };

--- a/src/components/recipe/RecipePage.stories.tsx
+++ b/src/components/recipe/RecipePage.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import React, { type ReactNode } from 'react';
+import React, { useState, type ReactNode } from 'react';
 import {
   RecipeHeader,
   RecipeList,
@@ -8,6 +8,9 @@ import {
   UsageList,
   DataTableList,
   RecipeMeta,
+  MarkdownToggle,
+  type MarkdownView,
+  CopyButton,
 } from '.';
 import { StoryLayout } from './shared/storyLayout';
 import { SAMPLE } from './RecipeHeader/RecipeHeader.fixtures';
@@ -33,6 +36,84 @@ const Page = ({ children }: { children: ReactNode }) => (
   <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--neo-spacing_5)' }}>{children}</div>
 );
 
+/** Stand-in for the raw `.md` source the generator emits — shown when the toggle flips to "Raw". */
+const SAMPLE_RAW_MARKDOWN = `---
+sidebar_label: "Common static analysis issues"
+description: "Resolve common static analysis issues (also known as SAST issues)."
+---
+
+# Common static analysis issues
+
+**org.openrewrite.staticanalysis.CommonStaticAnalysis**
+
+_Resolve common static analysis issues (also known as SAST issues)._
+
+## Recipe source
+
+This recipe is composed of more than one recipe. If you want to see the source
+code for this recipe, you can find it in the [rewrite-static-analysis] repository.
+
+## Definition
+
+### Preconditions
+
+* [Singleton](/recipes/core/singleton)
+
+### Recipe list
+
+* [Constructors of an \`abstract\` class should not be declared \`public\`](/recipes/...)
+* [Atomic Boolean, Integer, and Long equality checks compare their values](/recipes/...)
+* ...
+`;
+
+/** Top-right rendered ⇄ raw toggle (IDE-style) over the page body, in place of the old "View as
+ *  Markdown" CTA. "Raw" swaps the rendered components for the `.md` source, in place. */
+const PageWithToggle = ({ children }: { children: ReactNode }) => {
+  const [view, setView] = useState<MarkdownView>('rendered');
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--neo-spacing_3)' }}>
+      <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+        <MarkdownToggle value={view} onChange={setView} />
+      </div>
+      {view === 'rendered' ? (
+        <Page>{children}</Page>
+      ) : (
+        <div style={{ position: 'relative' }}>
+          {/* Corner copy button — same CopyButton as the recipe-id chips, matching every code block's
+              copy affordance. The raw view exists to grab the source, so copy is front-and-center. */}
+          <div
+            style={{
+              position: 'absolute',
+              top: 'var(--neo-spacing_1)',
+              right: 'var(--neo-spacing_1)',
+              background: 'var(--neo-surfaces-card)',
+              borderRadius: 'var(--neo-border-radius-x-s)',
+            }}
+          >
+            <CopyButton value={SAMPLE_RAW_MARKDOWN} label="Copy markdown source" />
+          </div>
+          <pre
+            style={{
+              margin: 0,
+              padding: 'var(--neo-spacing_2)',
+              paddingRight: 'var(--neo-spacing_5)',
+              fontSize: 'var(--neo-font-size-code)',
+              lineHeight: 1.6,
+              whiteSpace: 'pre-wrap',
+              background: 'var(--neo-surfaces-card-header)',
+              border: '1px solid var(--neo-border-card)',
+              borderRadius: 'var(--neo-border-radius-card)',
+              color: 'var(--neo-typography-input-default)',
+            }}
+          >
+            {SAMPLE_RAW_MARKDOWN}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+};
+
 const singleHeader = {
   displayName: 'Replace duplicate `String` literals',
   description:
@@ -52,7 +133,7 @@ const singleHeader = {
 /** Composite recipe: access badge + Definition (sub-recipe list) + Examples + Usage + Data tables. */
 export const CompositeRecipe: Story = {
   render: () => (
-    <Page>
+    <PageWithToggle>
       <RecipeMeta
         displayName={SAMPLE.displayName}
         description={SAMPLE.description}
@@ -62,7 +143,13 @@ export const CompositeRecipe: Story = {
         sourceUrl="https://github.com/openrewrite/rewrite-static-analysis"
       />
       <RecipeHeader {...SAMPLE} />
-      <RecipeList recipes={composite.subRecipes}>
+      <RecipeList
+        recipes={composite.subRecipes}
+        preconditions={composite.preconditions.map((p) => ({
+          name: p,
+          href: '/user-documentation/recipes/recipe-catalog/core/singleton',
+        }))}
+      >
         <h2>Definition</h2>
       </RecipeList>
       <ExampleList examples={composite.examples}>
@@ -74,14 +161,14 @@ export const CompositeRecipe: Story = {
       <DataTableList tables={composite.dataTables}>
         <h2>Data tables</h2>
       </DataTableList>
-    </Page>
+    </PageWithToggle>
   ),
 };
 
 /** Single recipe: Moderne-only badge + Options table + Examples + Usage + Data tables. */
 export const SingleRecipe: Story = {
   render: () => (
-    <Page>
+    <PageWithToggle>
       <RecipeMeta
         displayName="Replace duplicate String literals"
         description="Replaces String literals repeated a minimum of 3 times with a shared constant."
@@ -103,6 +190,6 @@ export const SingleRecipe: Story = {
       <DataTableList tables={single.dataTables}>
         <h2>Data tables</h2>
       </DataTableList>
-    </Page>
+    </PageWithToggle>
   ),
 };

--- a/src/components/recipe/index.ts
+++ b/src/components/recipe/index.ts
@@ -6,6 +6,7 @@ export { ExampleList } from './ExampleList';
 export { DataTableList } from './DataTableList';
 export { UsageList } from './UsageList';
 export { AccessInfoButton } from './AccessInfoButton';
+export { MarkdownToggle, type MarkdownView } from './MarkdownToggle';
 export { CopyButton } from './CopyButton';
 export { Accordion } from './Accordion';
 export type { AccordionItem } from './Accordion';


### PR DESCRIPTION
Hi @sjungling, pushed my iterations from @timtebeek's review onto the branch. Everything's in Storybook to click through. Here's the rundown.

**What changed in the UI:**
- Definition now folds up like the Examples/Usage sections.
- Preconditions are back, set apart with a purple counter that matches the platform's precondition color. The recipes themselves stay normal links.
- Markdown moved out of the button row into a rendered/raw toggle in the top-right corner, with a copy button in the raw view.
- "Try in Platform" got the unreadable hover fixed, plus a tooltip explaining the no-setup demo for non-customers.

Two of @timtebeek's points I left for you and the platform since they aren't UI: hiding the definition and used-in for proprietary recipes, and showing examples in the platform.

**A few technical things Claude surfaced while implementing, flagging for you:**
- Preconditions had to be fed through the page data. That's why they disappeared in the flatten: the data exists but nothing was passing them along, so the generator needs to include them.
- The raw markdown view is a placeholder and will need the real markdown source from the generator.
- It used the card border color for the dividers because the "secondary" border token renders noticeably darker.
- There's an unrelated `filterUtils` test that's failing.

Ready to review and merge whenever.
