### PR TITLE
Loosen RecipeHeader.artifact docstring to reflect all distributions

### DIFF
--- a/src/components/recipe/RecipeHeader/RecipeHeader.tsx
+++ b/src/components/recipe/RecipeHeader/RecipeHeader.tsx
@@ -20,7 +20,8 @@ export interface RecipeHeaderProps {
   tags: string[];
   license: string;
   fqName: string;
-  /** Maven coordinates `groupId:artifactId`, shown as a second code-chip when present. */
+  /** Install coordinates for the recipe's distribution package, shown as a second code-chip when
+   *  present. Format varies by distribution: Maven `groupId:artifactId`, npm/pip/NuGet package name. */
   artifact?: string;
   appLink: string;
   /** Raw markdown source URL (e.g. a raw.githubusercontent.com link). Consumed by the page-level


### PR DESCRIPTION
## Summary

The `artifact` prop on `<RecipeHeader>` currently documents itself as "Maven coordinates \`groupId:artifactId\`". The chip actually just renders whatever string the markdown generator hands it, and the generator has always been able to emit different shapes depending on where the recipe is distributed:

* Maven `groupId:artifactId` for Java recipes
* An npm package for TypeScript recipes
* A pip package for Python recipes
* A NuGet package for C# recipes

Update the docstring accordingly. No runtime change — the chip already renders those strings verbatim.

## Companion change

- openrewrite/rewrite-recipe-markdown-generator#350 fixes the generator so those non-Java strings are actually emitted into the prop (previously it unconditionally wrote `groupId:artifactId`, which made `<RecipeHeader>` show `io.moderne.recipe:rewrite-angular` on TypeScript recipe pages like [UpgradeToAngular16](https://docs.moderne.io/user-documentation/recipes/recipe-catalog/angular/upgradetoangular16/) even while the Usage section correctly instructed users to run `mod config recipes npm install @openrewrite/recipes-angular`).

The docstring update here can land independently of the generator PR — it just brings the documented contract in line with what the chip has always supported.

## Test plan

* [ ] Docs build (`yarn start` / CI) still passes — this is a comment-only change inside a TypeScript source file, so no output should differ.