### PR TITLE
Style inline code used as link text with the link color

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -568,6 +568,12 @@ html[data-theme='dark'] .markdown :not(pre) > code {
   color: var(--neo-grey-100);
 }
 
+/* Inline code used as link text should inherit the link color so it reads as clickable. */
+.markdown a > code,
+html[data-theme='dark'] .markdown a > code {
+  color: inherit;
+}
+
 /* Replit-style admonitions: rounded, subtle border, icon inline with text.
    When a title is present (`:::info[My title]`), the container stacks vertically
    so the heading row sits above the content. */


### PR DESCRIPTION
Inline code (`.markdown :not(pre) > code`) forced a dark text color on all inline code, including code used as link text, so links whose text is a code span (e.g. the `recipes-v5-released.csv` / `recipes-v5-snapshot.csv` links on the curate-recipe-marketplace page) rendered dark instead of blue and didn't read as clickable. This adds a rule so inline code inside a link inherits the link color, in both light and dark themes. Verified in the dev server that the affected links now render blue, and `yarn validate:css` passes.