### PR TITLE
Fix build-breaking heading anchor in csharp.md; flag classic heading ids in linter

### DIFF
--- a/docs/user-documentation/moderne-cli/how-to-guides/csharp.md
+++ b/docs/user-documentation/moderne-cli/how-to-guides/csharp.md
@@ -247,7 +247,7 @@ Data tables for each organization with rows are linked above
 
 ## Troubleshooting
 
-### `mod` runs Mono's tool instead of the Moderne CLI (`mod` returns: `Usage: mod.exe Url`) {#mod-runs-monos-tool-instead-of-the-moderne-cli}
+### `mod` runs Mono's tool instead of the Moderne CLI (`mod` returns: `Usage: mod.exe Url`) {/* #mod-runs-monos-tool-instead-of-the-moderne-cli */}
 
 When you install Mono on a Mac, you will often find that the `mod` command no longer does what you expect (you'll get weird HTML responses depending on what you enter). This is because Mono installs its own `mod` executable and adds its directory to your `PATH` (via `/etc/paths.d/mono-commands`). When it does that, the Mono `mod` typically takes higher precedence than the Moderne `mod`.
 

--- a/scripts/check-markdown.mjs
+++ b/scripts/check-markdown.mjs
@@ -172,9 +172,29 @@ const processor = unified()
  * @returns {Promise<{ rule: string, line: number, col: number, message: string, severity: string }[]>}
  */
 export async function checkMarkdown(content, filename) {
-  const file = new VFile({ value: content, path: filename });
-  const tree = processor.parse(file);
-  await processor.run(tree, file);
+  // Docusaurus extracts explicit heading ids (`## Heading {#custom-id}`) before
+  // MDX compilation. Our raw remark-mdx pipeline would instead parse `{#id}` as
+  // an MDX expression and crash acorn on the `#`, so strip the anchor first —
+  // trailing-only removal keeps every other line number intact.
+  const source = content.replace(
+    /^(#{1,6}[ \t].*?)[ \t]*\{#[a-zA-Z0-9_-]+\}[ \t]*$/gm,
+    '$1',
+  );
+  const file = new VFile({ value: source, path: filename });
+  let tree;
+  try {
+    tree = processor.parse(file);
+    await processor.run(tree, file);
+  } catch (err) {
+    const place = err?.place ?? err;
+    return [{
+      rule: err?.ruleId ?? err?.source ?? 'parse-error',
+      line: place?.line ?? 0,
+      col: place?.column ?? 0,
+      message: err?.reason ?? err?.message ?? String(err),
+      severity: 'error',
+    }];
+  }
   const isReleasesFile = /\bdocs[\\/]releases[\\/]/.test(filename ?? '');
   const isGeneratedFile = /\bdocs[\\/]user-documentation[\\/]recipes[\\/](recipe-catalog|lists)[\\/]/.test(filename ?? '') ||
     /\bdocs[\\/]user-documentation[\\/]moderne-cli[\\/]cli-reference\.md$/.test(filename ?? '') ||

--- a/scripts/check-markdown.mjs
+++ b/scripts/check-markdown.mjs
@@ -172,28 +172,38 @@ const processor = unified()
  * @returns {Promise<{ rule: string, line: number, col: number, message: string, severity: string }[]>}
  */
 export async function checkMarkdown(content, filename) {
-  // Docusaurus extracts explicit heading ids (`## Heading {#custom-id}`) before
-  // MDX compilation. Our raw remark-mdx pipeline would instead parse `{#id}` as
-  // an MDX expression and crash acorn on the `#`, so strip the anchor first —
-  // trailing-only removal keeps every other line number intact.
-  const source = content.replace(
-    /^(#{1,6}[ \t].*?)[ \t]*\{#[a-zA-Z0-9_-]+\}[ \t]*$/gm,
-    '$1',
-  );
+  const issues = [];
+
+  // Classic heading ids (`## Heading {#id}`) parse as an MDX expression and crash
+  // the build (markdown format defaults to mdx); flag, then strip so parsing continues.
+  const source = content.split('\n').map((line, i) => {
+    const m = line.match(/^(#{1,6}[ \t].*?)[ \t]*\{#([a-zA-Z0-9_-]+)\}[ \t]*$/);
+    if (!m) return line;
+    issues.push({
+      rule: 'no-classic-heading-id',
+      line: i + 1,
+      col: line.indexOf('{#') + 1,
+      message: `Classic heading id {#${m[2]}} breaks the MDX build. ` +
+        `Use the comment form instead: {/* #${m[2]} */}`,
+      severity: 'error',
+    });
+    return m[1];
+  }).join('\n');
+
   const file = new VFile({ value: source, path: filename });
-  let tree;
   try {
-    tree = processor.parse(file);
+    const tree = processor.parse(file);
     await processor.run(tree, file);
   } catch (err) {
     const place = err?.place ?? err;
-    return [{
+    issues.push({
       rule: err?.ruleId ?? err?.source ?? 'parse-error',
       line: place?.line ?? 0,
       col: place?.column ?? 0,
       message: err?.reason ?? err?.message ?? String(err),
       severity: 'error',
-    }];
+    });
+    return issues;
   }
   const isReleasesFile = /\bdocs[\\/]releases[\\/]/.test(filename ?? '');
   const isGeneratedFile = /\bdocs[\\/]user-documentation[\\/]recipes[\\/](recipe-catalog|lists)[\\/]/.test(filename ?? '') ||
@@ -201,7 +211,7 @@ export async function checkMarkdown(content, filename) {
     /\bdocs[\\/]user-documentation[\\/]moderne-platform[\\/]references[\\/]graphql-api-reference\.md$/.test(filename ?? '');
   const GENERATED_EXCLUDED = new Set(['no-h1-in-body', 'no-consecutive-blank-lines', 'unordered-list-marker-style']);
   const RELEASES_EXCLUDED = new Set(['unordered-list-marker-style', 'image-alt-text']);
-  return file.messages
+  const messages = file.messages
     .filter(msg => !(isReleasesFile && RELEASES_EXCLUDED.has(msg.ruleId)))
     .filter(msg => !(isGeneratedFile && GENERATED_EXCLUDED.has(msg.ruleId)))
     .map(msg => {
@@ -214,6 +224,7 @@ export async function checkMarkdown(content, filename) {
         severity: msg.fatal === true ? 'error' : 'warning',
       };
     });
+  return [...issues, ...messages];
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/check-markdown.test.mjs
+++ b/scripts/check-markdown.test.mjs
@@ -180,6 +180,29 @@ describe('valid-admonition-type', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Explicit heading ids
+//
+// Docusaurus supports `## Heading {#custom-id}`. The raw remark-mdx pipeline
+// would parse `{#id}` as an MDX expression and crash acorn on the `#`, so the
+// anchor must be stripped before parsing rather than aborting the whole run.
+// ---------------------------------------------------------------------------
+
+describe('explicit heading ids', () => {
+  it('does not crash on a heading with an explicit {#id} anchor', async () => {
+    const md = '### `mod` returns `Usage: mod.exe Url` {#mod-runs-monos-tool}\n\nBody.';
+    const issues = await checkMarkdown(md, 'test.md');
+    expect(issues.some(i => i.rule === 'parse-error')).toBe(false);
+  });
+
+  it('keeps line numbers accurate for issues after a heading id', async () => {
+    const md = '## Heading {#anchor}\n\nVisit {account} now.';
+    const issues = (await checkMarkdown(md, 'test.md')).filter(i => i.rule === 'no-bare-mdx-expression');
+    expect(issues).toHaveLength(1);
+    expect(issues[0].line).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Rule: unordered-list-marker-style
 //
 // STYLE_GUIDE Rule 3: use * for bullets, not -. Exception: docs/releases/

--- a/scripts/check-markdown.test.mjs
+++ b/scripts/check-markdown.test.mjs
@@ -182,19 +182,27 @@ describe('valid-admonition-type', () => {
 // ---------------------------------------------------------------------------
 // Explicit heading ids
 //
-// Docusaurus supports `## Heading {#custom-id}`. The raw remark-mdx pipeline
-// would parse `{#id}` as an MDX expression and crash acorn on the `#`, so the
-// anchor must be stripped before parsing rather than aborting the whole run.
+// Classic `## Heading {#id}` parses as an MDX expression and breaks the build,
+// so it is flagged. The MDX-comment form `{/* #id */}` compiles and is allowed.
 // ---------------------------------------------------------------------------
 
 describe('explicit heading ids', () => {
-  it('does not crash on a heading with an explicit {#id} anchor', async () => {
+  it('flags classic {#id} heading anchors as build-breaking', async () => {
     const md = '### `mod` returns `Usage: mod.exe Url` {#mod-runs-monos-tool}\n\nBody.';
+    const flagged = (await checkMarkdown(md, 'test.md')).filter(i => i.rule === 'no-classic-heading-id');
+    expect(flagged).toHaveLength(1);
+    expect(flagged[0].severity).toBe('error');
+    expect(flagged[0].line).toBe(1);
+  });
+
+  it('does not crash and does not flag the MDX-comment id form {/* #id */}', async () => {
+    const md = '### Heading {/* #my-id */}\n\nBody.';
     const issues = await checkMarkdown(md, 'test.md');
+    expect(issues.some(i => i.rule === 'no-classic-heading-id')).toBe(false);
     expect(issues.some(i => i.rule === 'parse-error')).toBe(false);
   });
 
-  it('keeps line numbers accurate for issues after a heading id', async () => {
+  it('keeps line numbers accurate for issues after a stripped anchor', async () => {
     const md = '## Heading {#anchor}\n\nVisit {account} now.';
     const issues = (await checkMarkdown(md, 'test.md')).filter(i => i.rule === 'no-bare-mdx-expression');
     expect(issues).toHaveLength(1);


### PR DESCRIPTION
## What broke the deploy

The [`Lint markdown` job on main](https://github.com/moderneinc/moderne-docs/actions/runs/29471067830/job/87534203060) crashed, blocking Build and Deploy — and the **Build itself was also broken**.

PR #854 added a classic explicit heading id to `docs/user-documentation/moderne-cli/how-to-guides/csharp.md`:

```markdown
### ...Moderne CLI (`mod` returns: `Usage: mod.exe Url`) {#mod-runs-monos-tool-instead-of-the-moderne-cli}
```

This repo's Docusaurus `markdown.format` is unset, so it defaults to **mdx**. Under mdx, `{#id}` is parsed as an MDX expression and acorn throws on the `#` (`Could not parse expression with acorn`). That broke two things:

* **Build**: `MDX compilation failed for csharp.md` — the classic `{#id}` heading syntax does not work when files compile as mdx.
* **Lint**: `scripts/check-markdown.mjs` hit the same parse error, but as an *uncaught exception* that aborted the entire run with a bare stack trace (no filename).

## Fix

**Doc** — convert to the MDX-comment id form, which compiles under mdx and which Docusaurus 3.9's headings plugin extracts into the same anchor:

```markdown
### ... {/* #mod-runs-monos-tool-instead-of-the-moderne-cli */}
```

**Linter** — `checkMarkdown()` now:
1. Detects classic `{#id}` heading anchors and reports them as a `no-classic-heading-id` **error** (pointing to the comment form) — instead of silently crashing.
2. Strips the anchor after flagging so the rest of the file still lints, with line numbers preserved.
3. Wraps parse/run in try/catch so any other unparseable MDX is reported as a per-file `parse-error` rather than aborting the whole run.

## Verification

* `SKIP_RECIPE_CATALOG=1 yarn build` → `[SUCCESS]`; anchor `mod-runs-monos-tool-instead-of-the-moderne-cli` confirmed present in the built HTML (so #854's broken-link fix stays intact).
* `yarn vitest run scripts/check-markdown.test.mjs` → 37 passed.
* `yarn lint:markdown` → exit 0.