### PR TITLE
Update agent-tools docs: retire create-organization, mark local MCP experimental

### DIFF
--- a/docs/hands-on-learning.md
+++ b/docs/hands-on-learning.md
@@ -80,7 +80,7 @@ Use AI as a co-author to build an OpenRewrite migration recipe from scratch. Lea
 
 **What you'll learn:**
 
-* The Moderne skills workflow for AI-assisted recipe development (`create-recipe` → `run-recipe` → `create-organization` → iterate)
+* The Moderne skills workflow for AI-assisted recipe development (`create-recipe` → `create-organization` → run with the CLI → iterate)
 * How to guide AI to choose the right recipe type (declarative YAML, imperative Java, Refaster templates)
 * Why test-driven development is a natural fit for AI-generated recipes
 * How to validate AI-generated recipes against real-world repositories

--- a/docs/hands-on-learning.md
+++ b/docs/hands-on-learning.md
@@ -76,11 +76,11 @@ Plan and execute a Spring Boot 4 migration with confidence. Learn to assess your
 
 ### AI-assisted recipe authoring
 
-Use AI as a co-author to build an OpenRewrite migration recipe from scratch. Learn a repeatable workflow for planning, building, and testing recipes with the Moderne CLI's built-in AI skills.
+Use AI as a co-author to build an OpenRewrite migration recipe from scratch. Learn a repeatable loop for planning, building, and testing recipes with an AI coding agent and the Moderne CLI.
 
 **What you'll learn:**
 
-* The Moderne skills workflow for AI-assisted recipe development (`create-recipe` → `create-organization` → run with the CLI → iterate)
+* A repeatable loop for AI-assisted recipe development (plan → build against real test cases → run on real repositories → iterate)
 * How to guide AI to choose the right recipe type (declarative YAML, imperative Java, Refaster templates)
 * Why test-driven development is a natural fit for AI-generated recipes
 * How to validate AI-generated recipes against real-world repositories

