### PR TITLE
Create a dedicated redirects file + cleanup redirects

### DIFF
--- a/docs/administrator-documentation/licensing/licensing.md
+++ b/docs/administrator-documentation/licensing/licensing.md
@@ -1,9 +1,0 @@
----
-id: licensing
-title: Licensing
-slug: /administrator-documentation/licensing
----
-
-import { Redirect } from '@docusaurus/router';
-
-<Redirect to="/licensing/overview" />;

--- a/docs/administrator-documentation/moderne-dx/getting-started/overview.md
+++ b/docs/administrator-documentation/moderne-dx/getting-started/overview.md
@@ -19,7 +19,7 @@ The key difference is that DX relies more on developers to drive value and creat
 
 DX delivers these capabilities through two customizable pipelines:
 
-* **Mass ingest** produces [LSTs](../../moderne-platform/references/lossless-semantic-trees.md) for all your repositories and publishes them to your artifact repository (e.g., Artifactory). You can then use this central data store to quickly answer questions like, "What's the impact of the Log4Shell vulnerability?" or "How are we doing migrating our services to Java 21?"
+* **Mass ingest** produces [LSTs](../../../user-documentation/recipes/authoring-recipes/concepts/lossless-semantic-trees.md) for all your repositories and publishes them to your artifact repository (e.g., Artifactory). You can then use this central data store to quickly answer questions like, "What's the impact of the Log4Shell vulnerability?" or "How are we doing migrating our services to Java 21?"
 * **Mass run** executes recipes at scale across those repositories, enabling large-scale remediation and reporting.
 
 Both pipelines are customizable blueprints that work with your existing infrastructure - no central service required.

