### PR TITLE
Don't fail marketplace build when one ecosystem's install fails

### DIFF
--- a/.github/scripts/build-recipe-marketplace.sh
+++ b/.github/scripts/build-recipe-marketplace.sh
@@ -128,6 +128,7 @@ tool_available() {
 
 log "Installing recipe modules using $RECIPE_VERSIONS versions"
 SKIPPED=()
+FAILED=()
 for cmd in "${INSTALL_CMDS[@]}"; do
   # The snapshot/released distinction only applies to jars: `:LATEST` picks the
   # newest artifact (including Maven snapshots) while `:RELEASE` picks the newest
@@ -141,7 +142,13 @@ for cmd in "${INSTALL_CMDS[@]}"; do
     continue
   fi
   log "Installing '$ecosystem' recipe modules"
-  mod "${parts[@]:1}"                # drop the literal leading `mod`
+  # Best effort: a single ecosystem failing to install (e.g. a flaky upstream
+  # module) shouldn't discard the marketplace CSV built from the others. Warn
+  # and carry on so the modules that did install still ship.
+  if ! mod "${parts[@]:1}"; then     # drop the literal leading `mod`
+    warn "Failed to install '$ecosystem' recipe modules; continuing without them"
+    FAILED+=("$ecosystem")
+  fi
 done
 
 # ---------------------------------------------------------------------------
@@ -165,4 +172,7 @@ log "Wrote marketplace CSV to $MARKETPLACE_CSV_DEST"
 
 if [ "${#SKIPPED[@]}" -gt 0 ]; then
   warn "Marketplace is missing modules for ecosystem(s): ${SKIPPED[*]} (toolchain unavailable)"
+fi
+if [ "${#FAILED[@]}" -gt 0 ]; then
+  warn "Marketplace is missing modules for ecosystem(s): ${FAILED[*]} (install failed)"
 fi


### PR DESCRIPTION
## Problem

The [Build recipe marketplace run](https://github.com/moderneinc/moderne-docs/actions/runs/29405016760) failed. The Go recipe module `github.com/moderneinc/recipes-go` failed to install (`Failed to install artifact`), so the Moderne CLI exited with code 254 and — under `set -e` — that aborted the whole script. The full cause lives in a `recipes.log` on the runner that isn't surfaced in CI, so it reads as a flaky/upstream install of a single ecosystem.

The workflow last succeeded on 2026-07-09, so nothing in this repo changed; one ecosystem's install went bad and took down the entire build.

## Fix

`build-recipe-marketplace.sh` already treats non-jar ecosystems as best-effort — it skips (with a warning) any ecosystem whose toolchain is missing. This extends the same philosophy to *install* failures: if a single `mod ... install` fails, warn and continue rather than discarding the marketplace CSV that the other ecosystems (jar/pip/npm) built successfully.

* Track failed ecosystems in a `FAILED` array alongside the existing `SKIPPED` array.
* Emit a loud `WARN` naming the ecosystem(s) whose modules are missing from the marketplace.
* The build still fails hard if the CSV itself is never produced (unchanged `die` at the copy step).

Net effect: a flaky upstream module no longer throws away all the modules that did install; the CSV still gets built and committed, minus the failing ecosystem, with a warning in the logs.