### PR TITLE
Render recipe title/description as markdown; harden RecipeList links

### DIFF
--- a/src/components/recipe/RecipeHeader/RecipeHeader.module.css
+++ b/src/components/recipe/RecipeHeader/RecipeHeader.module.css
@@ -82,6 +82,29 @@ font-family: var(--neo-font-family-code), var(--ifm-font-family-monospace);
   padding: 0;
 }
 
+/* Native markdown `code` in the compound <RecipeHeader.Title>/<RecipeHeader.Description> slots.
+   The <code> is emitted by the MDX pipeline and carries no class, so it must be targeted by element;
+   these mirror .titleCode/.descCode so the markdown path matches the prop fallback. The doubled class
+   raises specificity above Docusaurus's global inline-code styling (the pill background/border). */
+.title.title code {
+  font-family: var(--neo-font-family-code), var(--ifm-font-family-monospace);
+  font-size: 0.9em;
+  font-weight: var(--neo-font-weight-bold);
+  color: var(--neo-typography-code-primary);
+  background: transparent;
+  border: none;
+  padding: 0;
+}
+
+.description.description code {
+  font-family: var(--neo-font-family-code), var(--ifm-font-family-monospace);
+  font-size: 0.9em;
+  color: var(--neo-typography-code-primary);
+  background: transparent;
+  border: none;
+  padding: 0;
+}
+
 .idArtifactRow {
 display: flex;
   flex-direction: column;

--- a/src/components/recipe/RecipeHeader/RecipeHeader.stories.tsx
+++ b/src/components/recipe/RecipeHeader/RecipeHeader.stories.tsx
@@ -22,3 +22,22 @@ export const Production: Story = {
 export const ProductionModerneOnly: Story = {
   args: { ...SAMPLE, moderneOnly: true },
 };
+
+/**
+ * Compound API: title and description are passed as children so the generated MDX can author them as
+ * markdown (code spans, links). On real pages MDX renders the markdown; here we pass the equivalent JSX.
+ */
+export const CompoundChildren: Story = {
+  args: { ...SAMPLE, displayName: undefined, description: undefined },
+  render: (args) => (
+    <RecipeHeader {...args}>
+      <RecipeHeader.Title>
+        Replace <code>BigDecimal</code> rounding constants with <code>RoundingMode</code> enums
+      </RecipeHeader.Title>
+      <RecipeHeader.Description>
+        Install a CircleCI <a href="https://circleci.com/docs/2.0/orb-intro/">orb</a> if it is not already
+        installed. Uses <code>RoundingMode</code> under the hood.
+      </RecipeHeader.Description>
+    </RecipeHeader>
+  ),
+};

--- a/src/components/recipe/RecipeHeader/RecipeHeader.tsx
+++ b/src/components/recipe/RecipeHeader/RecipeHeader.tsx
@@ -1,4 +1,4 @@
-import React, { type FunctionComponent } from 'react';
+import React, { isValidElement, type FunctionComponent, type ReactElement, type ReactNode } from 'react';
 import clsx from 'clsx';
 import { ArrowRight } from 'lucide-react';
 import { NeoButton } from '@site/src/components/NeoButton';
@@ -9,8 +9,12 @@ import styles from './RecipeHeader.module.css';
 import shared from '../shared/styles.module.css';
 
 export interface RecipeHeaderProps {
-  displayName: string;
-  description: string;
+  /** Plain-text title. Optional when a `<RecipeHeader.Title>` child is provided (preferred — it renders
+   *  the title as native MDX so code/links resolve), kept for backward compatibility / Storybook. */
+  displayName?: string;
+  /** Plain-text description. Optional when a `<RecipeHeader.Description>` child is provided. */
+  description?: string;
+  children?: ReactNode;
   type: 'Composite recipe' | 'Single recipe';
   languages: string[];
   tags: string[];
@@ -33,10 +37,30 @@ const tagHref = (tag: string): string => {
   return `https://docs.moderne.io/?s=${encodeURIComponent(tag)}`;
 };
 
+/** Marker slots — their children are extracted by RecipeHeader and rendered into the title/description.
+ *  Lets the generated MDX pass the title/description as native markdown children (so `code` and
+ *  [links](…) render) instead of pre-flattened string props. Title and Description must be DISTINCT
+ *  component identities so the slot lookup (`c.type === Title`) can tell them apart. */
+const Title: FunctionComponent<{ children?: ReactNode }> = ({ children }) => <>{children}</>;
+const Description: FunctionComponent<{ children?: ReactNode }> = ({ children }) => <>{children}</>;
+
+/** Pull the children of the first child element whose type is `slot` (a Title/Description marker). */
+const slotChildren = (children: ReactNode, slot: FunctionComponent): ReactNode | undefined =>
+  React.Children.toArray(children).find(
+    (c): c is ReactElement => isValidElement(c) && c.type === slot,
+  )?.props.children;
+
 /** Header band for a recipe page: access badge, title, recipe-id/artifact code-chips, description, tags, CTAs. */
-export const RecipeHeader: FunctionComponent<RecipeHeaderProps> = ({
-  displayName, description, type, languages, tags, license, fqName, artifact, appLink, moderneOnly = false,
-}) => (
+const RecipeHeaderRoot: FunctionComponent<RecipeHeaderProps> = ({
+  displayName, description, children, type, languages, tags, license, fqName, artifact, appLink, moderneOnly = false,
+}) => {
+  // Prefer the markdown children; fall back to the plain-text props (older generated pages, Storybook).
+  const titleSlot = slotChildren(children, Title);
+  const descriptionSlot = slotChildren(children, Description);
+  const title = titleSlot ?? (displayName != null ? renderWithCode(displayName, styles.titleCode) : null);
+  const summary = descriptionSlot ?? (description != null ? renderWithCode(description, styles.descCode) : null);
+
+  return (
   <header className={styles.header}>
     {/* Identity group: access badge, title, recipe-id/artifact chips — tight gaps within. */}
     <div className={styles.titleGroup}>
@@ -54,7 +78,7 @@ export const RecipeHeader: FunctionComponent<RecipeHeaderProps> = ({
         {moderneOnly && <AccessInfoButton />}
       </div>
 
-      <h1 className={styles.title}>{renderWithCode(displayName, styles.titleCode)}</h1>
+      <h1 className={styles.title}>{title}</h1>
 
       <div className={styles.idArtifactRow}>
         <div className={styles.codeChip}>
@@ -74,7 +98,7 @@ export const RecipeHeader: FunctionComponent<RecipeHeaderProps> = ({
 
     {/* Summary group: description + tags — tight gaps within. */}
     <div className={styles.metaGroup}>
-      <p className={styles.description}>{renderWithCode(description, styles.descCode)}</p>
+      <p className={styles.description}>{summary}</p>
 
       <div className={styles.tagRow}>
         <span className={shared.chip}>{type}</span>
@@ -120,4 +144,12 @@ export const RecipeHeader: FunctionComponent<RecipeHeaderProps> = ({
       </div>
     </div>
   </header>
-);
+  );
+};
+
+/**
+ * Compound API: `<RecipeHeader …><RecipeHeader.Title>…</RecipeHeader.Title>
+ * <RecipeHeader.Description>…</RecipeHeader.Description></RecipeHeader>`. The slot children are authored
+ * as markdown in the generated MDX, so Docusaurus renders inline code and links natively.
+ */
+export const RecipeHeader = Object.assign(RecipeHeaderRoot, { Title, Description });

--- a/src/components/recipe/RecipeList/RecipeList.tsx
+++ b/src/components/recipe/RecipeList/RecipeList.tsx
@@ -7,13 +7,22 @@ import { renderWithCode } from '../shared/renderWithCode';
 import styles from './RecipeList.module.css';
 import shared from '../shared/styles.module.css';
 
-const RecipeLink: FunctionComponent<{ recipe: SubRecipe }> = ({ recipe }) => (
-  <li className={styles.recipeListItem}>
-    <a className={styles.recipeLink} href={recipe.href} target="_blank" rel="noopener noreferrer">
-      {renderWithCode(recipe.name, shared.inlineCode)}
-    </a>
-  </li>
-);
+const RecipeLink: FunctionComponent<{ recipe: SubRecipe }> = ({ recipe }) => {
+  const label = renderWithCode(recipe.name, shared.inlineCode);
+  return (
+    <li className={styles.recipeListItem}>
+      {recipe.href ? (
+        <a className={styles.recipeLink} href={recipe.href} target="_blank" rel="noopener noreferrer">
+          {label}
+        </a>
+      ) : (
+        // Unlinkable sub-recipe (not present in the catalog, e.g. an internal recipe) — render as plain
+        // text rather than an empty <a href=""> that would navigate to the current page.
+        <span className={styles.recipeLink}>{label}</span>
+      )}
+    </li>
+  );
+};
 
 /** A count badge in an accordion label — violet for preconditions, neutral for the recipe list. */
 const CountBadge: FunctionComponent<{ count: number; tone: 'violet' | 'neutral' }> = ({ count, tone }) => (


### PR DESCRIPTION
Fixes how the now-live component recipe pages render the title and description.

## Problem

On recipe pages, markdown in the **description** (and title) rendered as raw text — e.g. [Install an orb](https://docs.moderne.io/user-documentation/recipes/recipe-catalog/circleci/installorb/) showed `Install a CircleCI [orb](https://…) …` literally. `RecipeHeader` received them as flattened string props and only `renderWithCode` (backticks-only) ran on them, so links/bold/etc. didn't render. ~10% of descriptions contain links.

## Changes

- **Compound `RecipeHeader`** — `<RecipeHeader.Title>` / `<RecipeHeader.Description>` slots whose children the generator authors as markdown, so Docusaurus renders inline code and links natively (same approach as the section `##` headings). **Backward compatible:** falls back to the `displayName`/`description` string props when no slot children are present (older generated pages, Storybook).
- Native markdown `code` in those slots is styled to match the borderless inline-code look of the prop path.
- **`RecipeList`** renders an unlinkable sub-recipe (empty href) as plain text instead of a broken `<a href="">` that navigates to the current page.
- Added a Storybook story for the compound API.

## Pairs with

- [rewrite-recipe-markdown-generator#347](https://github.com/openrewrite/rewrite-recipe-markdown-generator/pull/347), which emits the slot children + absolute (trailing-slash) sub-recipe links. This component change is backward compatible, so it can merge first; recipe pages start rendering markdown once the generator change lands and `Update docs` runs.

## Verification

- `tsc` clean; `yarn validate:css` clean.
- Verified in `yarn start:examples` against generator output: description link renders as a real `<a>`, titles render inline `<code>`, block descriptions render lists/code, sub-recipe links resolve to absolute catalog URLs.