--- a/docs/hands-on-learning/agent-tools/module-2-install-agent-tools.md
+++ b/docs/hands-on-learning/agent-tools/module-2-install-agent-tools.md
@@ -64,11 +64,11 @@ Cursor and GitHub Copilot install skills *per project* (into `.cursor/rules/` or
 
 How you check depends on your agent. Restart the agent first if it was already running — most agents pick up new skills/MCP servers at startup.
 
-**Claude Code** - Open Claude Code in your workshop directory and type `/`. You should see entries like `/moderne:create-recipe`, `/moderne:run-recipe`, `/moderne:create-organization`, and `/moderne:analyze-impact`.
+**Claude Code** - Open Claude Code in your workshop directory and type `/`. You should see entries like `/moderne:create-recipe`, `/moderne:create-organization`, and `/moderne:edit-code`.
 
 **Cursor / GitHub Copilot** - Skills are loaded automatically as rules/instructions. Open the project in your editor and check that `.cursor/rules/moderne-*.mdc` or `.github/instructions/moderne-*.instructions.md` exist.
 
-**Windsurf, Amp, Codex** - Skills are referenced by name in your prompt (for example, "Using the run-recipe skill, ..."). See [Invoking skills](../../user-documentation/agent-tools/skills.md#invoking-skills) for the agent-specific syntax.
+**Windsurf, Amp, Codex** - Skills trigger automatically from what you ask for. Describe a task the skills cover (for example, "write me an OpenRewrite recipe that renames a method") and the agent loads the matching skill. See [Invoking skills](../../user-documentation/agent-tools/skills.md#invoking-skills).
 
 ### Takeaways
 
@@ -141,28 +141,34 @@ For Cursor, look at `.cursor/rules/moderne-create-recipe.mdc` in the current pro
 
 The file is plain markdown describing the recipe development workflow: when to choose declarative YAML vs Refaster vs imperative recipes, how to scaffold a project, how to write tests with `RewriteTest`, and how to handle imports correctly. This is what the agent reads before responding.
 
-The four skills you now have available are:
+The skills you now have available differ in what they need. These three work with the CLI alone:
 
 | Skill                     | What it does                                                                              |
 |---------------------------|-------------------------------------------------------------------------------------------|
-| **create-organization**   | Helps the agent assemble a curated set of repositories to test recipes against            |
 | **create-recipe**         | Guides the agent through recipe type selection, scaffolding, and writing tests            |
-| **run-recipe**            | Handles compiling, running, and diagnosing recipes against real repositories              |
-| **analyze-impact**        | Turns recipe run data into reports and visualizations                                     |
+| **create-organization**   | Helps the agent assemble a curated set of repositories to test recipes against            |
+| **prethink**              | Gives the agent pre-resolved architecture and risk context for a repository               |
+
+The rest teach the agent when to reach for a [Moderne MCP server tool](../../user-documentation/agent-tools/mcp/overview.md#available-tools), and need that server registered:
+
+| Skill                                        | What it does                                                          |
+|----------------------------------------------|------------------------------------------------------------------------|
+| **edit-code**                                | Applies a recipe across many files instead of hand-editing each one     |
+| **analyze-code**, **search-code**, **find-symbols** | Repo-wide analysis and type-aware search                        |
+| **change-symbols**, **pattern-replace**      | Atomic renames and one-shot structural rewrites                        |
+| **inspect-status**, **query-datatable**      | Readiness checks and SQL over recipe run data                          |
 
 See [Available skills](../../user-documentation/agent-tools/skills.md#available-skills) for the longer descriptions.
 
 #### Step 2 (optional): Try a skill with a throwaway prompt
 
-In Claude Code, invoke `/moderne:create-recipe` and give it a simple, throwaway request:
+Skills trigger from what you ask for. In your agent, give it a simple, throwaway request:
 
 ```
-/moderne:create-recipe
-
 I want to create an OpenRewrite recipe that renames the method getItems() to items() on com.example.ShoppingCart.
 ```
 
-For other agents, see [Invoking skills](../../user-documentation/agent-tools/skills.md#invoking-skills) for the right invocation syntax.
+The agent should load the `create-recipe` skill on its own. In Claude Code you can force it with `/moderne:create-recipe` if it doesn't.
 
 Notice how the skill shapes the agent's approach: it picks a recipe type *before* writing code, scaffolds a project layout, and writes tests with the `RewriteTest` framework. Without the skill, you'd typically get a single YAML or Java file with no tests.
 

--- a/docs/hands-on-learning/agent-tools/module-2-install-agent-tools.md
+++ b/docs/hands-on-learning/agent-tools/module-2-install-agent-tools.md
@@ -22,7 +22,7 @@ The Moderne CLI bundles two complementary kinds of agent tooling:
 
 | Component       | What it provides                                                                                              |
 |-----------------|---------------------------------------------------------------------------------------------------------------|
-| **Skills**      | Procedural instructions that teach an agent how to create recipes, run them, and analyze impact               |
+| **Skills**      | Procedural instructions that teach an agent how to create recipes, run them, and analyze code                 |
 | **MCP server**  | A live process that exposes tools for semantic search, navigation, refactoring, and recipe execution          |
 
 The install command auto-detects which coding agents are present on your machine and installs both components for each one. See [Skills for AI coding agents](../../user-documentation/agent-tools/skills.md) and the [MCP overview](../../user-documentation/agent-tools/mcp/overview.md) for full reference docs.
@@ -35,7 +35,7 @@ The install command auto-detects which coding agents are present on your machine
 mod config agent-tools install
 ```
 
-The CLI scans for installed coding agents (Claude Code, Cursor, GitHub Copilot, Windsurf, Sourcegraph Amp, OpenAI Codex), then installs skills and registers the MCP server for each one it finds. If no agents are detected, the CLI prints a message listing the supported agents and where it looked.
+The CLI scans for installed coding agents (Claude Code, Cursor, GitHub Copilot, Windsurf, Sourcegraph Amp, OpenAI Codex, opencode), then installs skills and registers the MCP server for each one it finds. If no agents are detected, the CLI prints a message listing the supported agents and where it looked.
 
 To remove everything later, run:
 
@@ -95,7 +95,7 @@ If you only want agent tools for one specific agent, use a per-agent subcommand.
 mod config agent-tools copilot install
 ```
 
-Other supported subcommands are `claude`, `cursor`, `windsurf`, `amp`, and `codex`. Each one installs both skills and the MCP server for that agent only. If the agent isn't detected on your system, the command prints a message and exits without making changes.
+Other supported subcommands are `claude`, `cursor`, `windsurf`, `amp`, `codex`, and `opencode`. Each one installs both skills and the MCP server for that agent only. If the agent isn't detected on your system, the command prints a message and exits without making changes.
 
 This is the right call when:
 

--- a/docs/hands-on-learning/agent-tools/module-2-install-agent-tools.md
+++ b/docs/hands-on-learning/agent-tools/module-2-install-agent-tools.md
@@ -20,12 +20,16 @@ In this module, you'll install the Moderne skills and the Moderne MCP server int
 
 The Moderne CLI bundles two complementary kinds of agent tooling:
 
-| Component       | What it provides                                                                                              |
-|-----------------|---------------------------------------------------------------------------------------------------------------|
-| **Skills**      | Procedural instructions that teach an agent how to create recipes, run them, and analyze code                 |
-| **MCP server**  | A live process that exposes tools for semantic search, navigation, refactoring, and recipe execution          |
+| Component                          | What it provides                                                                                              |
+|------------------------------------|---------------------------------------------------------------------------------------------------------------|
+| **Skills**                         | Procedural instructions that teach an agent how to create recipes, run them, and analyze code                 |
+| **MCP server** *(experimental)*    | A live process that exposes tools for semantic search, navigation, refactoring, and recipe execution          |
 
 The install command auto-detects which coding agents are present on your machine and installs both components for each one. See [Skills for AI coding agents](../../user-documentation/agent-tools/skills.md) and the [MCP overview](../../user-documentation/agent-tools/mcp/overview.md) for full reference docs.
+
+:::warning[Experimental]
+The local MCP server is experimental; skills are not. See the [MCP server overview](../../user-documentation/agent-tools/mcp/overview.md) for what may change.
+:::
 
 ### Steps
 
@@ -35,7 +39,7 @@ The install command auto-detects which coding agents are present on your machine
 mod config agent-tools install
 ```
 
-The CLI scans for installed coding agents (Claude Code, Cursor, GitHub Copilot, Windsurf, Sourcegraph Amp, OpenAI Codex, opencode), then installs skills and registers the MCP server for each one it finds. If no agents are detected, the CLI prints a message listing the supported agents and where it looked.
+The CLI scans for installed coding agents (Claude Code, Cursor, GitHub Copilot, Windsurf, Sourcegraph Amp, OpenAI Codex, OpenCode), then installs skills and registers the MCP server for each one it finds. If no agents are detected, the CLI prints a message listing the supported agents and where it looked.
 
 To remove everything later, run:
 
@@ -64,7 +68,7 @@ Cursor and GitHub Copilot install skills *per project* (into `.cursor/rules/` or
 
 How you check depends on your agent. Restart the agent first if it was already running — most agents pick up new skills/MCP servers at startup.
 
-**Claude Code** - Open Claude Code in your workshop directory and type `/`. You should see entries like `/moderne:create-recipe`, `/moderne:create-organization`, and `/moderne:edit-code`.
+**Claude Code** - Open Claude Code in your workshop directory and type `/`. You should see entries like `/moderne:create-recipe`, `/moderne:edit-code`, and `/moderne:find-symbols`.
 
 **Cursor / GitHub Copilot** - Skills are loaded automatically as rules/instructions. Open the project in your editor and check that `.cursor/rules/moderne-*.mdc` or `.github/instructions/moderne-*.instructions.md` exist.
 
@@ -141,24 +145,7 @@ For Cursor, look at `.cursor/rules/moderne-create-recipe.mdc` in the current pro
 
 The file is plain markdown describing the recipe development workflow: when to choose declarative YAML vs Refaster vs imperative recipes, how to scaffold a project, how to write tests with `RewriteTest`, and how to handle imports correctly. This is what the agent reads before responding.
 
-The skills you now have available differ in what they need. These three work with the CLI alone:
-
-| Skill                     | What it does                                                                              |
-|---------------------------|-------------------------------------------------------------------------------------------|
-| **create-recipe**         | Guides the agent through recipe type selection, scaffolding, and writing tests            |
-| **create-organization**   | Helps the agent assemble a curated set of repositories to test recipes against            |
-| **prethink**              | Gives the agent pre-resolved architecture and risk context for a repository               |
-
-The rest teach the agent when to reach for a [Moderne MCP server tool](../../user-documentation/agent-tools/mcp/overview.md#available-tools), and need that server registered:
-
-| Skill                                        | What it does                                                          |
-|----------------------------------------------|------------------------------------------------------------------------|
-| **edit-code**                                | Applies a recipe across many files instead of hand-editing each one     |
-| **analyze-code**, **search-code**, **find-symbols** | Repo-wide analysis and type-aware search                        |
-| **change-symbols**, **pattern-replace**      | Atomic renames and one-shot structural rewrites                        |
-| **inspect-status**, **query-datatable**      | Readiness checks and SQL over recipe run data                          |
-
-See [Available skills](../../user-documentation/agent-tools/skills.md#available-skills) for the longer descriptions.
+The install put several more skills alongside this one. Most of them front a [Moderne MCP server tool](../../user-documentation/agent-tools/mcp/overview.md#available-tools) and need that server registered; a couple work with the CLI alone. See [Available skills](../../user-documentation/agent-tools/skills.md#available-skills) for the full list and what each one covers.
 
 #### Step 2 (optional): Try a skill with a throwaway prompt
 

--- a/docs/hands-on-learning/agent-tools/module-5-mcp.md
+++ b/docs/hands-on-learning/agent-tools/module-5-mcp.md
@@ -35,6 +35,7 @@ Each agent has its own configuration mechanism. The CLI handles the differences 
 | GitHub Copilot  | `.vscode/mcp.json` and `~/.copilot/mcp-config.json` |
 | Sourcegraph Amp | Registered via `amp mcp add`                        |
 | OpenAI Codex    | Registered via `codex mcp add`                      |
+| opencode        | `~/.config/opencode/opencode.json`                  |
 
 For Claude Code, list registered MCP servers:
 
@@ -153,11 +154,25 @@ Pick a class or method in one of the workspace repositories that has obvious ren
 
 `change_method_name` updates the declaration and **every call site** atomically, just like an IDE rename across the whole workspace. Compare that to a regex find-and-replace that would also touch comments, string literals, and unrelated methods of the same name.
 
-#### Step 3 (optional): Try `pattern_replace` for a Refaster-style change
+#### Step 3 (optional): Try `pattern_replace` for a structural rewrite
 
-`pattern_replace` runs a Refaster template across the codebase. Provide a Java class with `@BeforeTemplate` and `@AfterTemplate` methods, and the agent applies it everywhere the pattern matches. This is the right tool when you have a mechanical pattern that's identical across many call sites (for example, replacing `Optional.ofNullable(x).orElse(y)` with `x != null ? x : y`).
+`pattern_replace` compiles a Kotlin recipe DSL at runtime and runs it across the codebase. You express the change as a `rewrite { before } to { after }` pair, and the agent applies it everywhere the `before` pattern matches. It's the right tool for a mechanical, structural rewrite that repeats across many call sites when no marketplace recipe fits, such as replacing `Arrays.asList(a, b)` with `List.of(a, b)`:
 
-See the [Refaster template documentation](../../user-documentation/recipes/authoring-recipes/concepts/recipes.md#refaster-template-recipes) for how the templates are structured. Most agents can write the template for you if you describe the change in plain English.
+```kotlin
+import org.openrewrite.Recipe
+import org.openrewrite.recipe
+
+val ArraysAsListToListOf: Recipe = recipe(
+    displayName = "Use `List.of` instead of `Arrays.asList`",
+    description = "Replace immutable Arrays.asList with List.of.",
+) {
+    edit {
+        rewrite { a: Any, b: Any -> java.util.Arrays.asList(a, b) } to { a, b -> java.util.List.of(a, b) }
+    }
+}
+```
+
+You don't need to write the DSL by hand. Describe the change in plain English and most agents will generate the recipe source for you. Reach for `edit_code` first, though, since `pattern_replace` is the fallback for when no curated marketplace recipe matches the change you want.
 
 #### Step 4: Revert if needed
 
@@ -171,7 +186,7 @@ git restore .
 ### Takeaways
 
 * MCP refactoring tools update **every reference** atomically. They are not text replacements.
-* Use `change_type`/`change_method_name` for clean renames. Use `pattern_replace` (Refaster) when the change is structural and repeated across call sites.
+* Use `change_type`/`change_method_name` for clean renames. Use `pattern_replace` (a Kotlin recipe DSL) when the change is structural and repeated across call sites.
 * For more complex changes, run an existing recipe (`run_recipe`) instead — see Exercise 5-4.
 
 ---
@@ -180,16 +195,16 @@ git restore .
 
 ### Goals for this exercise
 
-* See the agent invoke `search_recipes`, `learn_recipe`, and `run_recipe`
+* See the agent invoke `analyze_code`, `learn_recipe`, and `run_recipe`
 * Connect what you've learned in earlier modules: the agent uses Prethink + Trigrep + recipes to drive a fix
 
 ### Steps
 
 #### Step 1: Ask the agent to find a relevant recipe
 
-> Use `search_recipes` to find an OpenRewrite recipe that upgrades dependencies with known vulnerabilities. Show me the top 3 results.
+> Use `analyze_code` to find an OpenRewrite recipe that identifies dependencies with known vulnerabilities. Show me the top 3 results.
 
-The `search_recipes` tool returns a paginated list of matching recipes ranked by relevance. The agent picks one and uses `learn_recipe` to retrieve its description, options, and data table schemas before deciding to run it.
+The `analyze_code` tool returns a list of matching recipes ranked by relevance. The agent picks one and uses `learn_recipe` to retrieve its description, options, and data table schemas before deciding to run it.
 
 #### Step 2: Run the recipe
 

--- a/docs/hands-on-learning/agent-tools/module-5-mcp.md
+++ b/docs/hands-on-learning/agent-tools/module-5-mcp.md
@@ -198,7 +198,7 @@ The `search_recipes` tool returns a paginated list of matching recipes ranked by
 The `query_datatable` tool runs SQL against the recipe's output data tables (DuckDB under the hood). This is how the agent goes from raw recipe output to a structured answer.
 
 :::tip
-This is the same workflow `analyze-impact` skill walks the agent through, but driven by you. If you want the skill to do the orchestration, invoke it explicitly: `/moderne:analyze-impact` (Claude Code) or the equivalent in your agent.
+The `query-datatable` skill teaches the agent when to reach for this tool on its own. Ask a question about the run's results in plain language and it should get there without you naming the tool.
 :::
 
 ### Takeaways

--- a/docs/hands-on-learning/agent-tools/module-5-mcp.md
+++ b/docs/hands-on-learning/agent-tools/module-5-mcp.md
@@ -6,6 +6,10 @@ draft: true
 
 # Module 5: MCP server
 
+:::warning[Experimental]
+This module uses the local MCP server, which is experimental. See the [MCP server overview](../../user-documentation/agent-tools/mcp/overview.md) for what may change, including why some steps here may drift from what your CLI does.
+:::
+
 In this final module, you'll see how the Moderne MCP server gives your AI coding agent direct access to indexed search, semantic navigation, codebase-wide refactoring, and recipe execution. You already installed it in [Module 2](./module-2-install-agent-tools.md) (it ships alongside skills via `mod config agent-tools install`). Now you'll exercise the tools.
 
 For the full tool catalog and architecture details, see the [MCP server overview](../../user-documentation/agent-tools/mcp/overview.md). This module is hands-on practice.
@@ -35,7 +39,7 @@ Each agent has its own configuration mechanism. The CLI handles the differences 
 | GitHub Copilot  | `.vscode/mcp.json` and `~/.copilot/mcp-config.json` |
 | Sourcegraph Amp | Registered via `amp mcp add`                        |
 | OpenAI Codex    | Registered via `codex mcp add`                      |
-| opencode        | `~/.config/opencode/opencode.json`                  |
+| OpenCode        | `~/.config/opencode/opencode.json`                  |
 
 For Claude Code, list registered MCP servers:
 

--- a/docs/hands-on-learning/agent-tools/workshop-overview.md
+++ b/docs/hands-on-learning/agent-tools/workshop-overview.md
@@ -41,7 +41,7 @@ You will also need:
 
 * The [Moderne CLI](../../user-documentation/moderne-cli/getting-started/cli-intro.md) (version 4.2.1 or higher recommended). You'll install this in [Module 1](./module-1-cli-and-lsts.md)
 * A JDK installed locally (Java 17 or higher recommended)
-* An AI coding agent. The exercises demo with [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview), but every step works with [Cursor](https://cursor.sh), [GitHub Copilot](https://github.com/features/copilot), [Windsurf](https://codeium.com/windsurf), [Sourcegraph Amp](https://ampcode.com), or [OpenAI Codex](https://openai.com/codex)
+* An AI coding agent. The exercises demo with [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview), but every step works with [Cursor](https://cursor.sh), [GitHub Copilot](https://github.com/features/copilot), [Windsurf](https://codeium.com/windsurf), [Sourcegraph Amp](https://ampcode.com), [OpenAI Codex](https://openai.com/codex), or [opencode](https://opencode.ai)
 * A Moderne account on [app.moderne.io](https://app.moderne.io) (a free login is sufficient)
 
 If you've never used the Moderne CLI before, work through the [Introduction to OpenRewrite](../introduction/workshop-overview.md) workshop first. This workshop assumes you're comfortable running `mod` commands.
@@ -55,7 +55,7 @@ Most agents ask for your approval before running tools (reading files, executing
 :::
 
 :::tip[Agent-agnostic by design]
-Examples in this workshop demo with Claude Code (slash commands like `/moderne:create-recipe`, the `claude` startup command). Every step works the same way in Cursor, GitHub Copilot, Windsurf, Amp, and Codex. When you see a Claude-specific command, substitute the equivalent for your agent. See [Invoking skills](../../user-documentation/agent-tools/skills.md#invoking-skills) for the per-agent syntax.
+Examples in this workshop demo with Claude Code (slash commands like `/moderne:create-recipe`, the `claude` startup command). Every step works the same way in Cursor, GitHub Copilot, Windsurf, Amp, Codex, and opencode. When you see a Claude-specific command, substitute the equivalent for your agent. See [Invoking skills](../../user-documentation/agent-tools/skills.md#invoking-skills) for the per-agent syntax.
 :::
 
 ## Workshop modules

--- a/docs/hands-on-learning/agent-tools/workshop-overview.md
+++ b/docs/hands-on-learning/agent-tools/workshop-overview.md
@@ -41,7 +41,7 @@ You will also need:
 
 * The [Moderne CLI](../../user-documentation/moderne-cli/getting-started/cli-intro.md) (version 4.2.1 or higher recommended). You'll install this in [Module 1](./module-1-cli-and-lsts.md)
 * A JDK installed locally (Java 17 or higher recommended)
-* An AI coding agent. The exercises demo with [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview), but every step works with [Cursor](https://cursor.sh), [GitHub Copilot](https://github.com/features/copilot), [Windsurf](https://codeium.com/windsurf), [Sourcegraph Amp](https://ampcode.com), [OpenAI Codex](https://openai.com/codex), or [opencode](https://opencode.ai)
+* An AI coding agent. The exercises demo with [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview), but every step works with [Cursor](https://cursor.sh), [GitHub Copilot](https://github.com/features/copilot), [Windsurf](https://codeium.com/windsurf), [Sourcegraph Amp](https://ampcode.com), [OpenAI Codex](https://openai.com/codex), or [OpenCode](https://opencode.ai)
 * A Moderne account on [app.moderne.io](https://app.moderne.io) (a free login is sufficient)
 
 If you've never used the Moderne CLI before, work through the [Introduction to OpenRewrite](../introduction/workshop-overview.md) workshop first. This workshop assumes you're comfortable running `mod` commands.
@@ -55,7 +55,7 @@ Most agents ask for your approval before running tools (reading files, executing
 :::
 
 :::tip[Agent-agnostic by design]
-Examples in this workshop demo with Claude Code (slash commands like `/moderne:create-recipe`, the `claude` startup command). Every step works the same way in Cursor, GitHub Copilot, Windsurf, Amp, Codex, and opencode. When you see a Claude-specific command, substitute the equivalent for your agent. See [Invoking skills](../../user-documentation/agent-tools/skills.md#invoking-skills) for the per-agent syntax.
+Examples in this workshop demo with Claude Code (slash commands like `/moderne:create-recipe`, the `claude` startup command). Every step works the same way in Cursor, GitHub Copilot, Windsurf, Amp, Codex, and OpenCode. When you see a Claude-specific command, substitute the equivalent for your agent. See [Invoking skills](../../user-documentation/agent-tools/skills.md#invoking-skills) for the per-agent syntax.
 :::
 
 ## Workshop modules

--- a/docs/hands-on-learning/ai-recipes/module-1-plan.md
+++ b/docs/hands-on-learning/ai-recipes/module-1-plan.md
@@ -18,13 +18,14 @@ In this module, you'll learn about the Moderne skills workflow for AI-assisted r
 
 The Moderne CLI ships with AI skills that teach your coding agent how to work with OpenRewrite recipes effectively. Instead of starting from scratch, these skills give your agent procedural knowledge about recipe development.
 
-The three skills you'll use today:
+The two skills you'll use today:
 
 | Skill                   | What it does                                                                                                                                      |
 |-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
 | **create-recipe**       | Guides the agent through recipe type selection, project scaffolding, writing tests, and implementing recipes following OpenRewrite best practices |
-| **run-recipe**          | Handles compiling the recipe, setting up a working set of real repositories, running the recipe, and diagnosing results                           |
 | **create-organization** | Helps find and assemble a curated set of repositories to test against                                                                             |
+
+In Module 3 you'll run the recipe against those repositories with the `mod` CLI directly.
 
 These skills are supported across multiple agents. See [Skills for AI coding agents](../../user-documentation/agent-tools/skills.md) for details on supported agents and how to invoke skills in each one.
 
@@ -44,18 +45,14 @@ mod config agent-tools install
 
 #### Step 2: Verify the skills are available
 
-In Claude Code, type `/` and you should see the Moderne skills listed (e.g., `/moderne:create-recipe`). (For other agents, see the [Skills for AI coding agents](../../user-documentation/agent-tools/skills.md) docs for how to verify installation and invoke the skills.)
+In Claude Code, type `/` and you should see the Moderne skills listed (e.g., `/moderne:create-recipe`). (For other agents, see the [Skills for AI coding agents](../../user-documentation/agent-tools/skills.md) docs for how to verify installation.)
 
 #### Step 3: Try it out
 
-Invoke the `create-recipe` skill with a simple, throwaway request to see what it does. In Claude Code:
-
-```
-/moderne:create-recipe
-```
+Skills trigger from what you ask for — describe a recipe task and the agent loads `create-recipe` on its own.
 
 :::tip
-If you're using a different agent, invoke the skill using the method described in [Skills for AI coding agents](../../user-documentation/agent-tools/skills.md). For example, in Cursor use `@moderne-create-recipe`, or in Windsurf reference the skill by name in your prompt.
+If the agent doesn't pick up the skill, you can force it in Claude Code with `/moderne:create-recipe`.
 :::
 
 When prompted, give it a simple task:
@@ -91,7 +88,7 @@ When you've seen enough, you can stop the agent since you won't be using this ou
 
 ### How this maps to the workshop
 
-The skills you tried in Exercise 1-1 form an iterative development loop: identify the transformation, choose the recipe type, write tests, implement the recipe, and test with `run-recipe`. Each module in this workshop maps to a phase of that loop:
+The skills you tried in Exercise 1-1 form an iterative development loop: identify the transformation, choose the recipe type, write tests, implement the recipe, and test it against real repositories. Each module in this workshop maps to a phase of that loop:
 
 * **This exercise:** Plan what the recipe should do, scope it down, and confirm recipe type(s)
 * **Module 2:** Build the recipe with AI assistance, writing tests first to validate output
@@ -137,8 +134,6 @@ Throughout this workshop, you'll find **suggested prompts** in collapsible secti
 <details>
 <summary>Suggested prompt</summary>
 
-> `/moderne:create-recipe`
->
 > I want to create an OpenRewrite recipe to help migrate Java projects from Jackson 2.x to Jackson 3.x. Please read the official migration guide at https://github.com/FasterXML/jackson/blob/main/jackson3/MIGRATING_TO_JACKSON_3.md and propose a comprehensive list of code changes that could be automated with OpenRewrite recipes. Don't reference or copy from any existing OpenRewrite Jackson recipes. Build the plan from the migration guide itself.
 >
 > For each change, note:

--- a/docs/hands-on-learning/ai-recipes/module-1-plan.md
+++ b/docs/hands-on-learning/ai-recipes/module-1-plan.md
@@ -1,80 +1,75 @@
 ---
 sidebar_label: "Module 1: Plan"
-description: Install the Moderne skills, try them out, and plan a Jackson 2→3 migration recipe with AI assistance.
+description: Set up your coding agent, see the recipe development loop, and plan a Jackson 2→3 migration recipe with AI assistance.
 ---
 
 # Module 1: Plan
 
-In this module, you'll learn about the Moderne skills workflow for AI-assisted recipe development. After that, you'll learn how to use AI to research and plan a Jackson 2.x → 3.x migration recipe. The key takeaway: **start with a plan, not with code.**
+In this module, you'll see the development loop this workshop follows for AI-assisted recipe authoring. After that, you'll learn how to use AI to research and plan a Jackson 2.x → 3.x migration recipe. The key takeaway: **start with a plan, not with code.**
 
-## Exercise 1-1: Try the Moderne skills
+## Exercise 1-1: Set up your agent and see the loop
 
 ### Goals for this exercise
 
-* Install the Moderne skills and verify they work
-* See firsthand how skills change the agent's behavior
+* Get your agent ready to work on recipes
+* See the development loop the rest of this workshop follows
 
 ### Key concepts
 
-The Moderne CLI ships with AI skills that teach your coding agent how to work with OpenRewrite recipes effectively. Instead of starting from scratch, these skills give your agent procedural knowledge about recipe development.
+Building a recipe with an agent is a loop, not a single prompt:
 
-The two skills you'll use today:
+1. Tell the agent what kind of recipe you want.
+2. Have it find repositories to test against, and discover test cases from what it finds in real code.
+3. Implement the recipe until it passes those test cases.
+4. Run it against the real repositories and check they still compile and pass their own tests.
+5. If the results fall short, go back to step 2 and iterate. If they're clean, decide whether you're done or whether the test set should be wider.
 
-| Skill                   | What it does                                                                                                                                      |
-|-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
-| **create-recipe**       | Guides the agent through recipe type selection, project scaffolding, writing tests, and implementing recipes following OpenRewrite best practices |
-| **create-organization** | Helps find and assemble a curated set of repositories to test against                                                                             |
+Each module in this workshop is one part of that loop: plan here, build in Module 2, test and iterate in Module 3.
 
-In Module 3 you'll run the recipe against those repositories with the `mod` CLI directly.
+Coding models already know OpenRewrite reasonably well — the framework and its recipes are open source and well represented in training data — so you can work this loop with your agent and the `mod` CLI alone.
 
-These skills are supported across multiple agents. See [Skills for AI coding agents](../../user-documentation/agent-tools/skills.md) for details on supported agents and how to invoke skills in each one.
+The CLI can also install a `create-recipe` skill that encodes recipe type selection, project layout, and `RewriteTest` conventions, so the agent doesn't have to rediscover them each session. It's an accelerator, not a prerequisite.
 
 :::note
-This workshop demos with **Claude Code**, but skills are also supported for Windsurf, Sourcegraph Amp, Cursor, GitHub Copilot, and Codex. Results may vary across agents, but the workflow and principles are the same.
+This workshop demos with **Claude Code**, but the same workflow applies to Windsurf, Sourcegraph Amp, Cursor, GitHub Copilot, OpenAI Codex, and OpenCode. Results may vary across agents, but the loop and the principles are the same.
 :::
 
 ### Steps
 
-#### Step 1: Install the Moderne skills
-
-If you haven't already, install the Moderne skills for all detected coding agents using the CLI:
+#### Step 1 (optional): Install the Moderne skills
 
 ```bash
 mod config agent-tools install
 ```
 
-#### Step 2: Verify the skills are available
+In Claude Code, type `/` afterward and you should see entries like `/moderne:create-recipe`. For other agents, see [Skills for AI coding agents](../../user-documentation/agent-tools/skills.md) for install locations and how to verify.
 
-In Claude Code, type `/` and you should see the Moderne skills listed (e.g., `/moderne:create-recipe`). (For other agents, see the [Skills for AI coding agents](../../user-documentation/agent-tools/skills.md) docs for how to verify installation.)
-
-#### Step 3: Try it out
-
-Skills trigger from what you ask for — describe a recipe task and the agent loads `create-recipe` on its own.
-
-:::tip
-If the agent doesn't pick up the skill, you can force it in Claude Code with `/moderne:create-recipe`.
+:::note
+`create-recipe` requires Moderne CLI 4.5.3 or later. On an earlier version, skip this step — everything below works without it.
 :::
 
-When prompted, give it a simple task:
+#### Step 2: Try a throwaway request
+
+Open your agent and give it a small, self-contained task:
 
 > I want to create an OpenRewrite recipe that renames the method `getItems()` to `items()` on `com.example.ShoppingCart`.
 
-Watch how the agent responds. Don't worry about the output. Just notice how the skill shapes the agent's approach:
+Don't worry about the output. Watch the shape of the response instead:
 
-* The agent should choose a [recipe type](../../user-documentation/recipes/authoring-recipes/writing-recipes/types-of-recipes.md) *before* writing any code (declarative vs Refaster vs imperative)
-* The skill writes **tests** using OpenRewrite's `RewriteTest` framework with before/after code snippets
-* It follows a structured project layout rather than just dumping code (or YAML) in a single file
+* Does it choose a [recipe type](../../user-documentation/recipes/authoring-recipes/writing-recipes/types-of-recipes.md) *before* writing code (declarative vs Refaster vs imperative)?
+* Does it write **tests** with OpenRewrite's `RewriteTest` framework, using before/after code snippets?
+* Does it lay out a project, rather than dumping everything in one file?
 
-Without the skill, you may have only gotten a single YAML recipe file with no tests.
+If your agent skips these, say so directly — "choose the recipe type first" or "write the tests before the implementation." That kind of correction is the whole job in Module 2, and it's worth seeing now on something disposable.
 
 :::tip
-When you've seen enough, you can stop the agent since you won't be using this output.
+When you've seen enough, stop the agent. You won't be using this output.
 :::
 
 ### Takeaways
 
-* The Moderne skills give your AI coding agent specialized, procedural knowledge about OpenRewrite recipe development and usage.
-* Human judgment is still essential at every step (the agent proposes, you guide it).
+* Recipe development with an agent is an iterative loop, and the test repositories are what tell you whether you're done.
+* Human judgment is essential at every step. The agent proposes, you guide it.
 
 ---
 
@@ -88,15 +83,13 @@ When you've seen enough, you can stop the agent since you won't be using this ou
 
 ### How this maps to the workshop
 
-The skills you tried in Exercise 1-1 form an iterative development loop: identify the transformation, choose the recipe type, write tests, implement the recipe, and test it against real repositories. Each module in this workshop maps to a phase of that loop:
+Here is where each module lands in the loop from Exercise 1-1:
 
 * **This exercise:** Plan what the recipe should do, scope it down, and confirm recipe type(s)
 * **Module 2:** Build the recipe with AI assistance, writing tests first to validate output
 * **Module 3:** Run the recipe against real repos, compare to desired results, and iterate
 
-:::tip
-You can open the `create-recipe` skill file on your machine to see the full workflow. See [Skills for AI coding agents](../../user-documentation/agent-tools/skills.md#supported-agents) for install locations.
-:::
+The loop rarely runs cleanly end to end on the first pass. Module 3 sends you back to Module 2 more than once, and that's the normal shape of the work rather than a sign something went wrong.
 
 ### About the Jackson 2→3 migration
 
@@ -121,7 +114,7 @@ This is where your recipe project will live for the rest of the workshop.
 
 #### Step 2: Research the migration
 
-Invoke the `create-recipe` skill, then ask your agent to research the migration. Point it at the [source documentation](https://github.com/FasterXML/jackson/blob/main/jackson3/MIGRATING_TO_JACKSON_3.md) and ask it to propose automatable changes. A few tips for crafting your prompt:
+Ask your agent to research the migration. Point it at the [source documentation](https://github.com/FasterXML/jackson/blob/main/jackson3/MIGRATING_TO_JACKSON_3.md) and ask it to propose automatable changes. A few tips for crafting your prompt:
 
 * **Give it a primary source.** Point the agent at the [migration guide URL](https://github.com/FasterXML/jackson/blob/main/jackson3/MIGRATING_TO_JACKSON_3.md) so it works from authoritative documentation, not its own training data.
 * **Ask for structured output.** Request a list with specific information that you can use to validate the plan and guide the process (e.g. what changed, recipe type, priority) so the output is easy to review and scope in Step 3.
@@ -160,7 +153,7 @@ If the agent already proposed phases, review the first phase and refine it. If n
 
 #### Step 4: Review the subset
 
-Your results will vary, and that's expected. Most of the first phase will likely be declarative recipes, which is a good sign. The skill encourages using the simplest recipe type possible. But there is often the need for a transformation that requires something more, so one or two Refaster and/or imperative recipes will likely be proposed as well (especially since you asked for it to). Review the agent's proposed subset and recipe type suggestions. Key things to check:
+Your results will vary, and that's expected. Most of the first phase will likely be declarative recipes, which is a good sign — the simplest recipe type that does the job is the right one. But there is often the need for a transformation that requires something more, so one or two Refaster and/or imperative recipes will likely be proposed as well (especially since you asked for it to). Review the agent's proposed subset and recipe type suggestions. Key things to check:
 
 * Package renames, type renames, method renames, and dependency changes should all be **declarative YAML** using existing OpenRewrite primitives
 * Expression-level replacements (e.g., replacing one method chain with another) are a good fit for **Refaster templates**

--- a/docs/hands-on-learning/ai-recipes/module-2-build.md
+++ b/docs/hands-on-learning/ai-recipes/module-2-build.md
@@ -5,7 +5,7 @@ description: Build a Jackson 2→3 migration recipe with AI using test-driven de
 
 # Module 2: Build
 
-In this module, you'll build the Jackson 2→3 migration recipe with AI assistance. You should still be in the same agent session from [Module 1](./module-1-plan.md), with the `create-recipe` skill active and your plan in context. If you need to start a new session, re-invoke the skill and point the agent at your plan file before continuing.
+In this module, you'll build the Jackson 2→3 migration recipe with AI assistance. You should still be in the same agent session from [Module 1](./module-1-plan.md), with your plan in context. If you need to start a new session, point the agent at your plan file before continuing.
 
 You'll follow a test-driven development (TDD) approach: write tests first, validate them, then implement the recipe. Along the way, you'll create a declarative YAML recipe and an imperative Java recipe.
 
@@ -24,7 +24,7 @@ The agent will often try to do multiple steps at once. The exercises below break
 
 #### Step 1: Scaffold the project
 
-Ask the agent to set up the project. The skill includes the project structure, build configuration, and dependencies needed for recipe development, so it can scaffold a project from scratch.
+Ask the agent to set up the project. Recipe projects follow a conventional structure and build configuration, so the agent can scaffold one from scratch.
 
 <details>
 <summary>Suggested prompt</summary>
@@ -55,7 +55,7 @@ If you're not already working in an IDE, now is a good time to open the project 
 
 ### Takeaways
 
-* The skill includes the build configuration and project structure, so the agent can scaffold from scratch.
+* Recipe project structure and build configuration are conventional, so the agent can scaffold from scratch.
 * Always verify the project builds before you start adding code.
 
 ---
@@ -64,14 +64,14 @@ If you're not already working in an IDE, now is a good time to open the project 
 
 ### Goals for this exercise
 
-* See how the skill drives test-first development
+* Practice driving the agent through test-first development
 * Validate AI-generated test cases and recipe output
 * Create a composite YAML recipe using existing OpenRewrite primitives
 * Iterate on test failures
 
 ### Context
 
-The skill's workflow guides the agent to write tests first, then implement. OpenRewrite's testing framework uses a before/after pattern that works exceptionally well with this approach:
+Write the tests first, then implement. OpenRewrite's testing framework uses a before/after pattern that works exceptionally well with this approach:
 * **Before**: The code as it looks today (Jackson 2.x)
 * **After**: The code as it should look after migration (Jackson 3.x)
 
@@ -81,7 +81,7 @@ This is exactly the kind of paired example that an agent is good at generating, 
 
 #### Step 1: Start building
 
-Tell the agent to start on the declarative transformations. The skill's workflow already specifies that the agent should write tests first. The suggested prompt reinforces this, which can't hurt (especially when prompting step by step). If you want to see how the agent acts without that reinforced instruction, try without it, but watch it and make sure it writes tests first.
+Tell the agent to start on the declarative transformations, and ask for tests first. Agents often reach for the implementation before the test, so it is worth being explicit. If you want to see what yours does unprompted, leave that instruction out — but watch it, and redirect it if it skips the tests.
 
 <details>
 <summary>Suggested prompt</summary>
@@ -266,7 +266,7 @@ Just as before, verify the before/after examples are accurate and that there's a
 
 #### Step 3: Review the imperative recipe
 
-The skill covers imperative recipe patterns, so the agent should follow best practices. Key things to verify:
+Imperative recipes follow well-established patterns that the agent should already know. Key things to verify:
 * Does it call `super.visitX()` to continue tree traversal?
 * Is the matching logic correct for the specific transformation?
 * Does it handle edge cases (e.g., the negative case from your tests)?

--- a/docs/hands-on-learning/ai-recipes/module-3-test.md
+++ b/docs/hands-on-learning/ai-recipes/module-3-test.md
@@ -45,8 +45,6 @@ The `create-organization` skill helps find repos by technology. It uses `gh sear
 <details>
 <summary>Suggested prompt</summary>
 
-> /moderne:create-organization
->
 > Find 5-10 small-to-medium Java repositories on GitHub that use Jackson 2.x (com.fasterxml.jackson). I need a mix of Maven and Gradle projects. Create a repos.csv for testing a Jackson 2→3 migration recipe.
 
 </details>
@@ -64,7 +62,7 @@ This takes a few minutes. The skill's workflow includes syncing the working set 
 
 ### Goals for this exercise
 
-* Run your recipe against real repositories using the `run-recipe` skill
+* Run your recipe against real repositories with the Moderne CLI
 * Use the agent to perform pre-analysis and set expectations
 * Compare predictions to actual results
 
@@ -72,23 +70,35 @@ This takes a few minutes. The skill's workflow includes syncing the working set 
 
 #### Step 1: Run the recipe
 
-Use the `run-recipe` skill to run your recipe against the working set.
+Have the agent drive the CLI through the full loop. The `create-recipe` skill documents these commands, so the agent should know the sequence.
 
 <details>
 <summary>Suggested prompt</summary>
 
-> /moderne:run-recipe
->
-> Run my Jackson 2→3 migration recipe against the working set. The recipe is in this project (development mode). Before running, analyze the source code in the working set to predict which files should be affected.
+> Run my Jackson 2→3 migration recipe against the working set. The recipe is in this project, so publish it to Maven local, install the JAR, and set it as the active recipe. Before running, search the source code in the working set to predict which files should be affected. Then build the LSTs and run the recipe, and compare the results to your predictions.
 
 </details>
 
-The skill handles the full workflow: compiling your recipe, searching the working set for target patterns (pre-analysis), running the recipe, comparing results to predictions, and reporting findings. This will take several minutes. Watch as it goes.
+For reference, the underlying commands are:
+
+```bash
+./gradlew publishToMavenLocal
+mod config recipes jar install <groupId>:<artifactId>:<version>
+mod config recipes active set <RECIPE_PATH>
+mod build working-set --no-download --streaming
+mod run working-set --active-recipe --streaming --parallel 2
+```
+
+This will take several minutes. Watch as it goes.
+
+:::note
+LSTs must be built before the run. If every repo reports `runOutcome=Skipped`, the `mod build` step didn't complete.
+:::
 
 #### Step 2: Review the results
 
-Once the skill finishes, review its output. The skill should have reported:
-* Which repos it predicted would be affected (from pre-analysis)
+Once the run finishes, review the output. You want to know:
+* Which repos the agent predicted would be affected (from pre-analysis)
 * Which repos actually had changes
 * Any mismatches between predictions and results
 
@@ -159,4 +169,4 @@ You've now been through the full workflow: plan with AI, build with AI, and test
 
 * **Close the gaps**: Pick one or two gaps from the comparison and add them to your recipe. Each one follows the same loop: write a test, add the transformation, rebuild, re-run, verify.
 * **Test against more repositories**: Use the `create-organization` skill to find additional Jackson 2.x repositories and run your recipe against a broader set. More repos means more edge cases and a more complete recipe.
-* **Try it on your own migration**: Apply the same workflow to a migration that matters to you. Pick a library upgrade or API change relevant to your codebase, use `create-recipe` to plan and build it, and `run-recipe` to validate against your own repositories.
+* **Try it on your own migration**: Apply the same workflow to a migration that matters to you. Pick a library upgrade or API change relevant to your codebase, use `create-recipe` to plan and build it, then validate it against your own repositories with `mod build` and `mod run`.

--- a/docs/hands-on-learning/ai-recipes/module-3-test.md
+++ b/docs/hands-on-learning/ai-recipes/module-3-test.md
@@ -90,7 +90,7 @@ For reference, the underlying commands are:
 ./gradlew publishToMavenLocal
 mod config recipes jar install <groupId>:<artifactId>:<version>
 mod config recipes active set <RECIPE_PATH>
-mod build working-set --no-download --streaming
+mod build working-set --streaming
 mod run working-set --active-recipe --streaming --parallel 2
 ```
 

--- a/docs/hands-on-learning/ai-recipes/module-3-test.md
+++ b/docs/hands-on-learning/ai-recipes/module-3-test.md
@@ -11,7 +11,7 @@ In this module, you'll run your recipe against real-world repositories, compare 
 
 ### Goals for this exercise
 
-* Understand how the `create-organization` skill assembles a working set of repos
+* Assemble a working set of repositories from a `repos.csv`
 * Get ready to run your recipe against real Jackson 2.x codebases
 
 ### Steps
@@ -38,23 +38,28 @@ mod git sync csv working-set working-set/repos.csv --with-sources
 
 The sync clones the repositories and downloads their LSTs. This may take a few minutes. The `--with-sources` flag downloads source code so the agent can perform pre-analysis in the next exercise.
 
-**Option B: Build your own with the `create-organization` skill**
+**Option B: Have your agent find them**
 
-The `create-organization` skill helps find repos by technology. It uses `gh search code` and `gh search repos` to find relevant repositories, then generates a `repos.csv` file. If you'd like to try it:
+Agents are good at this with surprisingly little direction — they reach for the [`gh` CLI](https://cli.github.com/) on their own, so a broad instruction usually works better than a prescriptive one. Make sure `gh` is installed and authenticated first (`gh auth status`).
 
 <details>
 <summary>Suggested prompt</summary>
 
-> Find 5-10 small-to-medium Java repositories on GitHub that use Jackson 2.x (com.fasterxml.jackson). I need a mix of Maven and Gradle projects. Create a repos.csv for testing a Jackson 2→3 migration recipe.
+> Find 5-10 relevant Java repositories to test a Jackson 2.x → 3.x migration recipe on, and write them to `working-set/repos.csv`. Make sure their builds and tests are passing before including them in the test set.
 
 </details>
 
-This takes a few minutes. The skill's workflow includes syncing the working set after generating the repos.csv. If it doesn't sync automatically, run the sync command from Option A yourself. If you'd rather move on, use Option A and try the skill on your own time.
+The "builds and tests are passing" part matters more than it looks. In Module 3 you judge your recipe by whether the repositories still compile after it runs, and that signal is worthless if they were already broken beforehand.
+
+This takes a few minutes. Nothing syncs on its own, so run the sync command from Option A yourself once the file is written. If you'd rather move on, use Option A and try this on your own time.
+
+The four required columns are `cloneUrl`, `branch`, `origin`, and `path`. See [Creating a repos.csv file](../../user-documentation/moderne-cli/references/repos-csv.md) if you want to check the agent's output or write one by hand.
 
 ### Takeaways
 
-* The `create-organization` skill automates finding relevant test repositories.
-* For workshops, a pre-built repos.csv saves time. Try the skill on your own to learn the full workflow.
+* A working set is just a directory of cloned repositories described by a `repos.csv`, synced with `mod git sync csv`.
+* Only four columns are required: `cloneUrl`, `branch`, `origin`, and `path`. That's little enough that an agent can assemble one from a GitHub search.
+* For workshops, a pre-built repos.csv saves time. Building your own is how you'd test a recipe against the codebases you actually care about.
 
 ---
 
@@ -70,7 +75,7 @@ This takes a few minutes. The skill's workflow includes syncing the working set 
 
 #### Step 1: Run the recipe
 
-Have the agent drive the CLI through the full loop. The `create-recipe` skill documents these commands, so the agent should know the sequence.
+Have the agent drive the CLI through the full loop.
 
 <details>
 <summary>Suggested prompt</summary>
@@ -102,7 +107,7 @@ Once the run finishes, review the output. You want to know:
 * Which repos actually had changes
 * Any mismatches between predictions and results
 
-If the skill finds mismatches or gaps, it may iterate on its own: fixing the recipe, recompiling, and re-running. This is the core workflow for recipe development against real code. Let it run and review the changes it makes.
+If the agent finds mismatches or gaps, it may iterate on its own: fixing the recipe, recompiling, and re-running. This is the core workflow for recipe development against real code. Let it run and review the changes it makes.
 
 ### Takeaways
 
@@ -168,5 +173,5 @@ You may also find that your results are closer to the production recipe than you
 You've now been through the full workflow: plan with AI, build with AI, and test against real code. Here are some ways to keep going:
 
 * **Close the gaps**: Pick one or two gaps from the comparison and add them to your recipe. Each one follows the same loop: write a test, add the transformation, rebuild, re-run, verify.
-* **Test against more repositories**: Use the `create-organization` skill to find additional Jackson 2.x repositories and run your recipe against a broader set. More repos means more edge cases and a more complete recipe.
-* **Try it on your own migration**: Apply the same workflow to a migration that matters to you. Pick a library upgrade or API change relevant to your codebase, use `create-recipe` to plan and build it, then validate it against your own repositories with `mod build` and `mod run`.
+* **Test against more repositories**: Add more Jackson 2.x repositories to your `repos.csv`, re-sync, and run your recipe against the broader set. More repos means more edge cases and a more complete recipe.
+* **Try it on your own migration**: Apply the same workflow to a migration that matters to you. Pick a library upgrade or API change relevant to your codebase, plan and build it with your agent, then validate it against your own repositories with `mod build` and `mod run`.

--- a/docs/hands-on-learning/ai-recipes/workshop-overview.md
+++ b/docs/hands-on-learning/ai-recipes/workshop-overview.md
@@ -11,7 +11,7 @@ In this workshop, you'll use AI as a co-author to build an OpenRewrite migration
 
 ## What you'll learn
 
-* The Moderne skills workflow for AI-assisted recipe development (`create-recipe` → `run-recipe` → `create-organization` → iterate)
+* The Moderne skills workflow for AI-assisted recipe development (`create-recipe` → `create-organization` → run with the CLI → iterate)
 * How to guide AI to choose the right recipe type (declarative YAML, imperative Java, Refaster templates)
 * Why test-driven development (TDD) is a natural fit for AI-generated recipes
 * How to validate AI-generated recipes against real-world repositories

--- a/docs/hands-on-learning/ai-recipes/workshop-overview.md
+++ b/docs/hands-on-learning/ai-recipes/workshop-overview.md
@@ -1,17 +1,17 @@
 ---
 sidebar_label: Workshop overview
-description: Learn to use AI as a co-author for building OpenRewrite migration recipes, using the Moderne CLI's built-in AI skills.
+description: Learn to use AI as a co-author for building OpenRewrite migration recipes with a repeatable plan-build-test loop.
 ---
 
 # Overview: Teaching AI to write better OpenRewrite recipes
 
 AI can generate OpenRewrite recipe code, but it doesn't automatically know best practices. Without the right context, structure, and checks, AI-written recipes can be incomplete, incorrect, or just not what you were looking for. Effectively using AI for recipe authoring starts with understanding how to guide it and how to evaluate results.
 
-In this workshop, you'll use AI as a co-author to build an OpenRewrite migration recipe from scratch. You'll learn a repeatable workflow (plan with AI, build with AI, test against real code, and iterate) using the Moderne CLI's built-in AI skills to accelerate each step.
+In this workshop, you'll use AI as a co-author to build an OpenRewrite migration recipe from scratch. You'll learn a repeatable loop — plan with AI, build against real test cases, run on real repositories, and iterate — that you can apply to any migration.
 
 ## What you'll learn
 
-* The Moderne skills workflow for AI-assisted recipe development (`create-recipe` → `create-organization` → run with the CLI → iterate)
+* A repeatable loop for AI-assisted recipe development (plan → build against real test cases → run on real repositories → iterate)
 * How to guide AI to choose the right recipe type (declarative YAML, imperative Java, Refaster templates)
 * Why test-driven development (TDD) is a natural fit for AI-generated recipes
 * How to validate AI-generated recipes against real-world repositories
@@ -42,7 +42,7 @@ You will also need:
 * A JDK installed locally (Java 17 or higher recommended)
 * An AI coding agent (the instructor will demo with [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview), but the exercises work with other agents)
 
-This workshop uses **Moderne skills**, specialized instructions that ship with the Moderne CLI and teach AI coding agents how to create, run, and test OpenRewrite recipes effectively. You'll install and try the skills in [Exercise 1-1](./module-1-plan.md#exercise-1-1-try-the-moderne-skills). For more details, see the [Skills for AI coding agents](../../user-documentation/agent-tools/skills.md) page.
+Coding models already know OpenRewrite reasonably well, so the exercises work with your agent and the `mod` CLI alone. The CLI can also install a `create-recipe` skill that saves the agent from rediscovering recipe conventions each session. It's optional, and [Exercise 1-1](./module-1-plan.md#exercise-1-1-set-up-your-agent-and-see-the-loop) covers installing it. For more details, see the [Skills for AI coding agents](../../user-documentation/agent-tools/skills.md) page.
 
 :::warning
 Agents don't always respond the same way. Your results will differ from the examples shown here, and that's expected. Treat the exercises as a guide, not a script. You may need to adjust your prompts, skip steps the agent already completed, or steer the agent back on track. That's part of working with AI.
@@ -54,6 +54,6 @@ Most agents ask for your approval before running tools (reading files, executing
 
 ## Workshop modules
 
-* [Module 1: Plan](./module-1-plan.md) - Install skills, research the Jackson 2→3 migration, and scope the recipe with AI
+* [Module 1: Plan](./module-1-plan.md) - Set up your agent, research the Jackson 2→3 migration, and scope the recipe with AI
 * [Module 2: Build](./module-2-build.md) - Write tests first, build declarative and imperative recipes with AI assistance
 * [Module 3: Test](./module-3-test.md) - Run against real repositories, compare to the production recipe, and iterate

--- a/docs/hands-on-learning/spring-boot-migration/module-5-build-querydsl-recipe.md
+++ b/docs/hands-on-learning/spring-boot-migration/module-5-build-querydsl-recipe.md
@@ -106,13 +106,11 @@ claude  # or launch your preferred agent
 
 #### Step 2: Invoke the skill with the change specification
 
-Invoke the `create-recipe` skill and feed it the change specification from Exercise 5-1. The prompt should describe the concrete changes, not just "fix QueryDSL."
+Feed the agent the change specification from Exercise 5-1 — it should load the `create-recipe` skill on its own. The prompt should describe the concrete changes, not just "fix QueryDSL."
 
 <details>
 <summary>Suggested prompt</summary>
 
-> `/moderne:create-recipe`
->
 > I need a recipe to upgrade QueryDSL from 3.x (com.mysema.querydsl) to 5.x (com.querydsl) for use with Spring Boot 4 / Jakarta EE. Reference: https://github.com/querydsl/querydsl/releases/tag/QUERYDSL_4_0_0
 >
 > The specific changes are:

--- a/docs/user-documentation/agent-tools/mcp/getting-started.md
+++ b/docs/user-documentation/agent-tools/mcp/getting-started.md
@@ -37,7 +37,7 @@ mod config agent-tools copilot install
 
 Each per-agent command installs both skills and the MCP server for that agent only. If the agent is not detected on your system, the command displays a message and exits without making changes.
 
-The available per-agent subcommands are: `claude`, `windsurf`, `cursor`, `copilot`, `amp`, and `codex`.
+The available per-agent subcommands are: `claude`, `windsurf`, `cursor`, `copilot`, `amp`, `codex`, and `opencode`.
 
 To install only skills (without the MCP server) for all detected agents:
 
@@ -55,6 +55,7 @@ mod config agent-tools skills install
 | GitHub Copilot  | Yes         | Yes            | `.vscode/mcp.json` and `~/.copilot/mcp-config.json` |
 | Sourcegraph Amp | Yes         | Yes            | Registered via `amp mcp add`                        |
 | OpenAI Codex    | Yes         | Yes            | Registered via `codex mcp add`                      |
+| opencode        | Yes         | Yes            | `~/.config/opencode/opencode.json`                  |
 
 ## Next steps
 

--- a/docs/user-documentation/agent-tools/mcp/getting-started.md
+++ b/docs/user-documentation/agent-tools/mcp/getting-started.md
@@ -9,6 +9,10 @@ description: Install the Moderne MCP server for Claude Code, Cursor, Windsurf, a
 This guide installs the **local** MCP server, which runs on your workstation through the Moderne CLI. To connect an agent to the hosted platform server instead, see [the remote MCP server doc](./remote-server.md).
 :::
 
+:::warning[Experimental]
+The local MCP server is experimental. See the [MCP server overview](./overview.md) for what may change.
+:::
+
 ## Installation
 
 The following command installs both skills and the MCP server configuration for all detected coding agents:
@@ -55,7 +59,7 @@ mod config agent-tools skills install
 | GitHub Copilot  | Yes         | Yes            | `.vscode/mcp.json` and `~/.copilot/mcp-config.json` |
 | Sourcegraph Amp | Yes         | Yes            | Registered via `amp mcp add`                        |
 | OpenAI Codex    | Yes         | Yes            | Registered via `codex mcp add`                      |
-| opencode        | Yes         | Yes            | `~/.config/opencode/opencode.json`                  |
+| OpenCode        | Yes         | Yes            | `~/.config/opencode/opencode.json`                  |
 
 ## Next steps
 

--- a/docs/user-documentation/agent-tools/mcp/overview.md
+++ b/docs/user-documentation/agent-tools/mcp/overview.md
@@ -64,13 +64,14 @@ The MCP server exposes the following tools:
 |----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `change_type`        | Renames or moves a type across the entire codebase. Updates all imports, references, declarations, and usages, equivalent to an IDE's "rename type" refactoring applied across the whole repository.                                                                    |
 | `change_method_name` | Renames a method across the entire codebase. Updates all call sites, declarations, and references, equivalent to an IDE's "rename method" refactoring applied across the whole repository.                                                                              |
-| `pattern_replace`    | Compiles and runs a [Refaster template](https://docs.openrewrite.org/concepts-and-explanations/recipes#refaster-template-recipes) to make mechanical code changes across the entire codebase. Provide a Java class with `@BeforeTemplate` and `@AfterTemplate` methods. |
+| `pattern_replace`    | Compiles and runs a Kotlin recipe-DSL source (the `rewrite { } to { }` shape) to make structural code changes across the codebase. Use when `edit_code` finds no fitting marketplace recipe.                                                                            |
 
 ### Working with recipes
 
 | Tool              | Description                                                                                                                              |
 |-------------------|------------------------------------------------------------------------------------------------------------------------------------------|
-| `search_recipes`  | Searches available OpenRewrite recipes by natural-language query. Returns a paginated list of matching recipe names ranked by relevance. |
+| `edit_code`       | Finds a curated marketplace recipe that transforms code across the repository. First step, before `learn_recipe` and `run_recipe`.       |
+| `analyze_code`    | Finds a curated recipe that analyzes code across the repository without modifying it. Feeds `query_datatable` for structured results.    |
 | `learn_recipe`    | Retrieves full details for a specific recipe, including its description, configurable options, and data table schemas.                   |
 | `run_recipe`      | Runs an OpenRewrite recipe on the repository. Recipes perform automated code analysis, refactoring, migration, and formatting.           |
 | `query_datatable` | Executes SQL against data table results from a recipe run. Lazily loads results into DuckDB for querying.                                |
@@ -96,7 +97,7 @@ Skills and the MCP server are complementary:
 |-------------------------|-----------------------------------------------------------|---------------------------------------------------------|
 | **What they provide**   | Workflow guidance and domain knowledge                    | Semantic code search, navigation, and refactoring tools |
 | **How agents use them** | Read as instructions/prompts                              | Call as tools during conversation                       |
-| **When they help**      | Creating recipes, analyzing impact, building working sets | Searching, navigating, and refactoring code             |
+| **When they help**      | Creating recipes, building working sets, mapping context  | Searching, navigating, and refactoring code             |
 | **Requires LST build**  | No                                                        | Yes (for semantic tools)                                |
 
 For the best experience, install both. Skills teach agents the recipe development workflow, while the MCP server gives them the tools to execute that workflow effectively.

--- a/docs/user-documentation/agent-tools/mcp/overview.md
+++ b/docs/user-documentation/agent-tools/mcp/overview.md
@@ -11,6 +11,10 @@ The Moderne CLI includes a local [Model Context Protocol (MCP)](https://modelcon
 This page describes the **local** MCP server (`mod mcp`), which runs on a developer workstation through the CLI. Moderne also offers a [remote MCP server](./remote-server.md) hosted on the Moderne Platform that runs recipes against the repositories already ingested into your tenant.
 :::
 
+:::warning[Experimental]
+The local MCP server is experimental. Its tools and the commands that configure them may change significantly between CLI releases, and the tool descriptions are continually tuned for each supported agent. An agent decides for itself when to call a tool, so it may not always reach for a Moderne one, even where it would help.
+:::
+
 ## Why use the Moderne MCP server
 
 AI coding agents are limited to the tools bundled with them (typically just text search and file reading). These tools work at the text level and miss the **semantic** structure of code.

--- a/docs/user-documentation/agent-tools/mcp/security.md
+++ b/docs/user-documentation/agent-tools/mcp/security.md
@@ -71,11 +71,11 @@ As each component becomes ready, additional tools are registered and the client 
 | Tray client        | HTTP client that pushes session metadata to the macOS tray app over loopback (disabled by default)                           |
 | Transcript watcher | Reads the AI client's local conversation transcript files; writes a local CSV of search-tool usage observations              |
 | Recipe marketplace | Read-only view of local CSV files containing OpenRewrite recipe metadata; no network access                                  |
-| Refaster transformer | Applies Refaster-style statement transformations for precise, deterministic edits without AI inference                      |
+| Recipe-DSL engine  | Compiles and runs a Kotlin recipe-DSL source (`pattern_replace`) for deterministic structural edits; no AI inference         |
 
 ## Tools and resources exposed
 
-All 18 tools perform deterministic code analysis or transformation against local data. None contact external services or perform AI inference.
+All 19 tools perform deterministic code analysis or transformation against local data. None contact external services or perform AI inference.
 
 ### Available immediately (or once the search index is built)
 
@@ -97,13 +97,14 @@ All 18 tools perform deterministic code analysis or transformation against local
 | `find_annotations`     | Finds all usages of a specified annotation across the codebase.                                                                |
 | `find_implementations` | Finds all classes implementing or extending a given type, including indirect implementations.                                  |
 | `symbols_overview`     | Returns the symbol structure (classes, methods, fields) of a specific source file.                                             |
-| `search_recipes`       | Searches the local recipe marketplace CSV for OpenRewrite recipes by keyword.                                                  |
+| `edit_code`            | Searches the local recipe marketplace CSV for a recipe that transforms code across the repository.                             |
+| `analyze_code`         | Searches the local recipe marketplace CSV for a recipe that analyzes code without modifying it.                                |
 | `learn_recipe`         | Returns full metadata for a specific recipe from the local marketplace.                                                        |
 | `run_recipe`           | Executes an OpenRewrite recipe against the LST. May trigger a Maven artifact download if the recipe JAR is not locally cached. |
 | `query_datatable`      | SQL interface (DuckDB, in-process) over `.csv.gz` DataTable files produced by a prior `run_recipe` call.                       |
 | `change_type`          | Atomically renames or moves a Java type across the entire codebase.                                                            |
 | `change_method_name`   | Atomically renames a method across the entire codebase.                                                                        |
-| `pattern_replace`      | Applies a Refaster-style code pattern replacement across many files.                                                           |
+| `pattern_replace`      | Applies a Kotlin recipe-DSL (`rewrite { } to { }`) structural replacement across many files.                                   |
 
 ### Resources
 
@@ -160,7 +161,7 @@ Recipes may make outbound HTTPS connections as part of their normal behavior. Th
 
 In its default configuration, `mod mcp` transmits no telemetry, analytics, crash reports, or usage data. The transcript watcher writes search-tool usage observations to a local CSV at `~/.moderne/mcp/tool-observations.csv`. This file is never transmitted anywhere. There is no phone-home mechanism.
 
-`mod mcp` does not contact the Moderne SaaS platform API by default. The recipe marketplace used by `search_recipes`, `learn_recipe`, and `run_recipe` is read entirely from local CSV files installed by `mod config recipes` commands.
+`mod mcp` does not contact the Moderne SaaS platform API by default. The recipe marketplace used by `edit_code`, `analyze_code`, `learn_recipe`, and `run_recipe` is read entirely from local CSV files installed by `mod config recipes` commands.
 
 :::info
 In a future release, the Moderne CLI will provide an opt-in feature to connect to your Moderne platform for centralized telemetry collection and audit/governance data. This will require explicit configuration and will not be enabled by default.

--- a/docs/user-documentation/agent-tools/mcp/security.md
+++ b/docs/user-documentation/agent-tools/mcp/security.md
@@ -11,6 +11,10 @@ This page describes the security architecture of the Moderne MCP server (`mod mc
 This page covers the **local** MCP server that runs on developer workstations. The [remote MCP server](./remote-server.md) is a separate, hosted service on the Moderne Platform with the same security posture as the [Moderne API](../../moderne-platform/how-to-guides/accessing-the-moderne-api.md).
 :::
 
+:::warning[Experimental]
+The local MCP server is experimental. See the [MCP server overview](./overview.md) for what may change. Re-check this page against the CLI version you are approving rather than treating the tool list as fixed.
+:::
+
 ## Summary for security reviewers
 
 | Question                                               | Answer                                                                                                                                                                                                    |

--- a/docs/user-documentation/agent-tools/mcp/tool-browser.md
+++ b/docs/user-documentation/agent-tools/mcp/tool-browser.md
@@ -5,6 +5,10 @@ description: Monitor LST builds and test MCP tools with the Moderne tool browser
 
 # Tool browser
 
+:::warning[Experimental]
+The tool browser is part of the local MCP server, which is experimental. See the [MCP server overview](./overview.md) for what may change.
+:::
+
 The Moderne CLI includes an optional tool browser, a browser-based dashboard for monitoring LST builds and exploring available tools. To enable it:
 
 ```bash

--- a/docs/user-documentation/agent-tools/skills.md
+++ b/docs/user-documentation/agent-tools/skills.md
@@ -1,25 +1,30 @@
 ---
 sidebar_label: Skills for AI coding agents
-description: How to use Moderne skills with AI coding agents for recipe development, testing, and impact analysis.
+description: How to use Moderne skills with AI coding agents for recipe development, code search, and large-scale refactoring.
 ---
 
 import ReactPlayer from '@site/src/components/VideoPlayer';
 
 # Using Moderne skills with AI coding agents
 
-The Moderne CLI can install agent tools (skills and MCP servers) that teach AI coding agents how to work with OpenRewrite recipes. With a single command, you can install these tools for all detected agents, giving them guidance through the full recipe workflow: creating recipes, running them at scale, and analyzing the impact of what changed.
+The Moderne CLI can install agent tools (skills and MCP servers) that teach AI coding agents how to work with OpenRewrite recipes. With a single command, you can install these tools for all detected agents.
+
+Skills differ in what they need to do their job:
+
+* Most explain how and when to reach for a [Moderne MCP server](./mcp/overview.md) tool, so they need that server registered.
+* A few carry workflow knowledge that stands on its own and drive the `mod` CLI directly, so they work whether or not you use the MCP server.
 
 <ReactPlayer className="reactPlayer" url='https://www.youtube.com/watch?v=FuOaGA7JYTc' controls="true" />
 
 ## Why use Moderne skills
 
-Building OpenRewrite recipes requires understanding [visitor patterns](https://docs.openrewrite.org/concepts-and-explanations/visitors), [LST structures](https://docs.openrewrite.org/concepts-and-explanations/lossless-semantic-trees), and testing idioms that AI coding agents don't know out of the box.
+Building OpenRewrite recipes requires understanding [visitor patterns](https://docs.openrewrite.org/concepts-and-explanations/visitors), [LST structures](https://docs.openrewrite.org/concepts-and-explanations/lossless-semantic-trees), and testing idioms that AI coding agents don't know out of the box. Agents also don't know when a Moderne tool will do a job better than `grep` and a hand edit.
 
 Moderne skills teach agents about:
 
 * **Recipe creation** - choosing the right type of recipe ([Declarative](https://docs.openrewrite.org/concepts-and-explanations/recipes#declarative-recipes), [Refaster](https://docs.openrewrite.org/concepts-and-explanations/recipes#refaster-template-recipes), or [Imperative](https://docs.openrewrite.org/concepts-and-explanations/recipes#imperative-recipes)) and following [OpenRewrite conventions](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
-* **Testing workflows** - setting up working sets, running recipes against real code, and diagnosing why recipes match or don't match certain pieces of code
-* **Impact analysis** - turning recipe run data into executive reports and visualizations
+* **Repository discovery** - assembling a working set of real repositories to test against
+* **Tool routing** - reaching for a recipe or a type-aware search instead of text search when a change spans many files
 
 The skills are bundled with the CLI and stay current when you update.
 
@@ -33,6 +38,7 @@ The CLI auto-detects installed coding agents and installs skills to each one:
 | Windsurf        | `~/.codeium/`                                    | `~/.codeium/windsurf/skills/<skill>/SKILL.md`                    |
 | Sourcegraph Amp | `~/.config/agents/`                              | `~/.config/agents/skills/<skill>/SKILL.md`                       |
 | OpenAI Codex    | `~/.agents/`                                     | `~/.agents/skills/<skill>/SKILL.md`                              |
+| opencode        | `~/.config/opencode/`                            | `~/.config/opencode/skills/<skill>/SKILL.md`                     |
 | Cursor          | `~/.cursor/`                                     | `.cursor/rules/moderne-<skill>.mdc`                              |
 | GitHub Copilot  | `.github/` in current directory or `~/.copilot/` | `.github/instructions/moderne-<skill>.instructions.md`           |
 
@@ -68,7 +74,7 @@ mod config agent-tools copilot install
 
 Each per-agent command installs both skills and the MCP server for that agent only. If the agent is not detected on your system, the command displays a message and exits without making changes.
 
-The available per-agent subcommands are: `claude`, `windsurf`, `cursor`, `copilot`, `amp`, and `codex`.
+The available per-agent subcommands are: `claude`, `windsurf`, `cursor`, `copilot`, `amp`, `codex`, and `opencode`.
 
 ### Skills-only installation
 
@@ -84,44 +90,74 @@ To remove only skills:
 mod config agent-tools skills uninstall
 ```
 
+:::note
+This installs every skill, including the ones that call the Moderne MCP server and do nothing without it. It is most useful for refreshing skills when the MCP server is already registered. If you have not set up the MCP server, only `create-recipe`, `create-organization`, and `prethink` will function.
+:::
+
 ## Invoking skills
 
-How you invoke skills depends on your coding agent:
+Skills trigger automatically. Describe the task in your own words and the agent loads whichever skill matches — there are no commands to memorize:
 
-**Claude Code** - Use slash commands with the `/moderne:` prefix:
+```
+Write a recipe that replaces all calls to Logger.info() with Logger.debug()
+```
+
+```
+Find every repository in my GitHub org that uses Spring Boot and set up a working set
+```
+
+In Claude Code you can also invoke a skill explicitly with the `/moderne:` prefix, which is useful when you want to force a particular workflow:
 
 ```
 /moderne:create-recipe
 
-Create a recipe that replaces all calls to Logger.info() with Logger.debug()
-```
-
-**Windsurf, Sourcegraph Amp** - Reference skills by name in your prompt:
-
-```
-Using the run-recipe skill, test my recipe against the Default organization.
-```
-
-**Cursor** - Skills are loaded automatically as rules. Reference them in context:
-
-```
-@moderne-create-recipe Create a recipe that migrates deprecated API calls.
-```
-
-**GitHub Copilot** - Skills are loaded as instructions. Reference them in your prompt:
-
-```
-Following the moderne-run-recipe instructions, help me debug why my recipe isn't matching.
+Create a recipe that migrates deprecated API calls.
 ```
 
 ## Available skills
 
-The following skills are installed:
+### Skills that work with the CLI alone
 
-* **create-organization** - build a working set of repositories to test against
-* **create-recipe** - create new OpenRewrite recipes with proper patterns
-* **run-recipe** - test and debug recipes against real repositories
-* **analyze-impact** - create reports and visualizations from recipe run data
+These need no MCP server.
+
+| Skill                   | What it covers                                                                                             |
+|-------------------------|------------------------------------------------------------------------------------------------------------|
+| **create-recipe**       | Writing, fixing, and debugging recipes — declarative YAML, Refaster templates, Java visitors, scanning recipes, and `RewriteTest` coverage |
+| **create-organization** | Finding repositories across GitHub/GitLab/Bitbucket and assembling them into an organization or `repos.csv` |
+| **prethink**            | Pre-resolved codebase context — architecture, dependencies, and risk-ranked untested methods                |
+
+### Skills that use the MCP server
+
+Each of these explains when and how to reach for one of the [Moderne MCP server tools](./mcp/overview.md#available-tools), and requires the [MCP server](./mcp/overview.md) to be registered.
+
+:::note
+These skills operate on the repository the agent is currently working in — they are single-repo. To run a recipe across a working set of many repositories, use `mod run` from the CLI.
+:::
+
+| Skill               | What it covers                                                                              | MCP tool                                    |
+|---------------------|----------------------------------------------------------------------------------------------|---------------------------------------------|
+| **edit-code**       | Applying a recipe across many files in the current repository (migrate, upgrade, rename, replace, find-and-fix) | `edit_code`                |
+| **analyze-code**    | Read-only impact analysis across the current repository — usages, callers, references, annotations | `analyze_code`                         |
+| **search-code**     | Structural and symbol-aware search, including Comby patterns and trigram queries              | `trigrep_search`, `trigrep_structural_search`, `grep` |
+| **find-symbols**    | Type-aware lookups that resolve through the LST type system                                   | `find_types`, `find_methods`, `find_annotations`, `find_implementations`, `symbols_overview` |
+| **change-symbols**  | Renaming a method or moving a type atomically, including callers and imports                  | `change_method_name`, `change_type`         |
+| **pattern-replace** | One-shot structural rewrites when no marketplace recipe matches                               | `pattern_replace`                           |
+| **inspect-status**  | Confirming the LST, trigram index, or build tool is ready                                     | `lst_status`, `build_status`, `build_info`  |
+| **query-datatable** | SQL against data tables produced by a recipe run                                              | `query_datatable`                           |
+
+### create-recipe
+
+Use this skill when you want to create a new OpenRewrite recipe or modify an existing one.
+
+**When not to use**: general Java programming unrelated to OpenRewrite, or running an existing recipe across a working set (use `mod build` and `mod run`).
+
+This skill helps you with:
+
+* **Recipe type selection** - Choosing between declarative YAML (for composing existing recipes), Refaster templates (for simple expression replacements), or imperative Java recipes (for complex logic)
+* **Critical patterns** - LST immutability, visitor traversal, type matching with `MethodMatcher`, and proper import handling
+* **Testing** - Writing tests with the `RewriteTest` framework, including before/after assertions and no-change cases
+* **Data tables** - Emitting structured data for analysis
+* **Validating against real code** - Publishing the recipe, installing it, and running it across a working set with the CLI
 
 ### create-organization
 
@@ -135,63 +171,14 @@ This skill helps you:
 * **Sync repositories** using `mod git sync csv`
 * **Organize repositories** by team, technology, or business domain for focused testing
 
-### create-recipe
-
-Use this skill when you want to create a new OpenRewrite recipe or modify an existing one.
-
-**When not to use**: Testing or debugging a recipe you've written (use `run-recipe` instead) or general Java programming unrelated to OpenRewrite.
-
-This skill helps you with:
-
-* **Recipe type selection** - Choosing between declarative YAML (for composing existing recipes), Refaster templates (for simple expression replacements), or imperative Java recipes (for complex logic)
-* **Critical patterns** - LST immutability, visitor traversal, type matching with `MethodMatcher`, and proper import handling
-* **Testing** - Writing tests with the `RewriteTest` framework, including before/after assertions and no-change cases
-* **Data tables** - Emitting structured data for analysis
-
-### run-recipe
-
-Use this skill to discover, configure, and run OpenRewrite recipes against real repositories. This skill is especially useful for AI coding agents as they can use it to run recipes as part of automated workflows. With it, they can browse the recipe catalog, configure complex recipe options, and interpret results.
-
-:::note
-If you just want to run an existing recipe without iterative debugging, you can use the CLI directly (`mod run`).
-:::
-
-The skill supports two modes:
-
-* **Existing recipe mode** - For pre-built recipes from the catalog or Maven coordinates (uses `mod config recipes jar install`)
-* **Development mode** - For recipes you're actively editing (uses `mod config recipes active set`)
-
-When developing a new recipe, the skill guides you through an iterative loop:
-
-1. **Working set setup** - Syncing repositories from a Moderne organization or custom CSV
-2. **Pre-analysis** - Searching source code to predict which files *should* be affected
-3. **Recipe execution** - Running with appropriate parallelism and monitoring progress
-4. **Results comparison** - Comparing predictions vs actual results to diagnose mismatches
-5. **Diagnosis** - Investigating why expected changes are missing (e.g., checking matchers, reviewing visitor logic)
-6. **Iteration** - Fixing the recipe and re-running until results match expectations
-
-### analyze-impact
-
-Use this skill when you want to create reports and visualizations from recipe run data.
-
-This skill helps you with:
-
-* **Discovering data** - Finding existing recipe runs with `mod audit runs list`
-* **Data aggregation** - Extracting data tables with `mod study`
-* **Analysis** - Identifying patterns in vulnerability, migration, or code quality data
-* **Visualization** - Creating Sankey diagrams, bar charts, treemaps, and tables
-* **Report generation** - Building markdown-based slide decks with Marp
-
-The skill knows which recipes produce useful data tables for impact analysis, including `DependencyVulnerabilityCheck` for security, `UpgradeToJava25` for migration scope, and `CommonStaticAnalysis` for code quality.
-
 ## Workflow example
 
 The skills work together to support the full recipe lifecycle:
 
 1. **Create a working set** with `create-organization` to find Spring Boot repositories
 2. **Write a recipe** with `create-recipe` to migrate a deprecated API
-3. **Test iteratively** with `run-recipe` until the recipe matches expected files
-4. **Generate a report** with `analyze-impact` showing migration scope across teams
+3. **Test iteratively** by publishing the recipe and running it with `mod build` and `mod run` until it matches the files you expect
+4. **Apply it at scale** by running it across the whole working set with `mod run`, then dig into the results with `query-datatable`
 
 ## Keeping skills up to date
 

--- a/docs/user-documentation/agent-tools/skills.md
+++ b/docs/user-documentation/agent-tools/skills.md
@@ -12,7 +12,7 @@ The Moderne CLI can install agent tools (skills and MCP servers) that teach AI c
 Skills differ in what they need to do their job:
 
 * Most explain how and when to reach for a [Moderne MCP server](./mcp/overview.md) tool, so they need that server registered.
-* A few carry workflow knowledge that stands on its own and drive the `mod` CLI directly, so they work whether or not you use the MCP server.
+* A couple call no MCP tool at all: one carries recipe-authoring knowledge and drives the `mod` CLI directly, and one points the agent at context files already generated for the repository.
 
 <ReactPlayer className="reactPlayer" url='https://www.youtube.com/watch?v=FuOaGA7JYTc' controls="true" />
 
@@ -23,8 +23,8 @@ Building OpenRewrite recipes requires understanding [visitor patterns](https://d
 Moderne skills teach agents about:
 
 * **Recipe creation** - choosing the right type of recipe ([Declarative](https://docs.openrewrite.org/concepts-and-explanations/recipes#declarative-recipes), [Refaster](https://docs.openrewrite.org/concepts-and-explanations/recipes#refaster-template-recipes), or [Imperative](https://docs.openrewrite.org/concepts-and-explanations/recipes#imperative-recipes)) and following [OpenRewrite conventions](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
-* **Repository discovery** - assembling a working set of real repositories to test against
 * **Tool routing** - reaching for a recipe or a type-aware search instead of text search when a change spans many files
+* **Codebase context** - pre-resolved architecture, dependency, and risk information about a repository before the agent starts editing
 
 The skills are bundled with the CLI and stay current when you update.
 
@@ -38,7 +38,7 @@ The CLI auto-detects installed coding agents and installs skills to each one:
 | Windsurf        | `~/.codeium/`                                    | `~/.codeium/windsurf/skills/<skill>/SKILL.md`                    |
 | Sourcegraph Amp | `~/.config/agents/`                              | `~/.config/agents/skills/<skill>/SKILL.md`                       |
 | OpenAI Codex    | `~/.agents/`                                     | `~/.agents/skills/<skill>/SKILL.md`                              |
-| opencode        | `~/.config/opencode/`                            | `~/.config/opencode/skills/<skill>/SKILL.md`                     |
+| OpenCode        | `~/.config/opencode/`                            | `~/.config/opencode/skills/<skill>/SKILL.md`                     |
 | Cursor          | `~/.cursor/`                                     | `.cursor/rules/moderne-<skill>.mdc`                              |
 | GitHub Copilot  | `.github/` in current directory or `~/.copilot/` | `.github/instructions/moderne-<skill>.instructions.md`           |
 
@@ -91,7 +91,7 @@ mod config agent-tools skills uninstall
 ```
 
 :::note
-This installs every skill, including the ones that call the Moderne MCP server and do nothing without it. It is most useful for refreshing skills when the MCP server is already registered. If you have not set up the MCP server, only `create-recipe`, `create-organization`, and `prethink` will function.
+This installs every skill, including the ones that call the Moderne MCP server and do nothing without it. It is most useful for refreshing skills when the MCP server is already registered. If you have not set up the MCP server, `create-recipe` still works, and `prethink` works as long as you have generated [Prethink context](./prethink.md) some other way.
 :::
 
 ## Invoking skills
@@ -103,7 +103,7 @@ Write a recipe that replaces all calls to Logger.info() with Logger.debug()
 ```
 
 ```
-Find every repository in my GitHub org that uses Spring Boot and set up a working set
+Rename getItems() to items() on com.example.ShoppingCart everywhere it is used
 ```
 
 In Claude Code you can also invoke a skill explicitly with the `/moderne:` prefix, which is useful when you want to force a particular workflow:
@@ -116,15 +116,18 @@ Create a recipe that migrates deprecated API calls.
 
 ## Available skills
 
-### Skills that work with the CLI alone
+### Skills that call no MCP tool
 
-These need no MCP server.
+Neither of these reaches for a Moderne MCP server tool, so both work without that server registered.
 
-| Skill                   | What it covers                                                                                             |
-|-------------------------|------------------------------------------------------------------------------------------------------------|
-| **create-recipe**       | Writing, fixing, and debugging recipes — declarative YAML, Refaster templates, Java visitors, scanning recipes, and `RewriteTest` coverage |
-| **create-organization** | Finding repositories across GitHub/GitLab/Bitbucket and assembling them into an organization or `repos.csv` |
-| **prethink**            | Pre-resolved codebase context — architecture, dependencies, and risk-ranked untested methods                |
+| Skill             | What it covers                                                                                             |
+|-------------------|------------------------------------------------------------------------------------------------------------|
+| **create-recipe** | Writing, fixing, and debugging recipes — declarative YAML, Refaster templates, Java visitors, scanning recipes, and `RewriteTest` coverage |
+| **prethink**      | Reading pre-resolved codebase context — architecture, dependencies, and risk-ranked untested methods         |
+
+:::note
+`create-recipe` is self-contained. `prethink` is not: it tells the agent to read `.moderne/context/`, which only exists once you have generated [Prethink context](./prethink.md) by running the `UpdatePrethinkContextStarter` recipe. If you run the [MCP server](./mcp/overview.md), `mod mcp` refreshes that context in the background as you work.
+:::
 
 ### Skills that use the MCP server
 
@@ -147,6 +150,10 @@ These skills operate on the repository the agent is currently working in — the
 
 ### create-recipe
 
+:::note
+`create-recipe` requires Moderne CLI 4.5.3 or later. On earlier versions, `mod config agent-tools install` installs the other nine skills.
+:::
+
 Use this skill when you want to create a new OpenRewrite recipe or modify an existing one.
 
 **When not to use**: general Java programming unrelated to OpenRewrite, or running an existing recipe across a working set (use `mod build` and `mod run`).
@@ -158,27 +165,6 @@ This skill helps you with:
 * **Testing** - Writing tests with the `RewriteTest` framework, including before/after assertions and no-change cases
 * **Data tables** - Emitting structured data for analysis
 * **Validating against real code** - Publishing the recipe, installing it, and running it across a working set with the CLI
-
-### create-organization
-
-Use this skill when you want to create a custom set of repositories to run recipes against.
-
-This skill helps you:
-
-* **Find repositories** by language, technology (Spring Boot, JPA, Kafka, etc.), or by listing all accessible repos
-* **Search across platforms** - GitHub, GitLab, Bitbucket, and other sources like Sourcegraph and Libraries.io
-* **Generate repos.csv** files with proper format and organizational hierarchy
-* **Sync repositories** using `mod git sync csv`
-* **Organize repositories** by team, technology, or business domain for focused testing
-
-## Workflow example
-
-The skills work together to support the full recipe lifecycle:
-
-1. **Create a working set** with `create-organization` to find Spring Boot repositories
-2. **Write a recipe** with `create-recipe` to migrate a deprecated API
-3. **Test iteratively** by publishing the recipe and running it with `mod build` and `mod run` until it matches the files you expect
-4. **Apply it at scale** by running it across the whole working set with `mod run`, then dig into the results with `query-datatable`
 
 ## Keeping skills up to date
 


### PR DESCRIPTION
## What

Brings the agent-tools docs in line with what the CLI actually ships.

This PR started as the docs counterpart to moderneinc/moderne-cli#4393, which was going to restore both `create-recipe` and `create-organization`. **That PR changed before merging: `create-organization` stayed retired and only `create-recipe` came back.** The scope here grew accordingly — see [Why this grew](#why-this-grew) below.

## Why this grew

Three things pushed this past its original scope:

1. **`create-organization` is removed as well.** Every reference had to go, not just be updated. It was also load-bearing in the AI recipes workshop, which was built around the loop that `create-recipe` and `create-organization` formed together.
2. **The AI recipes workshop stopped making sense skills-first.** Rather than pull the course, it now leads with the development loop itself and treats `create-recipe` as an optional accelerator. Coding models already handle OpenRewrite reasonably well, since the framework is open source and well represented in training data, so the exercises work with the agent and the CLI alone.
3. **The local MCP server needed an experimental label**, which touches the same pages.

## Changes

**Skills page**

- Drops `create-organization` entirely. The standalone group is now `create-recipe` and `prethink`.
- Regroups the sections as "skills that call no MCP tool" rather than "work with the CLI alone". `prethink` calls no MCP tool, but it is not self-contained: it reads `.moderne/context/`, which only exists once the Prethink recipe has run. The old grouping implied install-and-go.
- Removes the workflow example. With `create-organization` gone, three of its four steps were plain CLI commands with one skill mention wedged in.
- Each MCP-backed skill still names the tool(s) it fronts, verified against the `See the <skill> skill` markers in the tool descriptions rather than inferred from names.

**Local MCP server marked experimental**

- A warning on the four local-server pages (`overview`, `getting-started`, `tool-browser`, `security`) and the two workshop modules that use it.
- The **remote** server is unaffected and deliberately unmarked.
- The full wording lives on the MCP overview only; every other page points at it, so the language is maintained in one place.
- The security page keeps a reviewer-specific line: re-check it against the CLI version being approved rather than treating the tool list as fixed.

**AI recipes workshop**

- Exercise 1-1 now sets up the agent and introduces the loop, instead of introducing the skills. Installing skills is an optional step.
- The `create-organization` repo-discovery path is replaced with a direct prompt, including the instruction to confirm builds and tests pass before a repo joins the test set. That matters because the workshop judges the recipe by whether repos still compile afterward, which is a worthless signal if they were already broken.
- Drops the "the skill does X" attributions in Modules 2 and 3, which credited a skill the reader may not have installed.

**Other**

- Removes the duplicated skill roster from the agent tools install module and links to the skills page, so the list lives in one place.
