### PR TITLE
Fix DX & Training secondary-nav highlight inside their docs

### DIFF
--- a/src/components/SecondaryNav/SecondaryNav.module.css
+++ b/src/components/SecondaryNav/SecondaryNav.module.css
@@ -87,6 +87,11 @@
   color: var(--ifm-navbar-link-hover-color);
 }
 
+/* Highlight the dropdown trigger when the current page lives under one of its items. */
+.dropdownButtonActive {
+  color: var(--neo-buttons-primary-default);
+}
+
 /* Chevron icon animation */
 .chevron {
   transition: transform 0.2s ease;
@@ -161,7 +166,8 @@
 }
 
 :global(html[data-theme='dark']) .productLinkActive,
-:global(html[data-theme='dark']) .productLinkActive:hover {
+:global(html[data-theme='dark']) .productLinkActive:hover,
+:global(html[data-theme='dark']) .dropdownButtonActive {
   color: var(--brand-digital-green);
 }
 

--- a/src/components/SecondaryNav/SecondaryNav.tsx
+++ b/src/components/SecondaryNav/SecondaryNav.tsx
@@ -34,7 +34,10 @@ export const SecondaryNav: FunctionComponent<SecondaryNavProps> = ({
   const location = useLocation();
 
   const isProductActive = (productHref: string) => {
-    return location.pathname.startsWith(productHref);
+    // Case-insensitive: some category slugs differ in case from their doc routes — e.g. the DX
+    // section slug is `/administrator-documentation/moderne-DX` but its pages live under
+    // `…/moderne-dx/…`, so a case-sensitive match would never highlight DX.
+    return location.pathname.toLowerCase().startsWith(productHref.toLowerCase());
   };
 
   const isDropdownItemActive = (itemHref: string) => {
@@ -44,6 +47,9 @@ export const SecondaryNav: FunctionComponent<SecondaryNavProps> = ({
     }
     return location.pathname.startsWith(itemHref);
   };
+
+  // A dropdown (Training / Releases) is active when the current page lives under one of its items.
+  const isDropdownActive = (items: NavLink[]) => items.some((item) => isDropdownItemActive(item.href));
 
   const toggleDropdown = useCallback((dropdown: 'training' | 'releases') => {
     setOpenDropdown((prev) => (prev === dropdown ? null : dropdown));
@@ -112,6 +118,7 @@ export const SecondaryNav: FunctionComponent<SecondaryNavProps> = ({
           <button
             className={clsx(styles.dropdownButton, {
               [styles.dropdownButtonOpen]: openDropdown === 'training',
+              [styles.dropdownButtonActive]: isDropdownActive(trainingItems),
             })}
             onClick={() => toggleDropdown('training')}
             aria-expanded={openDropdown === 'training'}
@@ -153,6 +160,7 @@ export const SecondaryNav: FunctionComponent<SecondaryNavProps> = ({
           <button
             className={clsx(styles.dropdownButton, {
               [styles.dropdownButtonOpen]: openDropdown === 'releases',
+              [styles.dropdownButtonActive]: isDropdownActive(releasesItems),
             })}
             onClick={() => toggleDropdown('releases')}
             aria-expanded={openDropdown === 'releases'}


### PR DESCRIPTION
## Problem

- The **DX** and **Training** items in the secondary nav lose their active highlight once you navigate into their docs (other sections are fine). Reported by @mike-solomon on #794; pre-existing on the live site.

## Root causes (in `SecondaryNav`)

- **DX** — the sidebar category slug is `/administrator-documentation/moderne-DX` (capital `DX`), but its pages live under `/administrator-documentation/moderne-dx/…` (lowercase). The active check `location.pathname.startsWith(productHref)` is case-sensitive, so it never matches on real DX pages.
- **Training** (and **Releases**) — these render as dropdown *buttons* that only get a class while the dropdown is *open*; they had no active state tied to the current route, so they never highlight inside their sections.

## Fix

- Make the product active-check **case-insensitive**.
- Add `isDropdownActive(items)` (true when the current page is under any non-external item) and a `.dropdownButtonActive` style (light + dark) for the Training/Releases triggers.

No URL/slug changes (avoids touching the published `/moderne-DX` index URL).

## Testing

`yarn start`, then navigate into a DX doc (`/administrator-documentation/moderne-dx/...`), a Training doc (e.g. `/hands-on-learning/...`), and a Releases doc — each section's nav item should stay highlighted. Verified `tsc` + `yarn validate:css`.