### PR TITLE
Update v2 user roles table for the SaaS v2 platform

### DIFF
--- a/docs/administrator-documentation/moderne-platform/references/user-roles.md
+++ b/docs/administrator-documentation/moderne-platform/references/user-roles.md
@@ -10,32 +10,34 @@ import VersionBanner from '@site/src/components/VersionBanner';
 
 # User roles
 
-| Action                                            |       Everyone                    |    Administrators     |
-| ------------------------------------------------- | :-------------------------------: | :-------------------: |
-| Interact with DevCenter                           | Users with organization access    | :white_check_mark:  |
-| View Marketplace                                  |       :white_check_mark:        | :white_check_mark:  |
-| Build recipes                                     |       :white_check_mark:        | :white_check_mark:  |
-| Create and use access tokens                      |       :white_check_mark:        | :white_check_mark:  |
-| Deploy recipe and visualization artifacts         |              :x:                  | :white_check_mark:  |
-| View list of repositories                         | Users with organization access    | :white_check_mark:  |
-| [View repository insights](#repository-insights)  | Users with organization access    | :white_check_mark:  |
-| View activity log                                 | Users with organization access    | :white_check_mark:  |
-| Run recipes and visualizations                    | Users with organization access    | :white_check_mark:  |
-| View recipe results                               | [Users with SCM access](#scm-access)             | [Users with SCM access](#scm-access)|
-| Commit recipe results                             | [Users with SCM access](#scm-access)             | [Users with SCM access](#scm-access) | 
-| [Download data tables](#user-content-fn-1)[^1]    | [Users with SCM access](#scm-access)             | [Users with SCM access](#scm-access) |
-| View audit logs                                   |              :x:                  | :white_check_mark:  |
-| Download usage reports                            |              :x:                  | :white_check_mark:  |
-| View connected agents and associated technologies |              :x:                  | :white_check_mark:  |
-| View and delete user access tokens                |              :x:                  | :white_check_mark:  |
-| Quarantine repositories                           |              :x:                  | :white_check_mark:  |
-| View connected workers                            |              :x:                  | :white_check_mark:  |
+| Action                                                | Everyone                             | Administrators                       |
+| ----------------------------------------------------- | :----------------------------------: | :----------------------------------: |
+| Interact with DevCenter                               | Users with organization access       | :white_check_mark:                   |
+| View Marketplace                                      | :white_check_mark:                   | :white_check_mark:                   |
+| Build recipes                                         | :white_check_mark:                   | :white_check_mark:                   |
+| Create and use access tokens                          | :white_check_mark:                   | :white_check_mark:                   |
+| Deploy recipe and visualization artifacts             | :x:                                  | :white_check_mark:                   |
+| View list of repositories                             | Users with organization access       | :white_check_mark:                   |
+| [View repository insights](#repository-insights)      | Users with organization access       | :white_check_mark:                   |
+| View activity log                                     | Users with organization access       | :white_check_mark:                   |
+| Run recipes and visualizations                        | Users with organization access       | :white_check_mark:                   |
+| View recipe results                                   | [Users with SCM access](#scm-access) | [Users with SCM access](#scm-access) |
+| Commit recipe results                                 | [Users with SCM access](#scm-access) | [Users with SCM access](#scm-access) |
+| [Download data tables](#user-content-fn-1)[^1]        | [Users with SCM access](#scm-access) | [Users with SCM access](#scm-access) |
+| View audit logs                                       | :x:                                  | :white_check_mark:                   |
+| View connected connectors and associated technologies | :x:                                  | :white_check_mark:                   |
+| [Manage Moddy organization prompts](#moddy-prompts)   | :x:                                  | :white_check_mark:                   |
+| View and delete user access tokens                    | :x:                                  | :white_check_mark:                   |
 
 ## SCM access
 
 In order to view recipe results, download data tables produced by a recipe, or commit recipe results, users will need to have [SCM access to the repositories](./flow.md#integrating-with-scms). This restriction applies even for admins in Moderne.
 
 [^1]: If a user does not have access to a specific repository, they will not see a row for said repository in the data table.
+
+## Moddy prompts
+
+Administrators can set the system prompt that steers [Moddy](../../../user-documentation/moddy/moddy-platform.md) for an entire organization, as well as the universal prompt that applies across the tenant. Any user can set their own personal prompt, which overrides the organization and universal prompts for that user.
 
 ## Repository insights
 


### PR DESCRIPTION
## Background / problem

The [user roles reference](https://docs.moderne.io/administrator-documentation/moderne-platform/references/user-roles) for the v2 Platform was a straight copy of the v1 page, so it still listed several permissions that don't map to anything in the SaaS v2 platform. Checking the v2 backend (`moderne-saas`), the two-tier model itself still holds (the only privileged role the platform recognizes is `admin`, and SCM access still gates recipe results), but a few rows describe v1-only features and the table was missing a capability that v2 added.

## Solution

Removed the rows for features that no longer exist in SaaS v2: downloading usage reports, quarantining repositories, and viewing connected workers. Renamed "View connected agents and associated technologies" to "View connected connectors and associated technologies", since v2 uses the connector model rather than agents. Added an admin-only row for managing Moddy organization prompts, with a short section explaining that administrators set the organization and universal prompts while any user can set their own personal prompt. Only the v2 page changed; the v1 page still documents the v1 feature set.

## Test plan

- [x] `yarn build` succeeds with no broken-link errors for the changed page
- [x] `yarn lint:markdown` passes on the modified file
