### PR TITLE
Correct v2 user roles after auditing against the SaaS v2 backend

### DIFF
--- a/docs/administrator-documentation/moderne-platform/references/user-roles.md
+++ b/docs/administrator-documentation/moderne-platform/references/user-roles.md
@@ -18,48 +18,20 @@ import VersionBanner from '@site/src/components/VersionBanner';
 | Create and use access tokens                          | :white_check_mark:                   | :white_check_mark:                   |
 | Deploy recipe and visualization artifacts             | :x:                                  | :white_check_mark:                   |
 | View list of repositories                             | Users with organization access       | :white_check_mark:                   |
-| [View repository insights](#repository-insights)      | Users with organization access       | :white_check_mark:                   |
 | View activity log                                     | Users with organization access       | :white_check_mark:                   |
 | Run recipes and visualizations                        | Users with organization access       | :white_check_mark:                   |
 | View recipe results                                   | [Users with SCM access](#scm-access) | [Users with SCM access](#scm-access) |
 | Commit recipe results                                 | [Users with SCM access](#scm-access) | [Users with SCM access](#scm-access) |
-| [Download data tables](#user-content-fn-1)[^1]        | [Users with SCM access](#scm-access) | [Users with SCM access](#scm-access) |
+| Download data tables                                  | Users with organization access       | :white_check_mark:                   |
 | View audit logs                                       | :x:                                  | :white_check_mark:                   |
-| View connected connectors and associated technologies | :x:                                  | :white_check_mark:                   |
+| View connected connectors and associated technologies | :white_check_mark:                   | :white_check_mark:                   |
 | [Manage Moddy organization prompts](#moddy-prompts)   | :x:                                  | :white_check_mark:                   |
 | View and delete user access tokens                    | :x:                                  | :white_check_mark:                   |
 
 ## SCM access
 
-In order to view recipe results, download data tables produced by a recipe, or commit recipe results, users will need to have [SCM access to the repositories](./flow.md#integrating-with-scms). This restriction applies even for admins in Moderne.
-
-[^1]: If a user does not have access to a specific repository, they will not see a row for said repository in the data table.
+In order to view recipe results or commit recipe results, users will need to have [SCM access to the repositories](./flow.md#integrating-with-scms). This restriction applies even for admins in Moderne. Viewing results is gated per repository: if you lack access to a given repository, you'll see the file and change counts but not the underlying diffs. Committing uses your own SCM credentials, so a commit will only succeed for repositories you can push to.
 
 ## Moddy prompts
 
 Administrators can set the system prompt that steers [Moddy](../../../user-documentation/moddy/moddy-platform.md) for an entire organization, as well as the universal prompt that applies across the tenant. Any user can set their own personal prompt, which overrides the organization and universal prompts for that user.
-
-## Repository insights
-
-The repository insights page provides details about a repository such as where the artifacts live, what version of Java it uses, how it was built, etc.
-
-You can find repository insights by clicking on the repositories link in the navigation bar:
-
-<figure>
-  ![Moderne left sidebar with Repositories option highlighted](./assets/repos-link.png)
-  <figcaption>_Repositories link_</figcaption>
-</figure>
-
-Then find the repository you want to learn more about in the list of repositories and click on the repository name:
-
-<figure>
-  ![Repositories list with arrow pointing to a clickable repository name](./assets/repo-insight-link.png)
-  <figcaption>_Repository insight link_</figcaption>
-</figure>
-
-You'll then be taken to the repository insights page:
-
-<figure>
-  ![Repository insights page showing language composition pie chart and file count table](./assets/repo-insight-details.png)
-  <figcaption>_Repository insights_</figcaption>
-</figure>


### PR DESCRIPTION
## Background / problem

- The v2 user roles page was originally copied from v1 (#807 took a first pass at it), but several rows still didn't match how the SaaS v2 platform actually authorizes things. To be sure, I audited every row against the `moderne-saas` backend rather than trusting the v1 wording. The two-tier model holds (the only privileged role the platform recognizes is `admin`, and SCM access still gates viewing diffs), but three rows were wrong.

## Solution

Downloading data tables is not gated by SCM access in v2. The `downloadDataTable` mutation and the REST download endpoint have no authorization, and the full file is returned with no per-repo row filtering, so the row moves to organization access and the stale footnote (which claimed you wouldn't see rows for repositories you lack access to) is removed. Viewing connectors is also ungated for any authenticated user, with no `@auth` directive, org filter, or masking, so it moves from admin-only to everyone. Repository insights has no v2 counterpart at all, since the v2 `Repository` type carries no language, build, or Java metadata, so its row and the accompanying screenshot section are removed. Finally, the SCM access section is reworded to explain that viewing results is gated per repository (you see counts but not diffs when denied) and that committing relies on your own SCM credentials at push time rather than a Moderne-side check.

## Test plan

- [x] `yarn build` succeeds with no broken-link errors for the changed page
- [x] `yarn lint:markdown` passes on the modified file
