### PR TITLE
Pin GOROOT so Go recipe modules install in the marketplace build

### DIFF
--- a/.github/scripts/build-recipe-marketplace.sh
+++ b/.github/scripts/build-recipe-marketplace.sh
@@ -114,6 +114,14 @@ done < <(awk '
 
 [ "${#INSTALL_CMDS[@]}" -gt 0 ] || die "No install commands found in $MODULES_DOC"
 
+# Pin GOROOT to the on-PATH `go` so the Go recipe build helper doesn't mix a second
+# Go install's compiler with this driver ("compile: version goX does not match goY").
+if command -v go >/dev/null 2>&1; then
+  GOROOT="$(go env GOROOT)"
+  export GOROOT
+  log "Pinned GOROOT=$GOROOT ($(go version))"
+fi
+
 # Each non-jar ecosystem shells out to an external toolchain. Skip (with a loud
 # warning) any ecosystem whose toolchain is missing rather than failing the run.
 tool_available() {

--- a/.github/workflows/build-recipe-marketplace.yml
+++ b/.github/workflows/build-recipe-marketplace.yml
@@ -59,6 +59,14 @@ jobs:
           MARKETPLACE_CSV_DEST: ${{ runner.temp }}/recipes-v5-${{ matrix.versions }}.csv
         run: .github/scripts/build-recipe-marketplace.sh
 
+      # Surface the CLI recipe logs (the real install error lives here, not stdout).
+      - uses: actions/upload-artifact@v7
+        if: failure()
+        with:
+          name: recipe-logs-${{ matrix.versions }}
+          path: ${{ runner.temp }}/moderne-cli-home/recipes/**/.moderne/recipes.log
+          if-no-files-found: ignore
+
       - uses: actions/upload-artifact@v7
         with:
           name: recipes-v5-${{ matrix.versions }}


### PR DESCRIPTION
## Problem

The [Build recipe marketplace run](https://github.com/moderneinc/moderne-docs/actions/runs/29405016760) failed to install the Go recipe module `github.com/moderneinc/recipes-go` — CI only showed `Failed to install artifact` / exit 254. The real exception lives in a `recipes.log` the workflow never surfaced:

```
compile: version "go1.26.4" does not match go tool version "go1.25.11"
```

Root cause is a **Go toolchain version skew**. The `ubuntu-latest` runner ships a pre-installed Go (now 1.26.x); `actions/setup-go@v6` adds a second Go (1.25.11) and sets `GOTOOLCHAIN=local`. With `GOROOT` unset, the Moderne CLI's Go recipe build helper drives the build with one `go` (1.25.11) but resolves the `compile` tool from the other install's GOROOT (1.26.x) — the compiler and driver disagree and the build aborts. It started failing on 2026-07-15 (nothing changed in this repo) once the runner image's default Go diverged from setup-go's pinned 1.25.

Reproduced locally by putting go 1.25.11 first on PATH with go 1.26.4 still reachable under `GOTOOLCHAIN=local` — same error. Pinning `GOROOT` to the on-PATH `go` makes it pass even with the second toolchain present; full script then installs all 213 Go recipes and writes the CSV.

## Fix

* `build-recipe-marketplace.sh`: export `GOROOT="$(go env GOROOT)"` before installing, so the build driver and compiler come from one toolchain. Kept in the script (not the workflow) so local runs are fixed too, per the "all logic lives in the script" design.
* `build-recipe-marketplace.yml`: upload the CLI `recipes.log` as an artifact on failure, so the next opaque install error is diagnosable instead of hidden.

- Complements #847, which stopped a single ecosystem's failure from discarding the whole marketplace CSV — this removes the underlying cause so Go recipes ship again instead of being silently skipped.