### PR TITLE
Pin Python recipe pip install commands to an explicit version

### DIFF
--- a/docs/user-documentation/moderne-cli/how-to-guides/python.md
+++ b/docs/user-documentation/moderne-cli/how-to-guides/python.md
@@ -154,11 +154,11 @@ Presuming everything has been set up correctly, you should see output similar to
 In order to run recipes, you'll need to make sure the recipes are installed on your local machine. For example, you can install recipes from a JAR or a pip package:
 
 ```bash
-mod config recipes jar install org.openrewrite:rewrite-python:LATEST
+mod config recipes jar install org.openrewrite:rewrite-python:{{VERSION_ORG_OPENREWRITE_REWRITE_PYTHON}}
 ```
 
 ```bash
-mod config recipes pip install openrewrite-migrate-python
+mod config recipes pip install openrewrite-migrate-python=={{VERSION_ORG_OPENREWRITE_RECIPE_REWRITE_MIGRATE_PYTHON}}
 ```
 
 :::tip

--- a/src/components/RunRecipe/index.tsx
+++ b/src/components/RunRecipe/index.tsx
@@ -66,6 +66,7 @@ export default function RunRecipe({
 
   // Python recipes
   if (pipPackage) {
+    const pipPackageSpec = version ? `${pipPackage}==${version}` : pipPackage;
     return (
       <>
         <p>
@@ -74,7 +75,7 @@ export default function RunRecipe({
         </p>
         <p>Once the CLI is installed, you can install this Python recipe package by running the following command:</p>
         <CodeBlock language="shell" title="Install the recipe package">
-          {`mod config recipes pip install ${pipPackage}`}
+          {`mod config recipes pip install ${pipPackageSpec}`}
         </CodeBlock>
         <p>Then, you can run the recipe via:</p>
         <CodeBlock language="shell" title="Run the recipe">


### PR DESCRIPTION
## What

Python recipe install snippets were unpinned (\`mod config recipes pip install openrewrite-migrate-python\`), unlike the Java jar path which pins a version. This renders an explicit version for Python recipes.

## How

- \`RunRecipe/index.tsx\`: the pip branch now appends \`==<version>\` when a \`versionKey\` resolves (reusing the same \`version\` resolution the Java/jar path already uses), falling back to an unpinned install when no version is available. \`UsageList\` delegates to \`RunRecipe\`, so this single change covers both entry points.
- \`how-to-guides/python.md\`: pinned the example jar and pip installs via version tokens (\`{{VERSION_ORG_OPENREWRITE_REWRITE_PYTHON}}\`, \`{{VERSION_ORG_OPENREWRITE_RECIPE_REWRITE_MIGRATE_PYTHON}}\`), resolved at build by the \`replace-tokens\` remark plugin.

- The generator that emits the \`versionKey\` prop is in a companion PR: openrewrite/rewrite-recipe-markdown-generator#351.

## Result

A \`rewrite-migrate-python\` recipe page now shows:

\`\`\`shell
mod config recipes pip install openrewrite-migrate-python==0.9.2
\`\`\`

## Validation

\`yarn typecheck\` and \`yarn lint:markdown\` pass. A full \`yarn start\` catalog build was not run locally (impractical for a one-line, type-safe component change).