### PR TITLE
fix(CopyPageAction): include base URL in non-recipe markdown URLs for AI prompts

### DIFF
--- a/src/components/CopyPageAction/index.tsx
+++ b/src/components/CopyPageAction/index.tsx
@@ -8,6 +8,7 @@ import CopyPageButton from 'docusaurus-plugin-copy-page-button/react';
 export const SuppressCopyPageContext = createContext(false);
 
 const GITHUB_RAW_DOCS = 'https://raw.githubusercontent.com/moderneinc/moderne-docs/refs/heads/main/docs';
+const DOCS_BASE_URL = 'https://docs.moderne.io';
 
 /**
  * Where the View / Open-in-ChatGPT / Open-in-Claude actions fetch markdown from:
@@ -18,8 +19,8 @@ const GITHUB_RAW_DOCS = 'https://raw.githubusercontent.com/moderneinc/moderne-do
  * (The clipboard "Copy" action always DOM-scrapes; this only redirects View + the AI links.)
  */
 const markdownUrlFor = (pageUrl: string): string => {
-  const path = new URL(pageUrl, 'https://docs.moderne.io').pathname.replace(/\/$/, '');
-  return path.includes('/recipe-catalog/') ? `${GITHUB_RAW_DOCS}${path}.md` : `${path}.md`;
+  const path = new URL(pageUrl, DOCS_BASE_URL).pathname.replace(/\/$/, '');
+  return path.includes('/recipe-catalog/') ? `${GITHUB_RAW_DOCS}${path}.md` : `${DOCS_BASE_URL}${path}.md`;
 };
 
 /**


### PR DESCRIPTION
## Summary

* The `markdownUrlFor` function in `CopyPageAction` was returning a bare pathname (e.g. `/user-documentation/foo.md`) for non-recipe pages, so the predefined prompt sent to Claude and ChatGPT contained an unresolvable relative path instead of a full `https://docs.moderne.io/...` URL.
* Added a `DOCS_BASE_URL` constant and prefixed it to the returned path for non-recipe pages, matching the behavior already used for recipe-catalog pages (which already had a full GitHub raw URL).

## Test plan

* [ ] Open any non-recipe doc page and click "Open in Claude" or "Open in ChatGPT" — verify the prompt contains a full `https://docs.moderne.io/...` URL.
* [ ] Open a recipe-catalog page and confirm the prompt still uses the GitHub raw URL (unchanged behavior).