--- a/docs/administrator-documentation/moderne-dx/getting-started/proof-of-value-prerequisites.md
+++ b/docs/administrator-documentation/moderne-dx/getting-started/proof-of-value-prerequisites.md
@@ -32,7 +32,7 @@ The easiest way to generate this file is with our [repository fetcher scripts](h
 
 ## Mass ingest
 
-While mass ingest is typically set up after the initial POV rather than during it, you may want to plan for it early. Mass ingest builds all of your repositories and creates the [LST artifacts](../../moderne-platform/references/lossless-semantic-trees.md) that recipes run against. It runs as a Docker container.
+While mass ingest is typically set up after the initial POV rather than during it, you may want to plan for it early. Mass ingest builds all of your repositories and creates the [LST artifacts](../../../user-documentation/recipes/authoring-recipes/concepts/lossless-semantic-trees.md) that recipes run against. It runs as a Docker container.
 
 | Resource | Minimum |
 |----------|---------|

--- a/docs/administrator-documentation/moderne-dx/how-to-guides/mass-ingest-dx.md
+++ b/docs/administrator-documentation/moderne-dx/how-to-guides/mass-ingest-dx.md
@@ -5,7 +5,7 @@ description: Instructions for ingesting a large number of repositories with Mode
 
 # Mass ingest
 
-One of the first steps of integrating your code with Moderne is setting up a pipeline that builds and publishes [LST](../../moderne-platform/references/lossless-semantic-trees.md) artifacts to an artifact repository that you control.
+One of the first steps of integrating your code with Moderne is setting up a pipeline that builds and publishes [LST](../../../user-documentation/recipes/authoring-recipes/concepts/lossless-semantic-trees.md) artifacts to an artifact repository that you control.
 
 To do this, we recommend that you set up a Docker image to pull the CLI, configure it, build the LSTs, and publish said artifacts. You would then run this image on a schedule (typically once per day) so that Moderne can have the latest LST artifacts available.
 

--- a/docs/administrator-documentation/moderne-platform-v1/getting-started/proof-of-value.md
+++ b/docs/administrator-documentation/moderne-platform-v1/getting-started/proof-of-value.md
@@ -1,3 +1,0 @@
-import { Redirect } from '@docusaurus/router';
-
-<Redirect to="/user-documentation/moderne-platform-v1/getting-started/proof-of-value" />;

--- a/docs/administrator-documentation/moderne-platform-v1/how-to-guides/creating-a-devcenter-recipe-beta.md
+++ b/docs/administrator-documentation/moderne-platform-v1/how-to-guides/creating-a-devcenter-recipe-beta.md
@@ -1,3 +1,0 @@
-import { Redirect } from '@docusaurus/router';
-
-<Redirect to="/administrator-documentation/moderne-platform-v1/how-to-guides/creating-a-devcenter-recipe" />

--- a/docs/administrator-documentation/moderne-platform-v1/how-to-guides/recipe-based-devcenter-beta.md
+++ b/docs/administrator-documentation/moderne-platform-v1/how-to-guides/recipe-based-devcenter-beta.md
@@ -1,3 +1,0 @@
-import { Redirect } from '@docusaurus/router';
-
-<Redirect to="/administrator-documentation/moderne-platform-v1/how-to-guides/recipe-based-devcenter" />

--- a/docs/administrator-documentation/moderne-platform-v1/references/how-ast-artifacts-are-produced.md
+++ b/docs/administrator-documentation/moderne-platform-v1/references/how-ast-artifacts-are-produced.md
@@ -1,3 +1,0 @@
-import { Redirect } from '@docusaurus/router';
-
-<Redirect to="/administrator-documentation/moderne-platform-v1/references/how-lst-artifacts-are-produced" />;

--- a/docs/administrator-documentation/moderne-platform/getting-started/proof-of-value.md
+++ b/docs/administrator-documentation/moderne-platform/getting-started/proof-of-value.md
@@ -1,3 +1,0 @@
-import { Redirect } from '@docusaurus/router';
-
-<Redirect to="/user-documentation/moderne-platform/getting-started/proof-of-value" />;

--- a/docs/administrator-documentation/moderne-platform/how-to-guides/agent-configuration/agent-config.md
+++ b/docs/administrator-documentation/moderne-platform/how-to-guides/agent-configuration/agent-config.md
@@ -1,3 +1,0 @@
-import { Redirect } from '@docusaurus/router';
-
-<Redirect to="/administrator-documentation/moderne-platform/how-to-guides/connector-configuration/connector-configuration" />;

--- a/docs/administrator-documentation/moderne-platform/how-to-guides/agent-configuration/agent-variables.md
+++ b/docs/administrator-documentation/moderne-platform/how-to-guides/agent-configuration/agent-variables.md
@@ -1,3 +1,0 @@
-import { Redirect } from '@docusaurus/router';
-
-<Redirect to="/administrator-documentation/moderne-platform/how-to-guides/connector-configuration/connector-variables" />;

--- a/docs/administrator-documentation/moderne-platform/how-to-guides/analyzing-build-failures.md
+++ b/docs/administrator-documentation/moderne-platform/how-to-guides/analyzing-build-failures.md
@@ -10,7 +10,7 @@ import VersionBanner from '@site/src/components/VersionBanner';
 
 # Analyzing build failures with mod trace
 
-When building [Lossless Semantic Trees (LSTs)](../references/lossless-semantic-trees.md) across many repositories, some builds will inevitably fail due to missing dependencies, compilation errors, or infrastructure issues. If you are managing a handful of repositories, you can probably dig through logs one at a time.
+When building [Lossless Semantic Trees (LSTs)](../../../user-documentation/recipes/authoring-recipes/concepts/lossless-semantic-trees.md) across many repositories, some builds will inevitably fail due to missing dependencies, compilation errors, or infrastructure issues. If you are managing a handful of repositories, you can probably dig through logs one at a time.
 
 But what if you are working with dozens or hundreds of repos? You will need a way to step back and see the bigger picture: Which failures are related? What are the most common root causes? Where should you focus your effort first?
 

--- a/docs/administrator-documentation/moderne-platform/how-to-guides/connector-configuration/connector-config.md
+++ b/docs/administrator-documentation/moderne-platform/how-to-guides/connector-configuration/connector-config.md
@@ -29,7 +29,7 @@ Looking for a complete, working example? Check out the [Moderne Connector exampl
 
 The Moderne Connector:
 
-* Encrypts and ships [LST](../../references/lossless-semantic-trees.md) and recipe artifacts from your artifact repository (e.g., Artifactory) to the Moderne SaaS
+* Encrypts and ships [LST](../../../../user-documentation/recipes/authoring-recipes/concepts/lossless-semantic-trees.md) and recipe artifacts from your artifact repository (e.g., Artifactory) to the Moderne SaaS
 * Provides the symmetric key that Moderne needs to decrypt your artifacts
 * Forwards requests from the Moderne SaaS to your SCM(s) (e.g., GitHub)
 * Forwards requests from the Moderne SaaS to the organization service (if configured)
@@ -343,7 +343,7 @@ Before Moderne can run recipes on your code, the Connector needs three things:
 
 1. The list of repositories you want Moderne to index.
 2. An [organizational hierarchy](./configure-organizations-hierarchy.md) that groups those repositories into organizations (at least one `org` column in the CSV). This doesn't need to be elaborate to start; a single `ALL` organization plus an organization for one team is a perfectly fine starting point that you can expand later.
-3. The [LST](../../references/lossless-semantic-trees.md) artifact location for each repository.
+3. The [LST](../../../../user-documentation/recipes/authoring-recipes/concepts/lossless-semantic-trees.md) artifact location for each repository.
 
 All of these things can come from a CSV file that you point the Connector to.
 

--- a/docs/administrator-documentation/moderne-platform/how-to-guides/mass-ingest.md
+++ b/docs/administrator-documentation/moderne-platform/how-to-guides/mass-ingest.md
@@ -10,7 +10,7 @@ import VersionBanner from '@site/src/components/VersionBanner';
 
 # Mass ingest
 
-One of the first steps of integrating your code with Moderne is setting up a pipeline that builds and publishes [LST](../references/lossless-semantic-trees.md) artifacts to an artifact repository that you control.
+One of the first steps of integrating your code with Moderne is setting up a pipeline that builds and publishes [LST](../../../user-documentation/recipes/authoring-recipes/concepts/lossless-semantic-trees.md) artifacts to an artifact repository that you control.
 
 To do this, we recommend that you set up a Docker image to pull the CLI, configure it, build the LSTs, and publish said artifacts. You would then run this image on a schedule (typically once per day) so that Moderne can have the latest LST artifacts available.
 

--- a/docs/administrator-documentation/moderne-platform/references/architecture.md
+++ b/docs/administrator-documentation/moderne-platform/references/architecture.md
@@ -37,7 +37,7 @@ Below is a high-level architecture diagram that shows the flow of data between M
 
 ### Mass ingest with mod CLI
 
-In order for Moderne to know the current state of your code, artifacts will need to be generated that contain a serialized representation of your code's [LSTs](./lossless-semantic-trees.md). These artifacts must be put inside an artifact repository that the [Moderne Connector](#moderne-connector) has access to.
+In order for Moderne to know the current state of your code, artifacts will need to be generated that contain a serialized representation of your code's [LSTs](../../../user-documentation/recipes/authoring-recipes/concepts/lossless-semantic-trees.md). These artifacts must be put inside an artifact repository that the [Moderne Connector](#moderne-connector) has access to.
 
 To do this, you'll want to set up mass ingestion with the Moderne CLI. For instructions on how to do that, please read our [mass ingestion guide](../how-to-guides/mass-ingest.md).
 
@@ -165,7 +165,7 @@ The indexer works with the [Connector](#moderne-connector) to scan your configur
 
 The recipe marketplace manages the catalog of available recipes, including discovery, search, and installation. Recipes can come from the public OpenRewrite marketplace, from custom recipe JARs your team publishes to your artifact repositories, or from inline YAML definitions.
 
-When you run a recipe, the recipe worker picks up the request, executes the recipe against the [LSTs](./lossless-semantic-trees.md) for the target repositories, and produces a changeset of results. Workers decrypt LST and recipe artifacts by requesting a customer-provided symmetric key via the [API gateway](#moderne-api-gateway) from the [Connector](#moderne-connector). Workers discard this key at the end of every request.
+When you run a recipe, the recipe worker picks up the request, executes the recipe against the [LSTs](../../../user-documentation/recipes/authoring-recipes/concepts/lossless-semantic-trees.md) for the target repositories, and produces a changeset of results. Workers decrypt LST and recipe artifacts by requesting a customer-provided symmetric key via the [API gateway](#moderne-api-gateway) from the [Connector](#moderne-connector). Workers discard this key at the end of every request.
 
 Workers also fetch a user's SCM OAuth token via the [API gateway](#moderne-api-gateway) in order to make authorization decisions about which repositories said user is allowed to read from. This ensures Moderne's read access is aligned with a user's SCM access in real-time for every recipe run request.
 
@@ -245,7 +245,7 @@ For more details, see the [DevCenter guide](../../../user-documentation/moderne-
 
 Moderne Trigrep provides code search across all repositories in your organization. You can search for code patterns, function calls, imports, and other structural elements across your entire codebase without needing to clone repositories locally.
 
-For more details, see the [Moderne Trigrep documentation](../../../user-documentation/recipes/moderne-trigrep.md).
+For more details, see the [Moderne Trigrep documentation](../../../user-documentation/agent-tools/trigrep.md).
 
 **Setup requirements**
 

--- a/docs/administrator-documentation/moderne-platform/references/how-ast-artifacts-are-produced.md
+++ b/docs/administrator-documentation/moderne-platform/references/how-ast-artifacts-are-produced.md
@@ -1,3 +1,0 @@
-import { Redirect } from '@docusaurus/router';
-
-<Redirect to="/administrator-documentation/moderne-platform/references/how-lst-artifacts-are-produced" />;

--- a/docs/administrator-documentation/moderne-platform/references/lossless-semantic-trees.md
+++ b/docs/administrator-documentation/moderne-platform/references/lossless-semantic-trees.md
@@ -1,8 +1,0 @@
----
-title: Lossless semantic trees
-slug: /administrator-documentation/moderne-platform/references/lossless-semantic-trees
----
-
-import { Redirect } from '@docusaurus/router';
-
-<Redirect to="/user-documentation/recipes/authoring-recipes/concepts/lossless-semantic-trees" />

--- a/docs/administrator-documentation/moderne-platform/references/mass-ingest-vs-ci.md
+++ b/docs/administrator-documentation/moderne-platform/references/mass-ingest-vs-ci.md
@@ -6,7 +6,7 @@ description: Why Moderne recommends producing LST artifacts through mass ingest 
 
 # Why use mass ingest instead of CI-integrated LST builds
 
-If your repositories already build in a CI system, it's natural to wonder why you shouldn't produce their [Lossless Semantic Tree (LST)](./lossless-semantic-trees.md) artifacts there too, instead of running a separate [mass ingest](../how-to-guides/mass-ingest.md) pipeline.
+If your repositories already build in a CI system, it's natural to wonder why you shouldn't produce their [Lossless Semantic Tree (LST)](../../../user-documentation/recipes/authoring-recipes/concepts/lossless-semantic-trees.md) artifacts there too, instead of running a separate [mass ingest](../how-to-guides/mass-ingest.md) pipeline.
 
 In short, mass ingest gives you a complete, current set of LSTs across every repository - whereas CI builds can't. This page explains why, and walks through the objections that come up most often.
 

--- a/docs/administrator-documentation/references/faq.md
+++ b/docs/administrator-documentation/references/faq.md
@@ -1,3 +1,0 @@
-import { Redirect } from '@docusaurus/router';
-
-<Redirect to="/user-documentation/recipes/faq" />

--- a/docs/administrator-documentation/references/licensing.md
+++ b/docs/administrator-documentation/references/licensing.md
@@ -1,9 +1,0 @@
----
-id: licensing
-title: Licensing
-slug: /administrator-documentation/references/licensing
----
-
-import { Redirect } from '@docusaurus/router';
-
-<Redirect to="/licensing/overview" />;

--- a/docs/administrator-documentation/references/repos-csv.md
+++ b/docs/administrator-documentation/references/repos-csv.md
@@ -1,3 +1,0 @@
-import { Redirect } from '@docusaurus/router';
-
-<Redirect to="/user-documentation/moderne-cli/references/repos-csv" />;

--- a/docs/hands-on-learning/agent-tools/module-1-cli-and-lsts.md
+++ b/docs/hands-on-learning/agent-tools/module-1-cli-and-lsts.md
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 
 # Module 1: CLI and LSTs
 
-In this module, you'll set up everything the agent tools depend on: the Moderne CLI, a couple of recipe JARs (including `io.moderne.recipe:rewrite-prethink`), and [Lossless Semantic Trees (LSTs)](../../administrator-documentation/moderne-platform/references/lossless-semantic-trees.md) for a small working set of Java and Spring repositories. The later modules build on top of this setup, so don't skip ahead until your LSTs build cleanly.
+In this module, you'll set up everything the agent tools depend on: the Moderne CLI, a couple of recipe JARs (including `io.moderne.recipe:rewrite-prethink`), and [Lossless Semantic Trees (LSTs)](../../user-documentation/recipes/authoring-recipes/concepts/lossless-semantic-trees.md) for a small working set of Java and Spring repositories. The later modules build on top of this setup, so don't skip ahead until your LSTs build cleanly.
 
 ## Exercise 1-1: Install and configure the Moderne CLI
 
@@ -153,7 +153,7 @@ The CLI walks through each matching recipe interactively and asks whether to set
 
 ### Key concepts
 
-A [Lossless Semantic Tree (LST)](../../administrator-documentation/moderne-platform/references/lossless-semantic-trees.md) is a type-attributed, format-preserving tree representation of your source code. Recipes, the MCP server's semantic tools, and the Trigrep search index all read from LSTs rather than raw text, which is what gives them type awareness.
+A [Lossless Semantic Tree (LST)](../../user-documentation/recipes/authoring-recipes/concepts/lossless-semantic-trees.md) is a type-attributed, format-preserving tree representation of your source code. Recipes, the MCP server's semantic tools, and the Trigrep search index all read from LSTs rather than raw text, which is what gives them type awareness.
 
 You can either **download** pre-built LSTs from the Moderne Platform or **build** them locally with `mod build`. Both options work for the rest of this workshop, but a local build is the more realistic flow for your own repositories. We'll show both paths.
 

--- a/docs/hands-on-learning/moderne-cli-workshop.md
+++ b/docs/hands-on-learning/moderne-cli-workshop.md
@@ -1,3 +1,0 @@
-import { Redirect } from '@docusaurus/router';
-
-<Redirect to="/user-documentation/moderne-cli/getting-started/moderne-cli-workshop" />;

--- a/docs/releases/cli-dx.md
+++ b/docs/releases/cli-dx.md
@@ -1,8 +1,0 @@
----
-title: CLI / DX changelog
-slug: /releases/cli-dx
----
-
-import { Redirect } from '@docusaurus/router';
-
-<Redirect to="/releases/cli-releases" />;

--- a/docs/user-documentation/agent-tools/code-search.md
+++ b/docs/user-documentation/agent-tools/code-search.md
@@ -1,8 +1,0 @@
----
-title: Code Search
-slug: /user-documentation/agent-tools/code-search
----
-
-import { Redirect } from '@docusaurus/router';
-
-<Redirect to="/user-documentation/agent-tools/trigrep" />

--- a/docs/user-documentation/agent-tools/mcp/overview.md
+++ b/docs/user-documentation/agent-tools/mcp/overview.md
@@ -5,7 +5,7 @@ description: Learn what the Moderne MCP server provides to AI coding agents and 
 
 # Moderne MCP server
 
-The Moderne CLI includes a local [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that gives AI coding agents tools for semantic code search, navigation, and refactoring. It runs on your own workstation as a subprocess of your coding agent, operating directly on the repositories you have checked out locally. While [skills](../skills.md) teach agents *how* to work with recipes, the MCP server gives agents direct access to these tools, backed by OpenRewrite's [Lossless Semantic Tree (LST)](../../../administrator-documentation/moderne-platform/references/lossless-semantic-trees.md) and [Moderne Trigrep](../trigrep.md).
+The Moderne CLI includes a local [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that gives AI coding agents tools for semantic code search, navigation, and refactoring. It runs on your own workstation as a subprocess of your coding agent, operating directly on the repositories you have checked out locally. While [skills](../skills.md) teach agents *how* to work with recipes, the MCP server gives agents direct access to these tools, backed by OpenRewrite's [Lossless Semantic Tree (LST)](../../recipes/authoring-recipes/concepts/lossless-semantic-trees.md) and [Moderne Trigrep](../trigrep.md).
 
 :::info
 This page describes the **local** MCP server (`mod mcp`), which runs on a developer workstation through the CLI. Moderne also offers a [remote MCP server](./remote-server.md) hosted on the Moderne Platform that runs recipes against the repositories already ingested into your tenant.
@@ -32,7 +32,7 @@ The MCP server **must be started from within a git repository**. If the working 
 When the MCP server starts, it builds two things in the background:
 
 1. **[Moderne Trigrep](../trigrep.md)**: a pre-computed trigram index that enables sub-second text search across the entire repository. This powers the `trigrep_search` and `trigrep_structural_search` tools.
-2. **[LSTs (Lossless Semantic Trees)](../../../administrator-documentation/moderne-platform/references/lossless-semantic-trees.md)**: a type-attributed tree representation of your source code that enables semantic tools like `find_types`, `find_methods`, `change_type`, and recipe execution.
+2. **[LSTs (Lossless Semantic Trees)](../../recipes/authoring-recipes/concepts/lossless-semantic-trees.md)**: a type-attributed tree representation of your source code that enables semantic tools like `find_types`, `find_methods`, `change_type`, and recipe execution.
 
 Tools become available progressively as each build completes. You can check their progress with the `build_status` and `lst_status` tools.
 

--- a/docs/user-documentation/code-remix-sessions/2024.md
+++ b/docs/user-documentation/code-remix-sessions/2024.md
@@ -766,7 +766,7 @@ import ReactPlayer from '@site/src/components/VideoPlayer';
   * **Content**:
     * [We released a new video about recruiting and retaining top tech talent](https://www.youtube.com/watch?v=D_2HT2n_3PM).
     * [Tim's session from Spring I/O is also available to watch](https://www.youtube.com/watch?v=KlQZH6WHa2c)
-    * [The workshop that Tim gave on creating recipes is also available in our docs](../../user-documentation/workshops/recipe-authoring.md).
+    * [The workshop that Tim gave on creating recipes is also available in our docs](../../hands-on-learning/fundamentals/workshop-overview.md).
 * [We then began our main discussion for the week – recipe authoring best practices](https://youtu.be/6_w6gx7GPII?t=492)
   * [We've created a detailed doc about recipe conventions and best practices that covers a lot of the points being discussed in this session](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices).
   * Sam began by talking about a common mistake people make when first creating recipes – [not making them idempotent and immutable](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices#recipes-must-be-idempotent-and-immutable). What this means is that if a recipe is given the same LST and configuration, it should _always_ produce the same result. To go along with that, a recipe's behaviour _should not_ be influenced by LSTs which have been visited previously.
@@ -829,7 +829,7 @@ import ReactPlayer from '@site/src/components/VideoPlayer';
 
 * [Announcements for the week](https://youtu.be/egf5Q3fb6W0?t=30)
   * **Events**:
-    * Tim will be at [Spring I/O in Barcelona from May 30th - 31st](https://2024.springio.net/sessions/automated-software-refactoring-with-openrewrite-and-generative-ai/). He'll be giving a talk and an interactive workshop there. If you want to check out the workshop for yourself ahead of time, you can find it [in our docs right now](../../user-documentation/workshops/recipe-authoring.md).
+    * Tim will be at [Spring I/O in Barcelona from May 30th - 31st](https://2024.springio.net/sessions/automated-software-refactoring-with-openrewrite-and-generative-ai/). He'll be giving a talk and an interactive workshop there. If you want to check out the workshop for yourself ahead of time, you can find it [in our docs right now](../../hands-on-learning/fundamentals/workshop-overview.md).
     * Tim also will be at [JNation.pt on June 5th to give a workshop on recipe authorship](https://jnation.pt/workshops/)
     * Sam will be hosting a No-fluff-just-stuff webinar on the fundamental of migration engineering on Friday, May 31st.
   * **Content**:
@@ -874,7 +874,7 @@ import ReactPlayer from '@site/src/components/VideoPlayer';
   * **Cool milestone**:
     * There are now over 2,500 recipes available in the Moderne Platform! 🎉
   * **Events**:
-    * Tim will be at [Spring I/O in Barcelona from May 30th - 31st](https://2024.springio.net/sessions/automated-software-refactoring-with-openrewrite-and-generative-ai/). He'll be giving a talk and an interactive workshop there. If you want to check out the workshop for yourself ahead of time, you can find it [in our docs right now](../../user-documentation/workshops/recipe-authoring.md).
+    * Tim will be at [Spring I/O in Barcelona from May 30th - 31st](https://2024.springio.net/sessions/automated-software-refactoring-with-openrewrite-and-generative-ai/). He'll be giving a talk and an interactive workshop there. If you want to check out the workshop for yourself ahead of time, you can find it [in our docs right now](../../hands-on-learning/fundamentals/workshop-overview.md).
   * **Content**:
     * We recently released a video about [how to fix security vulnerabilities across your entire codebase quickly with Moderne](https://www.youtube.com/watch?v=g97-2br6pug)
   * **Releases**:
@@ -905,7 +905,7 @@ import ReactPlayer from '@site/src/components/VideoPlayer';
     * We've released the [latest Moderne monthly newsletter](https://www.linkedin.com/pulse/its-mai-moderne-moderneinc-hqxhc/). It's a high-level summary of key events, talks, presentations, etc. Consider subscribing if you haven't already.
 * [OpenRewrite parsers](https://youtu.be/svNf6qHUYXA?t=180):
   * There are two types of parsers in OpenRewrite: parsers we build around an existing language compiler and there are parsers that we build around an [ANTLR grammar](https://www.antlr.org/).
-  * We began by discussing the [Java parser](https://youtu.be/svNf6qHUYXA?t=242) (which is based on an existing language compiler) and how we interact with the Java compiler to map objects to our [Lossless Semantic Tree](../../administrator-documentation/moderne-platform/references/lossless-semantic-trees.md).
+  * We began by discussing the [Java parser](https://youtu.be/svNf6qHUYXA?t=242) (which is based on an existing language compiler) and how we interact with the Java compiler to map objects to our [Lossless Semantic Tree](../recipes/authoring-recipes/concepts/lossless-semantic-trees.md).
   * We then stepped through the [ReloadableJava17Parser](https://github.com/openrewrite/rewrite/blob/main/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17Parser.java) and explained some key parts of the parser.
   * While stepping through the parser, we also jumped into the [ReloadableJava17ParserVisitor](https://github.com/openrewrite/rewrite/blob/main/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java) and talked through why it's a bit different from the traditional visitor you may be used to.
   * A lot of what goes on in the parser is taking the Java compiler's [abstract syntax tree (AST)](https://en.wikipedia.org/wiki/Abstract_syntax_tree) and the raw textual representation of the source file, and traversing through both in tandem to match up white space from the raw source file to the structured objects the Java compiler gives us. That then lets us produce the LST that has both of those pieces married together.

--- a/docs/user-documentation/community-office-hours.md
+++ b/docs/user-documentation/community-office-hours.md
@@ -1,9 +1,0 @@
----
-id: community-office-hours
-title: Code Remix sessions
-slug: /user-documentation/community-office-hours
----
-
-import { Redirect } from '@docusaurus/router';
-
-<Redirect to="/user-documentation/code-remix-sessions/2026" />;

--- a/docs/user-documentation/moderne-cli/faq.md
+++ b/docs/user-documentation/moderne-cli/faq.md
@@ -1,3 +1,0 @@
-import { Redirect } from '@docusaurus/router';
-
-<Redirect to="/user-documentation/moderne-cli/references/faq" />

--- a/docs/user-documentation/moderne-cli/getting-started/cli-dev-center.md
+++ b/docs/user-documentation/moderne-cli/getting-started/cli-dev-center.md
@@ -1,3 +1,0 @@
-import { Redirect } from '@docusaurus/router';
-
-<Redirect to="/user-documentation/moderne-cli/how-to-guides/cli-dev-center" />;

--- a/docs/user-documentation/moderne-cli/getting-started/cli-intro.md
+++ b/docs/user-documentation/moderne-cli/getting-started/cli-intro.md
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 
 # Getting started with the Moderne CLI
 
-The Moderne CLI is a command line tool that complements the Moderne Platform and Moderne DX, enabling you to build [Lossless Semantic Tree](../../../administrator-documentation/moderne-platform/references/lossless-semantic-trees.md) (LST) artifacts across many repositories and run recipes against all of them from your local machine. It also provides substantial benefits for creating and testing your own recipes.
+The Moderne CLI is a command line tool that complements the Moderne Platform and Moderne DX, enabling you to build [Lossless Semantic Tree](../../recipes/authoring-recipes/concepts/lossless-semantic-trees.md) (LST) artifacts across many repositories and run recipes against all of them from your local machine. It also provides substantial benefits for creating and testing your own recipes.
 
 To ensure you can use the Moderne CLI successfully, in this guide, we will walk you through everything you need to get started – from installation, to configuration, to examples demonstrating how to use it.
 

--- a/docs/user-documentation/moderne-cli/getting-started/dx-cli-install.md
+++ b/docs/user-documentation/moderne-cli/getting-started/dx-cli-install.md
@@ -1,3 +1,0 @@
-import { Redirect } from '@docusaurus/router';
-
-<Redirect to="/user-documentation/moderne-cli/getting-started/cli-internal-mirror" />;

--- a/docs/user-documentation/moderne-cli/getting-started/moderne-cli-workshop.md
+++ b/docs/user-documentation/moderne-cli/getting-started/moderne-cli-workshop.md
@@ -149,7 +149,7 @@ apache          awslabs         finos           Netflix         openrewrite     
 
 ## Part 3: Building LSTs
 
-If the [Lossless Semantic Trees](../../../administrator-documentation/moderne-platform/references/lossless-semantic-trees.md) (LSTs) were available to download from Moderne, then they will have been downloaded with the `mod git sync moderne` command. If the LST(s) were unavailable for some reason, you can generate them locally by running the `mod build .` command.
+If the [Lossless Semantic Trees](../../recipes/authoring-recipes/concepts/lossless-semantic-trees.md) (LSTs) were available to download from Moderne, then they will have been downloaded with the `mod git sync moderne` command. If the LST(s) were unavailable for some reason, you can generate them locally by running the `mod build .` command.
 
 :::info
 By default, the CLI is able to build LSTs for well-formed projects (i.e. projects that build well with a plain `mvn verify` or `gradle build`). At times, however, you may encounter a project that fails to build. This could be because of a hidden dependency on certain tooling, like NPM, or because specific dependencies or repositories are not available without additional configuration.

--- a/docs/user-documentation/moderne-cli/how-to-guides/air-gapped-cli-install.md
+++ b/docs/user-documentation/moderne-cli/how-to-guides/air-gapped-cli-install.md
@@ -1,3 +1,0 @@
-import { Redirect } from '@docusaurus/router';
-
-<Redirect to="/user-documentation/moderne-cli/getting-started/cli-internal-mirror" />;

--- a/docs/user-documentation/moderne-cli/how-to-guides/build-tool-config.md
+++ b/docs/user-documentation/moderne-cli/how-to-guides/build-tool-config.md
@@ -1,8 +1,0 @@
----
-title: Build tool configuration
-slug: /user-documentation/moderne-cli/how-to-guides/build-tool-config
----
-
-import { Redirect } from '@docusaurus/router';
-
-<Redirect to="/user-documentation/moderne-cli/how-to-guides/java" />

--- a/docs/user-documentation/moderne-cli/how-to-guides/coding-agent-skills.md
+++ b/docs/user-documentation/moderne-cli/how-to-guides/coding-agent-skills.md
@@ -1,9 +1,0 @@
----
-id: coding-agent-skills
-title: Skills for AI coding agents
-slug: /user-documentation/moderne-cli/how-to-guides/coding-agent-skills
----
-
-import { Redirect } from '@docusaurus/router';
-
-<Redirect to="/user-documentation/agent-tools/skills" />

--- a/docs/user-documentation/moderne-cli/how-to-guides/curate-recipe-marketplace.md
+++ b/docs/user-documentation/moderne-cli/how-to-guides/curate-recipe-marketplace.md
@@ -17,7 +17,7 @@ Curating your recipe marketplace is most useful when you want to guide developer
 * You want `mod config recipes search` to surface only the recipes your organization endorses.
 * You want to highlight specific internal recipes over more general ones.
 
-If your developers are recipe authors or power users who benefit from seeing the full catalog, the default behavior of `mod config recipes search` is the right fit, and no curation is needed. Curating your marketplace is also not the right tool if you need to add your own recipe code or apply custom category hierarchies to existing recipes. See [managing recipe categories](../../moderne-platform/how-to-guides/categorize-recipes.md) for those patterns.
+If your developers are recipe authors or power users who benefit from seeing the full catalog, the default behavior of `mod config recipes search` is the right fit, and no curation is needed. Curating your marketplace is also not the right tool if you need to add your own recipe code or apply custom category hierarchies to existing recipes. See [managing recipe categories](../../../administrator-documentation/moderne-platform/how-to-guides/categorize-recipes.md) for those patterns.
 
 ## Workflow overview
 
@@ -224,10 +224,10 @@ Without `mod config recipes delete`, `import` has no way to know that a recipe w
 ## Tips and caveats
 
 * **Keep `options` and `dataTables` intact.** When copying rows from an existing CSV, leave these columns unchanged. They are generated mechanically by the OpenRewrite build plugins, and hand-editing them reliably breaks recipes.
-* **Platform Marketplace distribution is a separate pattern.** If you publish recipes through the Moderne Platform Marketplace instead of CSV distribution via the CLI, see [managing recipe categories](../../moderne-platform/how-to-guides/categorize-recipes.md) for the wrapper JAR publishing workflow.
+* **Platform Marketplace distribution is a separate pattern.** If you publish recipes through the Moderne Platform Marketplace instead of CSV distribution via the CLI, see [managing recipe categories](../../../administrator-documentation/moderne-platform/how-to-guides/categorize-recipes.md) for the wrapper JAR publishing workflow.
 
 ## Next steps
 
 * [`recipes.csv` reference](../references/recipes-csv.md): full CSV format, column semantics, and validation rules.
-* [Managing recipe categories](../../moderne-platform/how-to-guides/categorize-recipes.md): for re-organizing recipes under custom category hierarchies.
+* [Managing recipe categories](../../../administrator-documentation/moderne-platform/how-to-guides/categorize-recipes.md): for re-organizing recipes under custom category hierarchies.
 * [CLI reference](../cli-reference.md#mod-config-recipes): full command documentation for `mod config recipes`.

--- a/docs/user-documentation/moderne-cli/how-to-guides/custom-parser-mappings.md
+++ b/docs/user-documentation/moderne-cli/how-to-guides/custom-parser-mappings.md
@@ -7,7 +7,7 @@ description: How to configure custom parser mappings so non-standard file types 
 
 Some codebases use non-standard file extensions — or no extensions at all — for files that are actually XML, JSON, YAML, or other structured formats. For example, a project might use `.mst` files for XML-based templates, `.cfg` files for JSON configuration, or extensionless files like `config` for structured data. By default, the Moderne CLI parses these as plain text, which means recipes cannot inspect or transform their structure.
 
-The `build.parsers` configuration lets you tell the CLI which parser to use for files matching specific glob patterns. Once configured, these files will be parsed into the appropriate [Lossless Semantic Tree (LST)](../../../administrator-documentation/moderne-platform/references/lossless-semantic-trees.md) type, enabling recipes to work with their full structure.
+The `build.parsers` configuration lets you tell the CLI which parser to use for files matching specific glob patterns. Once configured, these files will be parsed into the appropriate [Lossless Semantic Tree (LST)](../../recipes/authoring-recipes/concepts/lossless-semantic-trees.md) type, enabling recipes to work with their full structure.
 
 In this guide, you will learn how to add, view, and remove custom parser mappings using the CLI or `moderne.yml` configuration.
 

--- a/docs/user-documentation/moderne-cli/how-to-guides/jdk-selection-and-config.md
+++ b/docs/user-documentation/moderne-cli/how-to-guides/jdk-selection-and-config.md
@@ -1,8 +1,0 @@
----
-title: JDK configuration
-slug: /user-documentation/moderne-cli/how-to-guides/jdk-selection-and-config
----
-
-import { Redirect } from '@docusaurus/router';
-
-<Redirect to="/user-documentation/moderne-cli/how-to-guides/java" />

--- a/docs/user-documentation/moderne-cli/how-to-guides/layer-config-cli.md
+++ b/docs/user-documentation/moderne-cli/how-to-guides/layer-config-cli.md
@@ -5,7 +5,7 @@ description: How to set global or project-specific build arguments in the Modern
 
 # Layered configuration in the Moderne CLI
 
-One big challenge that comes with building [LSTs](../../../administrator-documentation/moderne-platform/references/lossless-semantic-trees.md) for many repositories on many machines is configuration. What arguments do you need to build each repository? Are there Maven specific ones? Gradle specific ones? Do they change depending on the group of projects? How do you share these configurations with new people on the team?
+One big challenge that comes with building [LSTs](../../recipes/authoring-recipes/concepts/lossless-semantic-trees.md) for many repositories on many machines is configuration. What arguments do you need to build each repository? Are there Maven specific ones? Gradle specific ones? Do they change depending on the group of projects? How do you share these configurations with new people on the team?
 
 To meet all of these needs, the Moderne CLI offers a few options for how you can include global or project-specific build arguments. In this guide, we'll walk through each of them and explain when you should use one over another.
 

--- a/docs/user-documentation/moderne-platform-v1/how-to-guides/writing-and-installing-recipes.md
+++ b/docs/user-documentation/moderne-platform-v1/how-to-guides/writing-and-installing-recipes.md
@@ -25,7 +25,7 @@ If your new recipe idea can be composed of many other recipes or if it can be cr
 
 If your recipe is more complex than that, please check out the [OpenRewrite recipe authoring documentation](https://docs.openrewrite.org/authoring-recipes/recipe-development-environment). Make sure to read over the documentation on the [different types of recipes](https://docs.openrewrite.org/authoring-recipes/types-of-recipes) so that you can create a recipe that best meets your needs.
 
-You may also find it beneficial to work through our [recipe authoring workshop](../../workshops/recipe-authoring.md) that will take you through the process of writing and running many different types of recipes.
+You may also find it beneficial to work through our [recipe authoring workshop](../../../hands-on-learning/fundamentals/workshop-overview.md) that will take you through the process of writing and running many different types of recipes.
 
 :::tip
 As a Moderne customer, you have access to the [Moderne recipe bom](https://central.sonatype.com/artifact/io.moderne.recipe/moderne-recipe-bom/versions) which can help you align versions of all Moderne recipe modules.

--- a/docs/user-documentation/moderne-platform/getting-started/code-quality.md
+++ b/docs/user-documentation/moderne-platform/getting-started/code-quality.md
@@ -14,7 +14,7 @@ Every programming language has a vast number of conventions and rules that make 
 
 Over the years, a variety of static analysis tools have been created to try and help, but these tools do not actually _fix_ your code. Rather, they rely on developers to manually change every line that they warn about. If a new convention is standardized, this can easily result in thousands of lines that need to be changed across a vast number of repositories.
 
-Fortunately, Moderne can help with this tricky problem. Thanks to a [comprehensive Lossless Semantic Tree](../../../administrator-documentation/moderne-platform/references/lossless-semantic-trees.md), Moderne can find _and_ fix static analysis and stylistic issues. Furthermore, for each change made, you can learn _why_ it was changed so that you and your team can write better code in the future. Instead of having to constantly remind your team to clean up the code, you can automate it!
+Fortunately, Moderne can help with this tricky problem. Thanks to a [comprehensive Lossless Semantic Tree](../../recipes/authoring-recipes/concepts/lossless-semantic-trees.md), Moderne can find _and_ fix static analysis and stylistic issues. Furthermore, for each change made, you can learn _why_ it was changed so that you and your team can write better code in the future. Instead of having to constantly remind your team to clean up the code, you can automate it!
 
 To help you get a better understanding of how Moderne can help improve your code quality, this guide will:
 

--- a/docs/user-documentation/moderne-platform/getting-started/proof-of-value-prerequisites.md
+++ b/docs/user-documentation/moderne-platform/getting-started/proof-of-value-prerequisites.md
@@ -36,7 +36,7 @@ You will need two separate environments provisioned and ready:
 
 ### Mass ingest
 
-The mass ingest environment builds all of your repositories and creates the [LST artifacts](../../../administrator-documentation/moderne-platform/references/lossless-semantic-trees.md) that recipes run against. It runs as a Docker container. When using a self-hosted SCM, it operates entirely within your network. When using a cloud SCM (github.com, gitlab.com, etc.), it requires outbound HTTPS to that service.
+The mass ingest environment builds all of your repositories and creates the [LST artifacts](../../recipes/authoring-recipes/concepts/lossless-semantic-trees.md) that recipes run against. It runs as a Docker container. When using a self-hosted SCM, it operates entirely within your network. When using a cloud SCM (github.com, gitlab.com, etc.), it requires outbound HTTPS to that service.
 
 | Resource | Minimum |
 |----------|---------|

--- a/docs/user-documentation/moderne-platform/how-to-guides/categorize-recipes.md
+++ b/docs/user-documentation/moderne-platform/how-to-guides/categorize-recipes.md
@@ -1,9 +1,0 @@
----
-id: categorize-recipes
-title: Managing recipe categories
-slug: /user-documentation/moderne-platform/how-to-guides/categorize-recipes
----
-
-import { Redirect } from '@docusaurus/router';
-
-<Redirect to="/administrator-documentation/moderne-platform/how-to-guides/categorize-recipes" />;

--- a/docs/user-documentation/moderne-platform/how-to-guides/writing-and-installing-recipes.md
+++ b/docs/user-documentation/moderne-platform/how-to-guides/writing-and-installing-recipes.md
@@ -24,7 +24,7 @@ If your new recipe idea can be composed of many other recipes or if it can be cr
 
 If your recipe is more complex than that, please check out the [OpenRewrite recipe authoring documentation](https://docs.openrewrite.org/authoring-recipes/recipe-development-environment). Make sure to read over the documentation on the [different types of recipes](https://docs.openrewrite.org/authoring-recipes/types-of-recipes) so that you can create a recipe that best meets your needs.
 
-You may also find it beneficial to work through our [recipe authoring workshop](../../workshops/recipe-authoring.md) that will take you through the process of writing and running many different types of recipes.
+You may also find it beneficial to work through our [recipe authoring workshop](../../../hands-on-learning/fundamentals/workshop-overview.md) that will take you through the process of writing and running many different types of recipes.
 
 :::tip
 As a Moderne customer, you have access to the [Moderne recipe bom](https://central.sonatype.com/artifact/io.moderne.recipe/moderne-recipe-bom/versions) which can help you align versions of all Moderne recipe modules.

--- a/docs/user-documentation/recipes/coordinating-parent-pom-migrations.md
+++ b/docs/user-documentation/recipes/coordinating-parent-pom-migrations.md
@@ -1,8 +1,0 @@
----
-title: Coordinating migrations with parent POMs
-slug: /user-documentation/recipes/coordinating-parent-pom-migrations
----
-
-import { Redirect } from '@docusaurus/router';
-
-<Redirect to="/user-documentation/recipes/popular-recipe-guides/coordinating-parent-pom-migrations" />

--- a/docs/user-documentation/recipes/managing-gradle-lock-files.md
+++ b/docs/user-documentation/recipes/managing-gradle-lock-files.md
@@ -1,8 +1,0 @@
----
-title: Managing Gradle lock files
-slug: /user-documentation/recipes/managing-gradle-lock-files
----
-
-import { Redirect } from '@docusaurus/router';
-
-<Redirect to="/user-documentation/moderne-cli/how-to-guides/managing-gradle-lock-files" />

--- a/docs/user-documentation/recipes/moderne-trigrep.md
+++ b/docs/user-documentation/recipes/moderne-trigrep.md
@@ -1,9 +1,0 @@
----
-id: moderne-trigrep
-title: Moderne Trigrep
-slug: /user-documentation/recipes/moderne-trigrep
----
-
-import { Redirect } from '@docusaurus/router';
-
-<Redirect to="/user-documentation/agent-tools/trigrep" />

--- a/docs/user-documentation/recipes/popular-recipe-guides/migrate-to-jakarta-ee-10.md
+++ b/docs/user-documentation/recipes/popular-recipe-guides/migrate-to-jakarta-ee-10.md
@@ -23,7 +23,7 @@ In this guide, we will show you how to run this recipe on the Moderne Platform o
 Before running this recipe, make sure:
 
 * Your codebase currently uses the `javax.*` enterprise APIs (Java EE or Jakarta EE 8) or an earlier Jakarta EE 9 release. `JakartaEE10` includes the [Jakarta EE 9 namespace migration](../recipe-catalog/java/migrate/jakarta/javaxmigrationtojakarta.md) transitively, so the `javax` to `jakarta` rename and the EE 10 updates are applied in a single run – you do not need to migrate to Jakarta EE 9 first.
-* Your build environment uses **Java 11 or later**. Jakarta EE 10 sets its baseline at Java SE 11 and also supports Java SE 17. If you are still on Java 8, run [Migrate to Java 17](./migrate-to-java-17.md) first and verify everything still builds.
+* Your build environment uses **Java 11 or later**. Jakarta EE 10 sets its baseline at Java SE 11 and also supports Java SE 17. If you are still on Java 8, run [Migrate to Java 17](./migrate-to-java.md) first and verify everything still builds.
 
 ## What this recipe does
 
@@ -104,5 +104,5 @@ Running the recipe never modifies your source repositories directly. Instead, th
 
 ## Additional reading
 
-* [Migrate to Spring Boot 3](./migrate-to-spring-boot-3.md) – Spring Boot 3 builds on this same `javax.*` to `jakarta.*` move, so start there if you are upgrading Spring applications.
+* [Migrate to Spring Boot 3](./migrate-to-spring-boot.md#coming-from-spring-boot-2x) – Spring Boot 3 builds on this same `javax.*` to `jakarta.*` move, so start there if you are upgrading Spring applications.
 * [Tracking migrations](../../moderne-platform/how-to-guides/track-migrations.md) – use data tables and visualizations to track the rollout of a Jakarta EE 10 upgrade across many repositories.

--- a/docs/user-documentation/recipes/popular-recipe-guides/migrate-to-java-17.md
+++ b/docs/user-documentation/recipes/popular-recipe-guides/migrate-to-java-17.md
@@ -1,9 +1,0 @@
----
-id: migrate-to-java-17
-title: Migrate to Java 17
-slug: /user-documentation/recipes/popular-recipe-guides/migrate-to-java-17
----
-
-import { Redirect } from '@docusaurus/router';
-
-<Redirect to="/user-documentation/recipes/popular-recipe-guides/migrate-to-java" />

--- a/docs/user-documentation/recipes/popular-recipe-guides/migrate-to-java-21.md
+++ b/docs/user-documentation/recipes/popular-recipe-guides/migrate-to-java-21.md
@@ -1,9 +1,0 @@
----
-id: migrate-to-java-21
-title: Migrate to Java 21
-slug: /user-documentation/recipes/popular-recipe-guides/migrate-to-java-21
----
-
-import { Redirect } from '@docusaurus/router';
-
-<Redirect to="/user-documentation/recipes/popular-recipe-guides/migrate-to-java" />

--- a/docs/user-documentation/recipes/popular-recipe-guides/migrate-to-java-25.md
+++ b/docs/user-documentation/recipes/popular-recipe-guides/migrate-to-java-25.md
@@ -1,9 +1,0 @@
----
-id: migrate-to-java-25
-title: Migrate to Java 25
-slug: /user-documentation/recipes/popular-recipe-guides/migrate-to-java-25
----
-
-import { Redirect } from '@docusaurus/router';
-
-<Redirect to="/user-documentation/recipes/popular-recipe-guides/migrate-to-java" />

--- a/docs/user-documentation/recipes/popular-recipe-guides/migrate-to-spring-boot-3.md
+++ b/docs/user-documentation/recipes/popular-recipe-guides/migrate-to-spring-boot-3.md
@@ -1,9 +1,0 @@
----
-id: migrate-to-spring-boot-3
-title: Migrate to Spring Boot 3
-slug: /user-documentation/recipes/popular-recipe-guides/migrate-to-spring-boot-3
----
-
-import { Redirect } from '@docusaurus/router';
-
-<Redirect to="/user-documentation/recipes/popular-recipe-guides/migrate-to-spring-boot#coming-from-spring-boot-2x" />

--- a/docs/user-documentation/recipes/popular-recipe-guides/migrate-to-spring-boot-4.md
+++ b/docs/user-documentation/recipes/popular-recipe-guides/migrate-to-spring-boot-4.md
@@ -1,9 +1,0 @@
----
-id: migrate-to-spring-boot-4
-title: Migrate to Spring Boot 4
-slug: /user-documentation/recipes/popular-recipe-guides/migrate-to-spring-boot-4
----
-
-import { Redirect } from '@docusaurus/router';
-
-<Redirect to="/user-documentation/recipes/popular-recipe-guides/migrate-to-spring-boot" />

--- a/docs/user-documentation/recipes/prethink.md
+++ b/docs/user-documentation/recipes/prethink.md
@@ -1,9 +1,0 @@
----
-id: prethink
-title: Moderne Prethink
-slug: /user-documentation/recipes/prethink
----
-
-import { Redirect } from '@docusaurus/router';
-
-<Redirect to="/user-documentation/agent-tools/prethink" />

--- a/docs/user-documentation/recipes/recipe-authoring/writing-python-recipes.md
+++ b/docs/user-documentation/recipes/recipe-authoring/writing-python-recipes.md
@@ -1,8 +1,0 @@
----
-title: Writing Python recipes
-slug: /user-documentation/recipes/recipe-authoring/writing-python-recipes
----
-
-import { Redirect } from '@docusaurus/router';
-
-<Redirect to="/user-documentation/recipes/authoring-recipes/writing-recipes/writing-python-recipes" />

--- a/docs/user-documentation/workshops/recipe-authoring.md
+++ b/docs/user-documentation/workshops/recipe-authoring.md
@@ -1,3 +1,0 @@
-import { Redirect } from '@docusaurus/router';
-
-<Redirect to="/hands-on-learning/fundamentals/" />;

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -4,6 +4,7 @@ import { themes as prismThemes } from 'prism-react-renderer';
 import { readdirSync } from 'node:fs';
 import latestVersions from "./src/plugins/latest-versions";
 import remarkTokenReplacer from "./src/plugins/replace-tokens";
+import redirects from "./redirects";
 
 // Fast iteration on the redesigned recipe pages: when EXAMPLE_RECIPES_ONLY is set, exclude the entire
 // recipe-catalog EXCEPT the handful of example pages we're actively developing, so a build/start only
@@ -209,6 +210,12 @@ const config: Config = {
           },
         ],
       },
+    ],
+    // Client-side redirects for docs that have moved. The list lives in
+    // ./redirects.ts — add an entry there when you move or rename a doc.
+    [
+      '@docusaurus/plugin-client-redirects',
+      { redirects },
     ],
   ],
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@algolia/autocomplete-core": "^1.19.7",
     "@docusaurus/core": "^3.10.1",
     "@docusaurus/faster": "^3.10.1",
+    "@docusaurus/plugin-client-redirects": "^3.10.1",
     "@docusaurus/preset-classic": "^3.10.1",
     "@docusaurus/theme-mermaid": "^3.10.1",
     "@mdx-js/react": "^3.0.0",

--- a/redirects.ts
+++ b/redirects.ts
@@ -1,0 +1,88 @@
+// Client-side redirects for docs that have moved.
+//
+// Each entry maps one or more old URLs (`from`) to their current location (`to`).
+// At build time, @docusaurus/plugin-client-redirects emits a small meta-refresh
+// HTML file at each old path, so bookmarks and external links keep working.
+//
+// When you move or rename a doc, add its OLD path here pointing at the new one.
+// Group several old paths under a single destination with a `from` array.
+//
+// Notes:
+//   * Paths are site-root-relative (this site serves docs at "/").
+//   * `to` must resolve to a real page; the build fails on a dangling target.
+//
+// Testing redirects locally:
+//   This plugin only emits redirect files during a production build. `yarn start`
+//   (the dev server) ignores it, so redirects never work there. To test them,
+//   build the site and serve the output:
+//
+//     EXAMPLE_RECIPES_ONLY=1 yarn build   # build + generate the redirect files
+//     npm run serve                       # serve build/ at http://localhost:3000
+//
+//   Then open an old path (e.g. http://localhost:3000/releases/cli-dx) and confirm
+//   it lands on the new page. EXAMPLE_RECIPES_ONLY skips the ~5,700 recipe-catalog
+//   pages for a much faster build; every redirect is still generated.
+
+type RedirectRule = { from: string | string[]; to: string };
+
+const redirects: RedirectRule[] = [
+  // Several old paths that now share a single destination.
+  {
+    from: [
+      '/administrator-documentation/licensing',
+      '/administrator-documentation/references/licensing',
+    ],
+    to: '/licensing/overview',
+  },
+  {
+    from: [
+      '/user-documentation/moderne-cli/how-to-guides/air-gapped-cli-install',
+      '/user-documentation/moderne-cli/getting-started/dx-cli-install',
+    ],
+    to: '/user-documentation/moderne-cli/getting-started/cli-internal-mirror',
+  },
+  {
+    from: [
+      '/user-documentation/moderne-cli/how-to-guides/jdk-selection-and-config',
+      '/user-documentation/moderne-cli/how-to-guides/build-tool-config',
+    ],
+    to: '/user-documentation/moderne-cli/how-to-guides/java',
+  },
+  {
+    from: [
+      '/user-documentation/recipes/popular-recipe-guides/migrate-to-java-17',
+      '/user-documentation/recipes/popular-recipe-guides/migrate-to-java-21',
+      '/user-documentation/recipes/popular-recipe-guides/migrate-to-java-25',
+    ],
+    to: '/user-documentation/recipes/popular-recipe-guides/migrate-to-java',
+  },
+  // One-to-one moves.
+  { from: '/administrator-documentation/references/repos-csv', to: '/user-documentation/moderne-cli/references/repos-csv' },
+  { from: '/user-documentation/community-office-hours', to: '/user-documentation/code-remix-sessions/2026' },
+  { from: '/hands-on-learning/moderne-cli-workshop', to: '/user-documentation/moderne-cli/getting-started/moderne-cli-workshop' },
+  { from: '/user-documentation/moderne-cli/how-to-guides/coding-agent-skills', to: '/user-documentation/agent-tools/skills' },
+  { from: '/administrator-documentation/moderne-platform-v1/how-to-guides/recipe-based-devcenter-beta', to: '/administrator-documentation/moderne-platform-v1/how-to-guides/recipe-based-devcenter' },
+  { from: '/administrator-documentation/moderne-platform-v1/how-to-guides/creating-a-devcenter-recipe-beta', to: '/administrator-documentation/moderne-platform-v1/how-to-guides/creating-a-devcenter-recipe' },
+  { from: '/user-documentation/moderne-cli/getting-started/cli-dev-center', to: '/user-documentation/moderne-cli/how-to-guides/cli-dev-center' },
+  { from: '/user-documentation/moderne-cli/faq', to: '/user-documentation/moderne-cli/references/faq' },
+  { from: '/releases/cli-dx', to: '/releases/cli-releases' },
+  { from: '/user-documentation/agent-tools/code-search', to: '/user-documentation/agent-tools/trigrep' },
+  { from: '/user-documentation/recipes/prethink', to: '/user-documentation/agent-tools/prethink' },
+  { from: '/administrator-documentation/moderne-platform/how-to-guides/agent-configuration/agent-config', to: '/administrator-documentation/moderne-platform/how-to-guides/connector-configuration/connector-configuration' },
+  { from: '/administrator-documentation/moderne-platform/how-to-guides/agent-configuration/agent-variables', to: '/administrator-documentation/moderne-platform/how-to-guides/connector-configuration/connector-variables' },
+  { from: '/administrator-documentation/moderne-platform-v1/getting-started/proof-of-value', to: '/user-documentation/moderne-platform-v1/getting-started/proof-of-value' },
+  { from: '/administrator-documentation/moderne-platform/getting-started/proof-of-value', to: '/user-documentation/moderne-platform/getting-started/proof-of-value' },
+  { from: '/user-documentation/recipes/recipe-authoring/writing-python-recipes', to: '/user-documentation/recipes/authoring-recipes/writing-recipes/writing-python-recipes' },
+  { from: '/administrator-documentation/moderne-platform-v1/references/how-ast-artifacts-are-produced', to: '/administrator-documentation/moderne-platform-v1/references/how-lst-artifacts-are-produced' },
+  { from: '/administrator-documentation/moderne-platform/references/how-ast-artifacts-are-produced', to: '/administrator-documentation/moderne-platform/references/how-lst-artifacts-are-produced' },
+  { from: '/user-documentation/recipes/coordinating-parent-pom-migrations', to: '/user-documentation/recipes/popular-recipe-guides/coordinating-parent-pom-migrations' },
+  { from: '/user-documentation/recipes/managing-gradle-lock-files', to: '/user-documentation/moderne-cli/how-to-guides/managing-gradle-lock-files' },
+  { from: '/user-documentation/recipes/popular-recipe-guides/migrate-to-spring-boot-4', to: '/user-documentation/recipes/popular-recipe-guides/migrate-to-spring-boot' },
+  { from: '/user-documentation/recipes/popular-recipe-guides/migrate-to-spring-boot-3', to: '/user-documentation/recipes/popular-recipe-guides/migrate-to-spring-boot#coming-from-spring-boot-2x' },
+  { from: '/administrator-documentation/moderne-platform/references/lossless-semantic-trees', to: '/user-documentation/recipes/authoring-recipes/concepts/lossless-semantic-trees' },
+  { from: '/user-documentation/workshops/recipe-authoring', to: '/hands-on-learning/fundamentals/' },
+  { from: '/user-documentation/moderne-platform/how-to-guides/categorize-recipes', to: '/administrator-documentation/moderne-platform/how-to-guides/categorize-recipes' },
+  { from: '/user-documentation/recipes/moderne-trigrep', to: '/user-documentation/agent-tools/trigrep' },
+];
+
+export default redirects;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1950,6 +1950,21 @@
     react-helmet-async "npm:@slorber/react-helmet-async@1.3.0"
     react-loadable "npm:@docusaurus/react-loadable@6.0.0"
 
+"@docusaurus/plugin-client-redirects@^3.10.1":
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.10.1.tgz#e22ed20e5837b7c3a28258e3d1816c4239c82b36"
+  integrity sha512-LHgd+YDvkhfOHMAE6XtUng3DQNzVM765RqVRrMJgHtzAvfopQhY6ieprqjxDVBdv21cLma6I0jHr+YCZH8fL9A==
+  dependencies:
+    "@docusaurus/core" "3.10.1"
+    "@docusaurus/logger" "3.10.1"
+    "@docusaurus/utils" "3.10.1"
+    "@docusaurus/utils-common" "3.10.1"
+    "@docusaurus/utils-validation" "3.10.1"
+    eta "^2.2.0"
+    fs-extra "^11.1.1"
+    lodash "^4.17.21"
+    tslib "^2.6.0"
+
 "@docusaurus/plugin-content-blog@3.10.1":
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.10.1.tgz#0bd8de700ccbd8e95d920df2613304ef59abe72b"


### PR DESCRIPTION
Previously, we were creating individual redirect files every time we changed the locations of a page. This is extremely tedious and made it so it was hard to search for docs locally.

By using the redirect plugin, we can define the redirects in this single file and add comments as we want.

One thing worth noting - you have to build and serve the site vs. just doing a `yarn start` in order for these redirects to work when testing locally.