### PR TITLE
Fail marketplace run when an ecosystem ships no modules

### DIFF
--- a/.github/scripts/build-recipe-marketplace.sh
+++ b/.github/scripts/build-recipe-marketplace.sh
@@ -178,9 +178,17 @@ mkdir -p "$(dirname "$MARKETPLACE_CSV_DEST")"
 cp "$CSV_SRC" "$MARKETPLACE_CSV_DEST"
 log "Wrote marketplace CSV to $MARKETPLACE_CSV_DEST"
 
+# Export any ecosystem that shipped no modules so CI can fail the run; the CSV
+# above is still built and committed either way. No-op locally (var unset).
+PROBLEM=()
 if [ "${#SKIPPED[@]}" -gt 0 ]; then
   warn "Marketplace is missing modules for ecosystem(s): ${SKIPPED[*]} (toolchain unavailable)"
+  PROBLEM+=("${SKIPPED[@]}")
 fi
 if [ "${#FAILED[@]}" -gt 0 ]; then
   warn "Marketplace is missing modules for ecosystem(s): ${FAILED[*]} (install failed)"
+  PROBLEM+=("${FAILED[@]}")
+fi
+if [ "${#PROBLEM[@]}" -gt 0 ] && [ -n "${GITHUB_OUTPUT:-}" ]; then
+  printf 'failed-ecosystems=%s\n' "${PROBLEM[*]}" >> "$GITHUB_OUTPUT"
 fi

--- a/.github/workflows/build-recipe-marketplace.yml
+++ b/.github/workflows/build-recipe-marketplace.yml
@@ -52,6 +52,7 @@ jobs:
           go-version: '1.25'
 
       - name: Build marketplace CSV
+        id: build
         env:
           RECIPE_VERSIONS: ${{ matrix.versions }}
           # Isolate CLI state to the runner temp dir.
@@ -61,20 +62,30 @@ jobs:
 
       # Surface the CLI recipe logs (the real install error lives here, not stdout).
       - uses: actions/upload-artifact@v7
-        if: failure()
+        if: failure() || steps.build.outputs.failed-ecosystems != ''
         with:
           name: recipe-logs-${{ matrix.versions }}
           path: ${{ runner.temp }}/moderne-cli-home/recipes/**/.moderne/recipes.log
           if-no-files-found: ignore
 
+      # Upload before the gate below so the partial CSV still reaches the commit job.
       - uses: actions/upload-artifact@v7
         with:
           name: recipes-v5-${{ matrix.versions }}
           path: ${{ runner.temp }}/recipes-v5-${{ matrix.versions }}.csv
 
+      # Turn the run red when an ecosystem shipped no modules (still committed below).
+      - name: Fail run if any ecosystem was missing
+        if: steps.build.outputs.failed-ecosystems != ''
+        run: |
+          echo "::error title=Marketplace ecosystem missing::${{ matrix.versions }} marketplace built without ecosystem(s): ${{ steps.build.outputs.failed-ecosystems }}. The partial CSV was still committed; check the recipe-logs-${{ matrix.versions }} artifact, fix the install, and re-run."
+          exit 1
+
   commit:
     name: Commit marketplace CSVs
     needs: build
+    # Still commit the partial CSVs when a build job went red over a missing ecosystem.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
- When a recipe ecosystem fails to install (e.g. the Go GOROOT/two-toolchain issue that silently dropped all 198 Go modules from the marketplace CSVs), the build script now exports the skipped/failed ecosystems and a new gate step turns the run red so the gap is noticed. The partial CSVs are still committed — the commit job runs with `if: !cancelled()` — so nothing that did install is lost. The CLI recipe logs are also uploaded on this soft failure to aid diagnosis. This keeps #847's best-effort behavior while restoring an alert when the marketplace is incomplete.