### PR TITLE
Fix sharded Pages deploy: redirect validation + MDX escape in proprietary changelog

### DIFF
--- a/docs/releases/proprietary-recipe-changelog.md
+++ b/docs/releases/proprietary-recipe-changelog.md
@@ -10,6 +10,195 @@ This page contains release notes for [Moderne proprietary OpenRewrite recipes](h
 This changelog is automatically generated from GitHub releases and only contains information from the past year.
 :::
 
+## July 14, 2026
+
+#### rewrite-ai - 0.4.3
+
+* Updated repository to use OpenRewrite version v8.87.0
+
+#### rewrite-ai-search - 0.35.2
+
+* Updated repository to use OpenRewrite version v8.87.0
+
+#### rewrite-android - 0.18.3
+
+* Updated repository to use OpenRewrite version v8.87.0
+
+#### rewrite-angular - 1.6.0
+
+* actions/checkout@v7
+* Upgrade official GitHub Actions to their latest versions
+
+#### rewrite-circleci - 3.12.3
+
+* Updated repository to use OpenRewrite version v8.87.0
+
+#### rewrite-cobol - 2.20.2
+
+* Updated repository to use OpenRewrite version v8.87.0
+
+#### rewrite-codemods - 0.27.1
+
+* Updated repository to use OpenRewrite version v8.87.0
+
+#### rewrite-codemods-ng - 0.21.3
+
+* Updated repository to use OpenRewrite version v8.87.0
+
+#### rewrite-compiled-analysis - 0.14.3
+
+* Updated repository to use OpenRewrite version v8.87.0
+
+#### rewrite-concourse - 3.11.3
+
+* Updated repository to use OpenRewrite version v8.87.0
+
+#### rewrite-cryptography - 0.14.9
+
+* Updated repository to use OpenRewrite version v8.87.0
+
+#### rewrite-devcenter - 1.28.0
+
+* Add Go version upgrade card
+
+#### rewrite-dotnet - 0.17.1
+
+* Updated repository to use OpenRewrite version v8.87.0
+
+#### rewrite-dropwizard - 0.5.5
+
+* Updated repository to use OpenRewrite version v8.87.0
+
+#### rewrite-dropwizard - 0.5.4
+
+* Updated repository to use OpenRewrite version v8.87.0
+
+#### rewrite-elastic - 0.8.1
+
+* Updated repository to use OpenRewrite version v8.87.0
+
+#### rewrite-hibernate - 0.26.2
+
+* Updated repository to use OpenRewrite version v8.87.0
+
+#### rewrite-jasperreports - 0.6.3
+
+* Updated repository to use OpenRewrite version v8.87.0
+
+#### rewrite-java-application-server - 0.7.8
+
+* Updated repository to use OpenRewrite version v8.87.0
+
+#### rewrite-java-security - 3.35.0
+
+* Respect maximumUpgradeDelta when advisories reference unpublished versions
+* Recognize Gradle dependencies blocks that lack type attribution
+* Go: support nested modules in DependencyVulnerabilityCheck
+* Go: fix DependencyVulnerabilityCheck never to downgrade
+* feat: Integrate End of Life detection recipes from rewrite-end-of-life
+* Single-source vulnerability target selection
+* Regenerate recipes.csv picking up new edited-dependency columns
+* Go: DependencyVulnerabilityCheck not to alter go.sum, if no changes t…
+* Update logback-core CVE expectations for new advisory
+
+#### rewrite-kafka - 0.7.3
+
+* Updated repository to use OpenRewrite version v8.87.0
+
+#### rewrite-kubernetes - 3.17.3
+
+* Updated repository to use OpenRewrite version v8.87.0
+
+#### rewrite-migrate-kotlin - 0.6.2
+
+* Updated repository to use OpenRewrite version v8.87.0
+
+#### rewrite-migrate-python - 0.9.4
+
+* Updated repository to use OpenRewrite version v8.87.0
+
+#### rewrite-nodejs - 0.47.1
+
+* Updated repository to use OpenRewrite version v8.87.0
+
+#### rewrite-nullability - 0.3.0
+
+* docs: NullSafety adoption book for Treehouse
+* fix: add dataTables column to recipes.csv so tables resolve in the SaaS UI
+
+#### rewrite-prethink - 0.9.0
+
+* Add duplicate-code and similar-code detection recipes
+* Richer Type-3 clone detection: gapped (insert/delete) alignment + tandem-repeat suppression
+* Marry duplicate + similar detection: anchor-free method alignment, shared MinHash/LSH
+* Fix star-alignment region-shrink and groupKey clone collapse
+* Suppress string-literal-concatenation blobs as Type-2 clone false positives
+* Support specifying multiple target agent config files
+* Rename the Prethink starter and route both legacy recipe ids to it
+* Detect JAX-RS/Jakarta EE ExceptionMapper handlers (#2760)
+* Add Python gRPC servicer detection for parity with Java, Go, and .NET
+* Document and test JAX-RS/Jakarta EE endpoint security detection
+* Detect raw kafka-clients, AWS SQS, Redis pub/sub, and EJB messaging
+* Detect ScheduledExecutorService and ManagedScheduledExecutorService scheduled tasks
+* Capture Django URL paths and resolve Flask/FastAPI route prefixes
+* Fix new UpdatePrethinkContext() call
+
+#### rewrite-program-analysis - 0.13.5
+
+* Updated repository to use OpenRewrite version v8.87.0
+
+#### rewrite-react - 0.3.4
+
+* Updated repository to use OpenRewrite version v8.87.0
+
+#### rewrite-reactive-streams - 0.20.3
+
+* Updated repository to use OpenRewrite version v8.87.0
+
+#### rewrite-release-metromap - 0.4.2
+
+* Updated repository to use OpenRewrite version v8.87.0
+
+#### rewrite-spring - 0.38.0
+
+* Use constructor injection for StoredProcedureItemReader (Spring Batch 6)
+* Guard withHttpClientDefaults recipe behind a Spring Boot &lt;4.1 precondition
+* Co-exclude `UserDetailsServiceAutoConfiguration` when `SecurityAutoConfiguration` is excluded (#2663)
+* Migrate RestTemplate to RestClient (incl. setter-based bean configuration)
+* Use `KotlinTemplate` for `@Retryable` migration on Kotlin sources
+* Fix MigrateSpringRetryRecoverToRetryTemplate wiping method bodies when @Retryable(value = {X.class}) uses array-initializer syntax
+* Run the SecurityAutoConfiguration co-exclude before the Boot 4 relocation (#2664)
+* Modularize legacy spring-session-data-redis and raw spring-data-redis under SB4
+* Remove `@ExpectedToFail` from now-passing Kotlin `@Retryable` migration tests
+* Replace removed `RedisCacheConfiguration.getTtl()` in Spring Data Redis 4.0
+* Add SB4 boot-jdbc and boot-hibernate namespace triggers to AddModularStarters
+* Convert `GatewayRedisAutoConfiguration` `exclude` to `excludeName` before SCG 5.0 upgrade
+
+#### rewrite-sql - 2.14.0
+
+* Guard against null Function names from table functions
+* Fix SQL anti-pattern false positives (concatenation + non-SQL DELETE) and add INSERT-without-columns recipe
+* Tighten non-SQL DELETE detection and add INSERT-without-columns recipe
+* Detect and inventory stored procedure calls (EXEC/EXECUTE/CALL)
+* Add limit-without-order-by and constant-predicate SQL anti-pattern recipes
+* Add surgical auto-remediations for null-comparison and order-by-in-subquery anti-patterns
+
+#### rewrite-struts - 0.26.3
+
+* Updated repository to use OpenRewrite version v8.87.0
+
+#### rewrite-tapestry - 0.4.3
+
+* Updated repository to use OpenRewrite version v8.87.0
+
+#### rewrite-terraform - 3.14.5
+
+* Updated repository to use OpenRewrite version v8.87.0
+
+#### rewrite-vulncheck - 0.7.5
+
+* Updated repository to use OpenRewrite version v8.87.0
+
 ## July 8, 2026
 
 #### rewrite-java-security - 3.34.3

--- a/docs/releases/proprietary-recipe-changelog.md
+++ b/docs/releases/proprietary-recipe-changelog.md
@@ -166,7 +166,7 @@ This changelog is automatically generated from GitHub releases and only contains
 * Co-exclude `UserDetailsServiceAutoConfiguration` when `SecurityAutoConfiguration` is excluded (#2663)
 * Migrate RestTemplate to RestClient (incl. setter-based bean configuration)
 * Use `KotlinTemplate` for `@Retryable` migration on Kotlin sources
-* Fix MigrateSpringRetryRecoverToRetryTemplate wiping method bodies when @Retryable(value = {X.class}) uses array-initializer syntax
+* Fix MigrateSpringRetryRecoverToRetryTemplate wiping method bodies when `@Retryable(value = {X.class})` uses array-initializer syntax
 * Run the SecurityAutoConfiguration co-exclude before the Boot 4 relocation (#2664)
 * Modularize legacy spring-session-data-redis and raw spring-data-redis under SB4
 * Remove `@ExpectedToFail` from now-passing Kotlin `@Retryable` migration tests

--- a/scripts/build-shard-patch.js
+++ b/scripts/build-shard-patch.js
@@ -33,7 +33,13 @@ const HEAVY_ROUTE_PATTERNS = [
 ];
 
 ssgExecutor.executeSSG = async function shardedExecuteSSG(opts) {
-  const allPaths = [...opts.props.routesPaths].sort();
+  // Keep the untouched full route list so we can restore it after SSG. The
+  // reduced list below only limits what THIS shard renders; postBuild plugins
+  // (client-redirects, sitemap) must still see every route or they validate
+  // their targets against a partial route set and fail (e.g. redirects to
+  // pages rendered by another shard look "missing").
+  const originalRoutesPaths = opts.props.routesPaths;
+  const allPaths = [...originalRoutesPaths].sort();
   const DEDICATED_SHARD = SHARD_TOTAL - 1;
 
   const isHeavy = (p) => HEAVY_ROUTE_PATTERNS.some((pat) => p === pat || p.startsWith(pat + '/'));
@@ -56,6 +62,13 @@ ssgExecutor.executeSSG = async function shardedExecuteSSG(opts) {
   opts.props.routesPaths = mine;
 
   const result = await originalExecuteSSG.call(this, opts);
+
+  // Restore the full route list now that this shard is done rendering, so
+  // postBuild lifecycle plugins (client-redirects target validation, sitemap)
+  // operate on the complete set of routes rather than this shard's subset.
+  // Every shard then emits the same redirect/sitemap files, which merge-shards
+  // deduplicates via last-wins.
+  opts.props.routesPaths = originalRoutesPaths;
 
   serializeShardMeta(result, opts);
 

--- a/scripts/build-shard-patch.js
+++ b/scripts/build-shard-patch.js
@@ -33,11 +33,7 @@ const HEAVY_ROUTE_PATTERNS = [
 ];
 
 ssgExecutor.executeSSG = async function shardedExecuteSSG(opts) {
-  // Keep the untouched full route list so we can restore it after SSG. The
-  // reduced list below only limits what THIS shard renders; postBuild plugins
-  // (client-redirects, sitemap) must still see every route or they validate
-  // their targets against a partial route set and fail (e.g. redirects to
-  // pages rendered by another shard look "missing").
+  // Kept so we can restore the full list after SSG (see below).
   const originalRoutesPaths = opts.props.routesPaths;
   const allPaths = [...originalRoutesPaths].sort();
   const DEDICATED_SHARD = SHARD_TOTAL - 1;
@@ -63,11 +59,8 @@ ssgExecutor.executeSSG = async function shardedExecuteSSG(opts) {
 
   const result = await originalExecuteSSG.call(this, opts);
 
-  // Restore the full route list now that this shard is done rendering, so
-  // postBuild lifecycle plugins (client-redirects target validation, sitemap)
-  // operate on the complete set of routes rather than this shard's subset.
-  // Every shard then emits the same redirect/sitemap files, which merge-shards
-  // deduplicates via last-wins.
+  // Restore the full route list so postBuild plugins (client-redirects,
+  // sitemap) validate/emit against every route, not just this shard's subset.
   opts.props.routesPaths = originalRoutesPaths;
 
   serializeShardMeta(result, opts);


### PR DESCRIPTION
## Problem

- The **Deploy Moderne docs to Pages (sharded)** workflow has been failing on every push to `main` since #840 ("Create a dedicated redirects file"). Two independent issues:

### 1. Redirect validation vs. the shard patch

`scripts/build-shard-patch.js` shrinks `props.routesPaths` so each shard only renders a subset of routes, but never restores it. The `@docusaurus/plugin-client-redirects` plugin validates its `to:` targets in `postBuild(props)` against `props.routesPaths` — so it saw only the current shard's routes and rejected every redirect whose target lives in another shard:

```
Error: You are trying to create client-side redirections to invalid paths.
These paths are redirected to but do not exist:
  - /licensing/overview
  - /releases/cli-releases
  ...
```

The patch already disables `onBrokenLinks`/`onBrokenAnchors` per shard for the same reason; redirect target validation had the same problem but wasn't handled.

**Fix:** restore the full route list after SSG so postBuild plugins (client-redirects, sitemap) validate/emit against every route. Each shard emits identical redirect files; `merge-shards.js` deduplicates via last-wins.

### 2. MDX evaluation in the changelog

`docs/releases/proprietary-recipe-changelog.md` contained a bare `{X.class}`, which MDX evaluates as JavaScript → `ReferenceError: X is not defined`, failing SSG for `/releases/proprietary-recipe-changelog`. Wrapped the annotation in backticks. (The other two `{...}` occurrences were already inside inline code and safe.)

## Verification

* Built the previously-failing dedicated heavy shard (`SHARD_INDEX=3`) and a normal shard (`SHARD_INDEX=0`) locally — both `[SUCCESS]`.
* Confirmed redirect files are emitted (e.g. `/releases/cli-dx` → meta-refresh to `/releases/cli-releases`).
* `yarn lint:markdown` passes.