### PR TITLE
Fix markdown lint break from unescaped generic in CLI changelog

### DIFF
--- a/docs/releases/cli-releases.md
+++ b/docs/releases/cli-releases.md
@@ -28,7 +28,7 @@ The Moderne CLI previously followed a two-track release model with separate "sta
 * remove leftover merge conflict markers in V3 tree registry
 * Custom JVM build tools: pick up hand-authored prebuild trees + V3 book chapter
 * Expand external SYSIN/SYSTSIN .prm members into the JCL LST during build
-* Call JclParser parmMembers(List<Path>) for the rewrite-cobol 2.20.1 seam
+* Call JclParser parmMembers(List`<Path>`) for the rewrite-cobol 2.20.1 seam
 
 ### CLI / DX v4.3.8 (2026-07-06)
 


### PR DESCRIPTION
## Specific cause

The Pages deploy for `main` failed in **Lint markdown** ([run 28938459340](https://github.com/moderneinc/moderne-docs/actions/runs/28938459340/job/85854563859)):

```
[31:3-31:75: Expected a closing tag for `<Path>` (31:34-31:40) before the end of `paragraph`]
ruleId: 'end-tag-mismatch', source: 'mdast-util-mdx-jsx'
```

The v4.3.9 changelog bullet in `docs/releases/cli-releases.md` was:

```
* Call JclParser parmMembers(List<Path>) for the rewrite-cobol 2.20.1 seam
```

MDX parses the bare `<Path>` as an opening JSX tag with no closing tag, so the whole document fails to parse. Fixed by backticking the generic (`List``<Path>``) — matching how **every other** `<...>` token in this file is already written (e.g. `RepositoriesProperty``<T>``, `build/``<id>``).

`yarn lint:markdown` now passes clean.

## Automation that caused it

This line was introduced by the **`Release moderne-cli main`** commit (91b1a8767, `team-moderne[bot]`), which is generated **upstream in the moderne-cli repo** and pushed **directly to `main`**. Two compounding automation gaps:

1. **Upstream (root cause):** the CLI changelog generator copies raw git commit subjects into MDX bullets *verbatim*, without escaping MDX-unsafe angle brackets. The other `<...>` entries in this file only survive because a human happened to backtick them in the commit subject; `List<Path>` was written bare and slipped through. The generator should wrap/escape code-like tokens (or the whole subject) so any `<...>` is inert in MDX.
2. **Process gap (here):** `pr-validation.yml` runs `lint:markdown` only on `pull_request`. Because the release bot pushes straight to `main`, that gate never runs — the first time markdown is linted is inside the deploy pipeline (`pages-sharded.yml`), i.e. *after* the bad content is already on `main`. Routing bot-generated doc updates through a PR (or running the markdown lint upstream before the push) would catch this pre-merge.

- This PR fixes #1's symptom on `main`. The durable fix (escaping in the upstream generator + not bypassing pre-merge lint) needs a change in the moderne-cli release automation.