### PR TITLE
Document the DevCenter org-statistics recipes required in v2

### DIFF
--- a/docs/administrator-documentation/moderne-platform/how-to-guides/creating-a-devcenter-recipe.md
+++ b/docs/administrator-documentation/moderne-platform/how-to-guides/creating-a-devcenter-recipe.md
@@ -69,7 +69,7 @@ description: >-
 
 ### Recipe list
 
-After that, it lists out the recipes that will be run to build the DevCenter dashboard. Each of these recipes will turn into a card in your DevCenter:
+After that, it lists out the recipes that will be run to build the DevCenter dashboard. Most of these recipes will turn into a card in your DevCenter:
 
 ```yaml
 recipeList:
@@ -93,14 +93,14 @@ DevCenter recipes have two notable properties worth calling out:
 * `cardName` is a property that allows you to customize what the name of the card should be. Not all recipes have a `cardName` property. For instance, the [LibraryUpgrade recipe](https://github.com/moderneinc/rewrite-devcenter/blob/main/src/main/java/io/moderne/devcenter/LibraryUpgrade.java#L35-L38) has a `cardName` property – whereas the [JavaVersionUpgrade recipe](https://github.com/moderneinc/rewrite-devcenter/blob/main/src/main/java/io/moderne/devcenter/JavaVersionUpgrade.java) does not.
 * `upgradeRecipe` is a property that defines the recipe that should be run to upgrade your repositories. It is the recipe that will get executed when you press the `Upgrade` button on a card.
 
-:::info
-The last two recipes in the list, `io.moderne.devcenter.FindOrganizationStatistics` and `org.openrewrite.search.FindCommitters`, do not produce cards. They populate the **Lines of code** and **Contributing developers** cards in the DevCenter's Organizational ownership section. Include both in every DevCenter recipe; without them, those two cards remain empty.
-:::
-
 <figure>
   ![DevCenter card for Move to Java 21 showing a donut chart with repo categories and an Upgrade button](./assets/example-card.png)
   <figcaption>_An example of a DevCenter card._</figcaption>
 </figure>
+
+### Organizational ownership recipes
+
+The last two recipes in the list, `io.moderne.devcenter.FindOrganizationStatistics` and `org.openrewrite.search.FindCommitters`, do not produce cards. They populate the **Lines of code** and **Contributing developers** cards in the DevCenter's Organizational ownership section. Include both in every DevCenter recipe; without them, those two cards remain empty. The canonical recipe list that includes both is the [DevCenterStarter recipe](https://github.com/moderneinc/rewrite-devcenter/blob/main/src/main/resources/META-INF/rewrite/devcenter-starter.yml).
 
 ### Security card
 
@@ -172,6 +172,8 @@ recipeList:
   - io.moderne.devcenter.JUnitJupiterUpgrade:
       upgradeRecipe: org.openrewrite.java.testing.junit5.JUnit4to5Migration
   - io.moderne.devcenter.SecurityStarter
+  # Required in every DevCenter recipe (they do not produce cards).
+  # See "Organizational ownership recipes" above.
   - io.moderne.devcenter.FindOrganizationStatistics
   - org.openrewrite.search.FindCommitters
 ---
@@ -219,6 +221,8 @@ recipeList:
   - io.moderne.devcenter.JUnitJupiterUpgrade:
       upgradeRecipe: org.openrewrite.java.testing.junit5.JUnit4to5Migration
   - io.moderne.devcenter.SecurityStarter
+  # Required in every DevCenter recipe (they do not produce cards).
+  # See "Organizational ownership recipes" above.
   - io.moderne.devcenter.FindOrganizationStatistics
   - org.openrewrite.search.FindCommitters
 ---

--- a/docs/administrator-documentation/moderne-platform/how-to-guides/creating-a-devcenter-recipe.md
+++ b/docs/administrator-documentation/moderne-platform/how-to-guides/creating-a-devcenter-recipe.md
@@ -85,11 +85,17 @@ recipeList:
   - io.moderne.devcenter.JUnitJupiterUpgrade:
       upgradeRecipe: org.openrewrite.java.testing.junit5.JUnit4to5Migration
   - io.moderne.devcenter.SecurityStarter
+  - io.moderne.devcenter.FindOrganizationStatistics
+  - org.openrewrite.search.FindCommitters
 ```
 DevCenter recipes have two notable properties worth calling out:
 
 * `cardName` is a property that allows you to customize what the name of the card should be. Not all recipes have a `cardName` property. For instance, the [LibraryUpgrade recipe](https://github.com/moderneinc/rewrite-devcenter/blob/main/src/main/java/io/moderne/devcenter/LibraryUpgrade.java#L35-L38) has a `cardName` property – whereas the [JavaVersionUpgrade recipe](https://github.com/moderneinc/rewrite-devcenter/blob/main/src/main/java/io/moderne/devcenter/JavaVersionUpgrade.java) does not.
 * `upgradeRecipe` is a property that defines the recipe that should be run to upgrade your repositories. It is the recipe that will get executed when you press the `Upgrade` button on a card.
+
+:::info
+The last two recipes in the list, `io.moderne.devcenter.FindOrganizationStatistics` and `org.openrewrite.search.FindCommitters`, do not produce cards. They populate the **Lines of code** and **Contributing developers** cards in the DevCenter's Organizational ownership section. Include both in every DevCenter recipe; without them, those two cards remain empty.
+:::
 
 <figure>
   ![DevCenter card for Move to Java 21 showing a donut chart with repo categories and an Upgrade button](./assets/example-card.png)
@@ -166,6 +172,8 @@ recipeList:
   - io.moderne.devcenter.JUnitJupiterUpgrade:
       upgradeRecipe: org.openrewrite.java.testing.junit5.JUnit4to5Migration
   - io.moderne.devcenter.SecurityStarter
+  - io.moderne.devcenter.FindOrganizationStatistics
+  - org.openrewrite.search.FindCommitters
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: io.moderne.devcenter.UpgradeQuarkus
@@ -211,6 +219,8 @@ recipeList:
   - io.moderne.devcenter.JUnitJupiterUpgrade:
       upgradeRecipe: org.openrewrite.java.testing.junit5.JUnit4to5Migration
   - io.moderne.devcenter.SecurityStarter
+  - io.moderne.devcenter.FindOrganizationStatistics
+  - org.openrewrite.search.FindCommitters
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: io.moderne.devcenter.UpgradeApacheMavenParent

--- a/docs/releases/saas-v2-migration.md
+++ b/docs/releases/saas-v2-migration.md
@@ -147,6 +147,15 @@ To make this easy to operationalize, Moderne provides a sample [auto-redeploy-re
 For the "pick up the newest version" behavior to work, install your recipe bundles with a moving version selector (for example, `latest.release` or `latest.integration` for Maven, or `LATEST` for pip and Go). Bundles pinned to a concrete version are simply re-resolved to the same version. See the [automation's README](https://github.com/moderneinc/saas-templates/tree/main/auto-redeploy-recipes) for the full list of requirements, configuration variables, and scheduling examples.
 :::
 
+## DevCenter
+
+In SaaS v1, the DevCenter Organizational ownership cards (Repositories, Contributing developers, and Lines of code) were populated automatically from your ingested LSTs each time the DevCenter ran. In SaaS v2, the Contributing developers and Lines of code cards are produced by two recipes that must be part of your DevCenter recipe:
+
+* `io.moderne.devcenter.FindOrganizationStatistics` populates Lines of code.
+* `org.openrewrite.search.FindCommitters` populates Contributing developers.
+
+If your DevCenter recipe does not include both, those two cards stay empty in v2, even though the Repositories card still works. Add both recipes to the `recipeList` of your DevCenter recipe, redeploy the recipe artifact, and re-run the DevCenter. The default [DevCenterStarter recipe](https://github.com/moderneinc/rewrite-devcenter/blob/main/src/main/resources/META-INF/rewrite/devcenter-starter.yml) already includes them. For more details, see [Creating a DevCenter recipe](../administrator-documentation/moderne-platform/how-to-guides/creating-a-devcenter-recipe.md).
+
 ## What gets migrated and when
 
 Moderne migrates the following automatically, in a single pass scheduled just before your full v1 to v2 cutover:
@@ -272,7 +281,7 @@ Run these with v1 still serving as your front door, using the header, cookie, an
 * [ ] Marketplace lists the recipes you expect (including non-Java recipes if applicable).
 * [ ] Repositories view shows the orgs and repos you expect.
 * [ ] Run a small recipe against a small org end-to-end. This single test exercises LST fetch, recipe execution, SCM result presentation, and marketplace resolution. By far the most efficient smoke test.
-* [ ] If you use DevCenter, configure and load it at `/devcenter/configure?organizationId={org}`.
+* [ ] If you use DevCenter, confirm your DevCenter recipe includes `io.moderne.devcenter.FindOrganizationStatistics` and `org.openrewrite.search.FindCommitters` (required in v2 to populate the Contributing developers and Lines of code cards; see [DevCenter](#devcenter)), redeploy it, then configure and load it at `/devcenter/configure?organizationId={org}`.
 * [ ] Update internal bookmarks, runbooks, and any automation that references removed or renamed URLs (`/admin/status`, `/admin/agents`, `/batch-changes`, the bare GraphQL endpoint).
 * [ ] Coordinate the final user-data migration window with your Moderne contact. Tokens, activity, commits, orgs, and audit logs will be migrated then.
 

--- a/docs/releases/saas-v2-migration.md
+++ b/docs/releases/saas-v2-migration.md
@@ -149,12 +149,9 @@ For the "pick up the newest version" behavior to work, install your recipe bundl
 
 ## DevCenter
 
-In SaaS v1, the DevCenter Organizational ownership cards (Repositories, Contributing developers, and Lines of code) were populated automatically from your ingested LSTs each time the DevCenter ran. In SaaS v2, the Contributing developers and Lines of code cards are produced by two recipes that must be part of your DevCenter recipe:
+In SaaS v1, the DevCenter Organizational ownership cards (**Repositories**, **Contributing developers**, and **Lines of code**) were populated automatically from your ingested LSTs each time the DevCenter ran. In SaaS v2, the **Contributing developers** and **Lines of code** cards are produced by two recipes that must be part of your DevCenter recipe: `io.moderne.devcenter.FindOrganizationStatistics` and `org.openrewrite.search.FindCommitters`. See [Organizational ownership recipes](../administrator-documentation/moderne-platform/how-to-guides/creating-a-devcenter-recipe.md#organizational-ownership-recipes) for the details.
 
-* `io.moderne.devcenter.FindOrganizationStatistics` populates Lines of code.
-* `org.openrewrite.search.FindCommitters` populates Contributing developers.
-
-If your DevCenter recipe does not include both, those two cards stay empty in v2, even though the Repositories card still works. Add both recipes to the `recipeList` of your DevCenter recipe, redeploy the recipe artifact, and re-run the DevCenter. The default [DevCenterStarter recipe](https://github.com/moderneinc/rewrite-devcenter/blob/main/src/main/resources/META-INF/rewrite/devcenter-starter.yml) already includes them. For more details, see [Creating a DevCenter recipe](../administrator-documentation/moderne-platform/how-to-guides/creating-a-devcenter-recipe.md).
+If your DevCenter recipe does not include both, those two cards stay empty in v2, even though the **Repositories** card still works. Add both recipes to the `recipeList` of your DevCenter recipe, redeploy the recipe artifact, and re-run the DevCenter. The default [DevCenterStarter recipe](https://github.com/moderneinc/rewrite-devcenter/blob/main/src/main/resources/META-INF/rewrite/devcenter-starter.yml) already includes them.
 
 ## What gets migrated and when
 
@@ -281,7 +278,7 @@ Run these with v1 still serving as your front door, using the header, cookie, an
 * [ ] Marketplace lists the recipes you expect (including non-Java recipes if applicable).
 * [ ] Repositories view shows the orgs and repos you expect.
 * [ ] Run a small recipe against a small org end-to-end. This single test exercises LST fetch, recipe execution, SCM result presentation, and marketplace resolution. By far the most efficient smoke test.
-* [ ] If you use DevCenter, confirm your DevCenter recipe includes `io.moderne.devcenter.FindOrganizationStatistics` and `org.openrewrite.search.FindCommitters` (required in v2 to populate the Contributing developers and Lines of code cards; see [DevCenter](#devcenter)), redeploy it, then configure and load it at `/devcenter/configure?organizationId={org}`.
+* [ ] If you use DevCenter, confirm your DevCenter recipe includes the two org-statistics recipes required in v2 (see [DevCenter](#devcenter)) and redeploy it, then configure and load it at `/devcenter/configure?organizationId={org}`.
 * [ ] Update internal bookmarks, runbooks, and any automation that references removed or renamed URLs (`/admin/status`, `/admin/agents`, `/batch-changes`, the bare GraphQL endpoint).
 * [ ] Coordinate the final user-data migration window with your Moderne contact. Tokens, activity, commits, orgs, and audit logs will be migrated then.
 


### PR DESCRIPTION
## Problem

In SaaS v1, the DevCenter Organizational ownership cards (Contributing developers, Lines of code) were computed automatically from ingested LSTs. In v2 they are produced by two recipes that must be part of the DevCenter recipe (`io.moderne.devcenter.FindOrganizationStatistics`, `org.openrewrite.search.FindCommitters`). A DevCenter recipe that predates those recipes (or was copied from the docs) leaves both cards blank after migrating, and neither the migration guide nor the "Creating a DevCenter recipe" how-to mentions the requirement.

## Solution

* Add a DevCenter section to the v2 migration guide explaining the v1→v2 change, and update the pre-cutover checklist item.
* Add both recipes to the example `recipeList`s in "Creating a DevCenter recipe", with a note that they back the Organizational ownership cards.

- fixes: https://github.com/moderneinc/customer-requests/issues/2661


Fix applied by sunbit and reported to be working, including a screenshot https://moderneinc.slack.com/archives/C08U13ET2CW/p1782383759786779
