### PR TITLE
Make fundamentals workshop usable without a Moderne license

### DIFF
--- a/docs/hands-on-learning/fundamentals/module-1-recipe-development-environment.md
+++ b/docs/hands-on-learning/fundamentals/module-1-recipe-development-environment.md
@@ -33,7 +33,7 @@ If you have not already completed the [Introduction to OpenRewrite course](../in
 
 * Set up a new recipe module in your IDE, based on the [`rewrite-recipe-starter`](https://github.com/moderneinc/rewrite-recipe-starter) project.
 * Run the unit tests for the recipe module, to ensure everything is set up correctly.
-* Install your recipe module to your local Maven repository for debugging later.
+* Run your in-development recipe against a real repository using the CLI's active recipe.
 
 ### Steps
 
@@ -42,6 +42,10 @@ If you have not already completed the [Introduction to OpenRewrite course](../in
 1. Clone or fork the [`rewrite-recipe-starter`](https://github.com/moderneinc/rewrite-recipe-starter) project or [use it as a template](https://github.com/new?template_name=rewrite-recipe-starter&template_owner=moderneinc).
 2. Open the project in your IDE (this workshop demonstrates IntelliJ IDEA).
 3. Import either the Maven or Gradle build (your preference) into your IDE and enable annotation processing. 
+
+:::note
+If your IDE compiles sources itself rather than delegating to Maven or Gradle (IntelliJ delegates by default), add `-parameters` to your IDE's Java compiler options. Without it, the `RewriteTest` framework may report that your recipe fails a serialization check, which would prevent the CLI from loading the recipe later.
+:::
 
 :::tip
 For a better idea about the reference recipes and tests that are included in the starter project, review the [`README.md`](https://github.com/moderneinc/rewrite-recipe-starter/blob/main/README.md) there. Many of them will be referenced later in this workshop.
@@ -62,33 +66,39 @@ To make the project your own and allow it to be versioned and shared without con
 For the purposes of this workshop, this step isn't required, so feel free to leave it alone and continue to use `com.yourorg`.
 :::
 
-#### Step 4: Install and verify locally
+#### Step 4: Set an active recipe and run it locally
 
-1. Install the project to your local Maven repository by running one of the following commands from the root of your project, depending on which build tool you prefer:
+To try your in-development recipe against a real repository, set it as the CLI's **active recipe**. This points the CLI directly at your recipe source, so you only need to recompile between runs, with no jar to publish each time you make a change.
 
-```bash
-# Maven
-mvn install
+1. Point the CLI at your recipe source (a `.java` or `.yml` file):
 
-# Gradle
-./gradlew publishToMavenLocal
-```
+  ```bash
+  mod config recipes active set src/main/java/com/yourorg/AssertEqualsToAssertThat.java
+  ```
 
-2. Install the recipe package to the local recipe marketplace with the Moderne CLI:
+2. Compile the project using your preferred build tool command:
 
-```bash
-mod config recipes jar install com.yourorg:rewrite-recipe-starter:LATEST
-```
+  ```bash
+  # Gradle (add --continuous so Gradle rebuilds automatically on every change)
+  ./gradlew classes
 
-3. To confirm that everything is set up for testing imperative recipes, run one of the starter project's recipes by name. Open a terminal, navigate to your workshop directory, and run:
+  # Maven
+  ./mvnw compile
+  ```
+
+:::note
+You need to do this every time you change the recipe. Alternatively, you can build and publish the jar to your local Maven repository (`mvn install` or `./gradlew publishToMavenLocal`) and reinstall it each time with `mod config recipes jar install com.yourorg:rewrite-recipe-starter:LATEST`.
+:::
+
+3. Run the active recipe against your workshop repositories:
 
   ```bash
   cd ~/moderne-workshop
-  mod run . --recipe=com.yourorg.AssertEqualsToAssertThat
+  mod run . --active-recipe
   ```
 
 :::tip
-If you have the Moderne plugin installed (which requires a [licensed CLI](../../user-documentation/moderne-cli/getting-started/moderne-cli-license.md)), you can instead open the `AssertEqualsToAssertThat` class in IntelliJ, right-click the class name, select **Set Active Recipe**, and run `mod run . --active-recipe`.
+The Moderne plugin's **Set Active Recipe** action is a UI shortcut for `mod config recipes active set`. The plugin requires a [licensed CLI](../../user-documentation/moderne-cli/getting-started/moderne-cli-license.md), but the commands above do not need the plugin.
 :::
 
 ### Takeaways

--- a/docs/hands-on-learning/fundamentals/module-1-recipe-development-environment.md
+++ b/docs/hands-on-learning/fundamentals/module-1-recipe-development-environment.md
@@ -41,7 +41,7 @@ If you have not already completed the [Introduction to OpenRewrite course](../in
 
 1. Clone or fork the [`rewrite-recipe-starter`](https://github.com/moderneinc/rewrite-recipe-starter) project or [use it as a template](https://github.com/new?template_name=rewrite-recipe-starter&template_owner=moderneinc).
 2. Open the project in your IDE (this workshop demonstrates IntelliJ IDEA).
-3. If you're using IntelliJ, choose Maven or Gradle import when prompted (your preference), and enable annotation processing if the IDE suggests it. These steps will differ if you're using the command line or another IDE.
+3. Import either the Maven or Gradle build (your preference) into your IDE and enable annotation processing. 
 
 :::tip
 For a better idea about the reference recipes and tests that are included in the starter project, review the [`README.md`](https://github.com/moderneinc/rewrite-recipe-starter/blob/main/README.md) there. Many of them will be referenced later in this workshop.

--- a/docs/hands-on-learning/fundamentals/module-1-recipe-development-environment.md
+++ b/docs/hands-on-learning/fundamentals/module-1-recipe-development-environment.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: "Module 1: Environment setup"
-description: How to set up your IDE to write custom recipes.
+description: How to set up your environment to write custom recipes.
 ---
 
 # Module 1: Recipe development environment
@@ -14,10 +14,14 @@ You'll want to have the following installed:
 * Java 21, as our [RewriteTests](../../user-documentation/recipes/authoring-recipes/testing-and-best-practices/recipe-testing.md#rewritetest-interface) use text blocks.
   * The [`rewrite-recipe-starter`](https://github.com/moderneinc/rewrite-recipe-starter) project expects JDK 21. (Temurin JDK 21.0.7 (`temurin-21.0.7`), for example, has been specified in the `.sdkmanrc` file, but other version 21 JDKs may work as well.)
   * Recipes use Java 8 source level, so they can run on Java 8 and higher.
-* IntelliJ IDEA (2025.3+ recommended)
+* A Java IDE or editor. This workshop demonstrates IntelliJ IDEA (2025.3+ recommended), but you can follow along in any IDE or from the command line.
+* A build tool (Maven or Gradle) to compile the project and run tests. The starter project supports both.
+* [The Moderne CLI](../../user-documentation/moderne-cli/getting-started/cli-intro.md), to run recipes at scale locally, and debug against serialized LSTs. The CLI is free to use against public repositories.
+
+If you use IntelliJ IDEA, the following plugins can improve the experience, but neither is required to complete this workshop:
+
 * The [OpenRewrite plugin](https://plugins.jetbrains.com/plugin/23814-openrewrite), to run and write YAML recipes.
-* [The Moderne plugin](../../user-documentation/moderne-ide-integration/how-to-guides/moderne-plugin-install.md), for faster recipe development and to help debug recipes.
-* [The Moderne CLI](../../user-documentation/moderne-cli/getting-started/cli-intro.md), to run recipes at scale locally, and debug against serialized LSTs.
+* [The Moderne plugin](../../user-documentation/moderne-ide-integration/how-to-guides/moderne-plugin-install.md), for faster recipe development and to help debug recipes. Note that this plugin requires the CLI to be configured with a [Moderne license](../../user-documentation/moderne-cli/getting-started/moderne-cli-license.md).
 
 :::warning
 If you have not already completed the [Introduction to OpenRewrite course](../introduction/workshop-overview.md), go there first and complete at least Module 1 before continuing. The exercises in this workshop assume that module has been completed - meaning that the Moderne CLI is working and that you have a `~/moderne-workshop` directory with the `Default` org synced.
@@ -36,9 +40,8 @@ If you have not already completed the [Introduction to OpenRewrite course](../in
 #### Step 1: Clone and open the project
 
 1. Clone or fork the [`rewrite-recipe-starter`](https://github.com/moderneinc/rewrite-recipe-starter) project or [use it as a template](https://github.com/new?template_name=rewrite-recipe-starter&template_owner=moderneinc).
-2. Open the project in IntelliJ IDEA.
-3. If prompted, choose Maven or Gradle import (your preference).
-4. Enable annotation processing if IntelliJ suggests it.
+2. Open the project in your IDE (this workshop demonstrates IntelliJ IDEA).
+3. If you're using IntelliJ, choose Maven or Gradle import when prompted (your preference), and enable annotation processing if the IDE suggests it. These steps will differ if you're using the command line or another IDE.
 
 :::tip
 For a better idea about the reference recipes and tests that are included in the starter project, review the [`README.md`](https://github.com/moderneinc/rewrite-recipe-starter/blob/main/README.md) there. Many of them will be referenced later in this workshop.
@@ -46,9 +49,10 @@ For a better idea about the reference recipes and tests that are included in the
 
 #### Step 2: Run tests once
 
-1. Run all unit tests to confirm your environment is working. To do this in IntelliJ, navigate to the `src/test/java` folder in the Project Tool window and right-click on it. Then select the green play button that says Run 'All Tests' (if you're using Maven), or 'Run Tests in rewrite-recipe-starter' (if you're using Gradle).
+1. Run all unit tests to confirm your environment is working.
+    * From the command line, run `mvn test` (Maven) or `./gradlew test` (Gradle) from the root of the project.
+    * In IntelliJ, you can instead navigate to the `src/test/java` folder in the Project Tool window, right-click it, and select the green play button (Run 'All Tests' for Maven, or 'Run Tests in rewrite-recipe-starter' for Gradle). If you're using Gradle and tests feel slow, consider [updating the way tests run in IntelliJ](https://docs.openrewrite.org/reference/building-openrewrite-from-source#developing-tips) for faster feedback.
 2. Confirm that all tests pass, and you should see a message that the project was successfully built. You can ignore any warnings as long as the build is successful.
-3. _(Optional)_ If you're using Gradle and tests feel slow, consider [updating the way tests run in IntelliJ](https://docs.openrewrite.org/reference/building-openrewrite-from-source#developing-tips) for faster feedback.
 
 #### Step 3: _(Optional)_ Customize coordinates
 
@@ -76,15 +80,15 @@ mvn install
 mod config recipes jar install com.yourorg:rewrite-recipe-starter:LATEST
 ```
 
-3. To confirm that everything is set up for testing imperative recipes, open the `AssertEqualsToAssertThat` class in IntelliJ, right-click the class name, and select **Set Active Recipe**. Then open a terminal, navigate to your workshop directory, and run:
+3. To confirm that everything is set up for testing imperative recipes, run one of the starter project's recipes by name. Open a terminal, navigate to your workshop directory, and run:
 
   ```bash
   cd ~/moderne-workshop
-  mod run . --active-recipe
+  mod run . --recipe=com.yourorg.AssertEqualsToAssertThat
   ```
 
-:::note
-This requires the Moderne plugin; if it is not installed, the **Set Active Recipe** option will not appear. You can still run the recipe with the `mod` CLI if you refer to the recipe by name (as in the next step).
+:::tip
+If you have the Moderne plugin installed (which requires a [licensed CLI](../../user-documentation/moderne-cli/getting-started/moderne-cli-license.md)), you can instead open the `AssertEqualsToAssertThat` class in IntelliJ, right-click the class name, select **Set Active Recipe**, and run `mod run . --active-recipe`.
 :::
 
 ### Takeaways

--- a/docs/hands-on-learning/fundamentals/module-2-declarative-yaml-recipes.md
+++ b/docs/hands-on-learning/fundamentals/module-2-declarative-yaml-recipes.md
@@ -29,7 +29,7 @@ A declarative YAML recipe consists of [at least] metadata fields (`type`, `name`
 
 The recipe starter project already contains a migration recipe for replacing Spring string utilities with Apache string utilities, but it's just a start and is missing some cases that still need to be covered. For one, you'll want to change from Spring's `trimWhitespace(String)` to Apache Common's `StringUtils.strip(String)`.
 
-1. Open [src/main/resources/META-INF/rewrite/stringutils.yml](https://github.com/moderneinc/rewrite-recipe-starter/blob/main/src/main/resources/META-INF/rewrite/stringutils.yml) from your project in IntelliJ.
+1. Open [src/main/resources/META-INF/rewrite/stringutils.yml](https://github.com/moderneinc/rewrite-recipe-starter/blob/main/src/main/resources/META-INF/rewrite/stringutils.yml) from your project in your IDE.
 2. Add [`org.openrewrite.java.ChangeMethodName`](https://docs.openrewrite.org/recipes/java/changemethodname) to the end of `recipeList`.
 3. Set the options for this recipe as follows:
     * `methodPattern: org.apache.commons.lang3.StringUtils trimWhitespace(java.lang.String)`
@@ -62,9 +62,9 @@ recipeList:
 You may notice that [the method pattern](../../user-documentation/recipes/authoring-recipes/references/method-patterns.md) actually refers to a method that does not exist. Apache Commons does not have a `trimWhitespace` method, but Spring does. However, because recipes in the `recipeList` are executed in order and the `ChangeType` recipe comes before the new `ChangeMethodName` recipe, when `ChangeMethodName` runs, the type will already be Apache Commons and there will no longer be a Spring `trimWhitespace` method. This is an important point to keep in mind when chaining recipes together.
 
 :::tip
-IntelliJ can suggest recipe options. Place your cursor between `description` and `recipeList`, then trigger auto-complete (Ctrl/Cmd + Space) to see optional fields that may be missing (like `estimatedEffortPerOccurrence` in this example).
+If you're using IntelliJ, it can suggest recipe options. Place your cursor between `description` and `recipeList`, then trigger auto-complete (Ctrl/Cmd + Space) to see optional fields that may be missing (like `estimatedEffortPerOccurrence` in this example).
 
-You can also click through in IntelliJ on a recipe name (like `AddDependency` or `ChangeType`) to open its definition using Ctrl/Cmd + Click.
+You can also click through on a recipe name (like `AddDependency` or `ChangeType`) to open its definition using Ctrl/Cmd + Click.
 :::
 
 #### Step 2: Add a unit test
@@ -77,7 +77,7 @@ Even for declarative recipes, you should always write tests. Make sure you expan
      * The existing `replacesStringEquals` test uses `rewriteRun(SourceSpecs...)` with a single `java(String, String)` before/after text block, which asserts the recipe transforms the "before" code into the "after" code.
      * The `noChangeWhenAlreadyUsingCommonsLang3` test only includes a before block, which as the comment mentions, indicates that the after code block should be the same as the before code block.
      * The `//language=java` injection on the text blocks enables IntelliJ syntax highlighting and code completion.
-2. Now run the existing `replacesStringEquals` test (use the green play icon to the left of the test method) to confirm it passes. This takes care of that particular case, but now you need to cover the method name change that you just implemented.
+2. Now run the tests to confirm the existing `replacesStringEquals` case passes (in IntelliJ, you can run just that test using the green play icon to the left of the method). This takes care of that particular case, but now you need to cover the method name change that you just implemented.
 3. Add a unit test that validates `trimWhitespace` is converted to `strip`.
 <details>
 <summary>Reference example: trimWhitespace test</summary>

--- a/docs/hands-on-learning/fundamentals/module-3-refaster-recipes.md
+++ b/docs/hands-on-learning/fundamentals/module-3-refaster-recipes.md
@@ -19,14 +19,14 @@ In this exercise, you will generate a recipe from an existing Refaster template 
 
 * Understand how OpenRewrite supports Refaster recipes.
 * See how Refaster recipes are written in Java, and how they can be run as recipes.
-* Use IDE support for generating Refaster recipes.
+* Generate an OpenRewrite recipe from a Refaster template.
 
 ### Steps
 
 #### Step 1: See how Refaster recipes are generated from templates
 
 1. Open [src/main/java/com/yourorg/SimplifyTernary.java](https://github.com/moderneinc/rewrite-recipe-starter/blob/main/src/main/java/com/yourorg/SimplifyTernary.java) and take a look at the Refaster template to see the before/after pattern it's matching to simplify ternary expressions.
-2. Build the project (Ctrl/Cmd + F9) to trigger Refaster code generation. This will automatically create an imperative OpenRewrite recipe in a new file with the name `SimplifyTernaryRecipes.java`. 
+2. Build the project to trigger Refaster code generation (in IntelliJ, use Ctrl/Cmd + F9; or run `mvn compile` or `./gradlew build` from the command line). This will automatically create an imperative OpenRewrite recipe in a new file with the name `SimplifyTernaryRecipes.java`. 
 :::info
 Refaster template recipe names are the class name followed by `Recipe` or `Recipes` (depending on if there is more than one template in the class).
 :::
@@ -73,11 +73,11 @@ Now that you've seen how Refaster template recipes work, you can create your own
 
 #### Step 3: Build and re-run the tests
 
-1. Build the project (Ctrl/Cmd + F9) to generate the recipe class the tests expect.
+1. Build the project (in IntelliJ, Ctrl/Cmd + F9; or run `mvn compile` or `./gradlew build`) to generate the recipe class the tests expect.
 2. Re-run the tests and use the remaining failures to decide the next template. (This iterative pattern is a common method for recipe development.)
 
 :::tip
-With the Moderne plugin installed, you can generate a new Refaster recipe from any method invocation by right-clicking the invocation, selecting "Refactor", then "Create OpenRewrite Recipe", then "Create Recipe (Refaster Style)". For example, you could generate a Refaster template to convert `StringUtils.trim(..)` to `StringUtils.strip(..)` as you did in the previous module using a declarative recipe.
+With the Moderne plugin installed (which requires a [licensed CLI](../../user-documentation/moderne-cli/getting-started/moderne-cli-license.md)), you can generate a new Refaster recipe from any method invocation by right-clicking the invocation, selecting "Refactor", then "Create OpenRewrite Recipe", then "Create Recipe (Refaster Style)". For example, you could generate a Refaster template to convert `StringUtils.trim(..)` to `StringUtils.strip(..)` as you did in the previous module using a declarative recipe.
 :::
 
 #### Step 4: Complete coverage
@@ -154,6 +154,6 @@ public class StringIsEmpty {
 
 * Refaster templates are converted into regular OpenRewrite recipes, and can be run as such.
 * Common base classes, and embedding options lighten the load in implementing Refaster templates.
-* Refaster templates can be generated from the IDE, and used as a starting point for more complex recipe implementations.
+* Refaster templates can be used as a starting point for more complex recipe implementations.
 * A Refaster rule can contain more than one before template, to match different ways to check for an empty string.
 * You can customize the Recipe name and description, with the help of the `@RecipeDescriptor` annotation.


### PR DESCRIPTION
## What

Scrubs the **Fundamentals of recipe development** workshop so it can be completed by self-service users who don't have a Moderne license, and so it no longer assumes IntelliJ IDEA specifically.

## Why

The workshop leaned on the Moderne IntelliJ plugin, which [requires a licensed CLI](https://docs.moderne.io/user-documentation/moderne-ide-integration/how-to-guides/moderne-plugin-install) (an access token isn't enough). Self-service users on the free tier hit dead ends on those steps. In practice, almost all of the workshop is already license-free — the OpenRewrite plugin, the `RewriteTest` unit tests, and the `mod` CLI on public repos are all free — so the changes are narrow.

## What changed

- **Module 1**
  - Split prerequisites: Java, an IDE/editor, a build tool, and the CLI are required; the OpenRewrite and Moderne plugins moved to an "if you use IntelliJ" subsection framed as not required. The Moderne plugin keeps a note that it requires a licensed CLI. Added that the CLI is free against public repositories.
  - Genericized the IDE/setup and test-running steps (added `mvn test` / `./gradlew test`), scoping IntelliJ-only details (import, annotation processing, green-play icon) as IntelliJ-specific.
  - Flipped the imperative-recipe verification to run by name (`mod run . --recipe=com.yourorg.AssertEqualsToAssertThat`) instead of the license-gated **Set Active Recipe** flow, which is now an optional tip.
- **Module 2**: genericized IDE references and single-test run guidance.
- **Module 3**: genericized the build step (added command-line equivalents) and flagged the Moderne plugin Refaster-generation tip as license-gated.

## Notes for reviewers

- No content was removed — license-gated and IntelliJ-specific paths are preserved as optional tips, just no longer required.
- The Module 1 prerequisite still points at the Introduction workshop's `~/moderne-workshop` + `Default` org, which is on the public instance (free), so it isn't a license blocker.
- There's a separate, broader question (not in this PR) about whether to keep investing in the IDE/plugin-centric fundamentals course vs. steering toward the AI-assisted authoring lab. That's being discussed separately.
- Pre-merge: `yarn start` link/build validation still recommended per repo convention.