### PR TITLE
Document Connector AWS CodeArtifact token minting for Maven repositories

### DIFF
--- a/docs/administrator-documentation/moderne-platform/how-to-guides/connector-configuration/configure-a-connector-with-maven-repository-access.md
+++ b/docs/administrator-documentation/moderne-platform/how-to-guides/connector-configuration/configure-a-connector-with-maven-repository-access.md
@@ -157,6 +157,6 @@ java -jar connector-{version}.jar \
 
 ### AWS CodeArtifact
 
-AWS CodeArtifact is not supported as an LST source. Maven poll discovery relies on the [maven-indexer](https://maven.apache.org/maven-indexer/) index, which CodeArtifact does not serve, so a CodeArtifact repository configured as a poll source would never discover any LSTs. CodeArtifact package assets are also immutable, which prevents re-publishing an updated organization CSV in place. The Connector rejects CodeArtifact URLs in LST and organization source configuration at startup with an error explaining this. Host LST sources in a repository manager such as Artifactory or Nexus instead.
+AWS CodeArtifact is not supported as an LST source. Maven poll discovery relies on the [maven-indexer](https://maven.apache.org/maven-indexer/) index, which CodeArtifact does not serve, so a CodeArtifact repository configured as a poll source would never discover any LSTs. CodeArtifact package assets are also immutable, which prevents re-publishing an updated organization CSV in place. The Connector rejects CodeArtifact URLs in LST and organization source configuration at startup with an error explaining this. Host LST sources in cloud object storage instead, such as [S3](./configure-a-connector-with-s3-access.md) or Azure Blob Storage.
 
 CodeArtifact is supported for [recipe marketplace repositories](./configure-recipe-marketplace-repositories.md#aws-codeartifact), including automatic authorization token minting.

--- a/docs/administrator-documentation/moderne-platform/how-to-guides/connector-configuration/configure-a-connector-with-maven-repository-access.md
+++ b/docs/administrator-documentation/moderne-platform/how-to-guides/connector-configuration/configure-a-connector-with-maven-repository-access.md
@@ -157,28 +157,6 @@ java -jar connector-{version}.jar \
 
 ### AWS CodeArtifact
 
-When a poll repository URL points at an AWS CodeArtifact endpoint (`<domain>-<account-id>.d.codeartifact.<region>.amazonaws.com`) and you leave the password unset, the Connector mints and refreshes CodeArtifact authorization tokens itself instead of relying on a manually rotated token. This behaves the same way here as it does for recipe artifact repositories; see [AWS CodeArtifact under Recipe marketplace repositories](./configure-recipe-marketplace-repositories.md#aws-codeartifact) for how token minting works and the IAM permissions the Connector's AWS identity needs. Configure the repository with only its CodeArtifact `uri` and leave `password` unset.
+AWS CodeArtifact is not supported as an LST source. Maven poll discovery relies on the [maven-indexer](https://maven.apache.org/maven-indexer/) index, which CodeArtifact does not serve, so a CodeArtifact repository configured as a poll source would never discover any LSTs. CodeArtifact package assets are also immutable, which prevents re-publishing an updated organization CSV in place. The Connector rejects CodeArtifact URLs in LST and organization source configuration at startup with an error explaining this. Host LST sources in a repository manager such as Artifactory or Nexus instead.
 
-<Tabs groupId="agent-type">
-<TabItem value="oci-container" label="OCI Container">
-
-```bash
-docker run \
-# ... Existing variables
--e MODERNE_ORGANIZATION_SOURCES_HTTP_0_POLL_MAVEN_0_URI=https://my-domain-111122223333.d.codeartifact.us-east-1.amazonaws.com/maven/my-repo/ \
-# ... Additional variables
-```
-
-</TabItem>
-
-<TabItem value="executable-jar" label="Executable JAR">
-
-```bash
-java -jar connector-{version}.jar \
-# ... Existing arguments
---moderne.organization.sources.http[0].poll.maven[0].uri=https://my-domain-111122223333.d.codeartifact.us-east-1.amazonaws.com/maven/my-repo/ \
-# ... Additional arguments
-```
-
-</TabItem>
-</Tabs>
+CodeArtifact is supported for [recipe marketplace repositories](./configure-recipe-marketplace-repositories.md#aws-codeartifact), including automatic authorization token minting.

--- a/docs/administrator-documentation/moderne-platform/how-to-guides/connector-configuration/configure-a-connector-with-maven-repository-access.md
+++ b/docs/administrator-documentation/moderne-platform/how-to-guides/connector-configuration/configure-a-connector-with-maven-repository-access.md
@@ -154,3 +154,31 @@ java -jar connector-{version}.jar \
 ```
 </TabItem>
 </Tabs>
+
+### AWS CodeArtifact
+
+When a poll repository URL points at an AWS CodeArtifact endpoint (`<domain>-<account-id>.d.codeartifact.<region>.amazonaws.com`) and you leave the password unset, the Connector mints and refreshes CodeArtifact authorization tokens itself instead of relying on a manually rotated token. This behaves the same way here as it does for recipe artifact repositories; see [AWS CodeArtifact under Recipe marketplace repositories](./configure-recipe-marketplace-repositories.md#aws-codeartifact) for how token minting works and the IAM permissions the Connector's AWS identity needs. Configure the repository with only its CodeArtifact `uri` and leave `password` unset.
+
+<Tabs groupId="agent-type">
+<TabItem value="oci-container" label="OCI Container">
+
+```bash
+docker run \
+# ... Existing variables
+-e MODERNE_ORGANIZATION_SOURCES_HTTP_0_POLL_MAVEN_0_URI=https://my-domain-111122223333.d.codeartifact.us-east-1.amazonaws.com/maven/my-repo/ \
+# ... Additional variables
+```
+
+</TabItem>
+
+<TabItem value="executable-jar" label="Executable JAR">
+
+```bash
+java -jar connector-{version}.jar \
+# ... Existing arguments
+--moderne.organization.sources.http[0].poll.maven[0].uri=https://my-domain-111122223333.d.codeartifact.us-east-1.amazonaws.com/maven/my-repo/ \
+# ... Additional arguments
+```
+
+</TabItem>
+</Tabs>

--- a/docs/administrator-documentation/moderne-platform/how-to-guides/connector-configuration/configure-recipe-marketplace-repositories.md
+++ b/docs/administrator-documentation/moderne-platform/how-to-guides/connector-configuration/configure-recipe-marketplace-repositories.md
@@ -119,10 +119,10 @@ java -jar connector-{version}.jar \
 
 When a Maven repository URL points at an [AWS CodeArtifact](https://docs.aws.amazon.com/codeartifact/latest/ug/welcome.html) endpoint (`<domain>-<account-id>.d.codeartifact.<region>.amazonaws.com`) and you leave the password unset, the Connector mints and refreshes CodeArtifact authorization tokens itself. CodeArtifact tokens are short-lived (up to 12 hours), so this removes the need to manually generate and rotate a token before it expires. The Connector resolves AWS credentials through the [default credential provider chain](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials-chain.html) (IAM role, profile, environment variables, etc.), mints one token per CodeArtifact domain, and re-mints ahead of expiry so the request path does not block.
 
-To enable it, configure the repository with its CodeArtifact URL and leave `password` unset; the Connector authenticates as the CodeArtifact user `aws` automatically. A statically configured `password` always takes precedence, so a manually minted token remains fully supported (for example, when the Connector runs without an AWS identity).
+To enable it, configure the repository with its CodeArtifact URL and leave `password` unset; the Connector authenticates as the CodeArtifact user `aws` automatically. Statically configured credentials (`username` + `password`) always take precedence, so a manually minted token remains fully supported (for example, when the Connector runs without an AWS identity).
 
 :::info
-Token minting applies to recipe marketplace repositories only. CodeArtifact is not supported as an [LST source](./configure-a-connector-with-maven-repository-access.md#aws-codeartifact): CodeArtifact does not serve the maven-indexer index that LST poll discovery requires, and its package assets are immutable, so the Connector rejects CodeArtifact URLs in LST and organization source configuration at startup.
+Token minting does not apply to LST or organization sources. CodeArtifact is not supported as an [LST source](./configure-a-connector-with-maven-repository-access.md#aws-codeartifact): CodeArtifact does not serve the maven-indexer index that LST poll discovery requires, and its package assets are immutable, so the Connector rejects CodeArtifact URLs in LST and organization source configuration at startup.
 :::
 
 #### Prerequisites

--- a/docs/administrator-documentation/moderne-platform/how-to-guides/connector-configuration/configure-recipe-marketplace-repositories.md
+++ b/docs/administrator-documentation/moderne-platform/how-to-guides/connector-configuration/configure-recipe-marketplace-repositories.md
@@ -122,7 +122,7 @@ When a Maven repository URL points at an [AWS CodeArtifact](https://docs.aws.ama
 To enable it, configure the repository with its CodeArtifact URL and leave `password` unset; the Connector authenticates as the CodeArtifact user `aws` automatically. A statically configured `password` always takes precedence, so a manually minted token remains fully supported (for example, when the Connector runs without an AWS identity).
 
 :::info
-This applies to any Maven repository configured for the Connector, including the [LST Maven poll sources](./configure-a-connector-with-maven-repository-access.md).
+Token minting applies to recipe marketplace repositories only. CodeArtifact is not supported as an [LST source](./configure-a-connector-with-maven-repository-access.md#aws-codeartifact): CodeArtifact does not serve the maven-indexer index that LST poll discovery requires, and its package assets are immutable, so the Connector rejects CodeArtifact URLs in LST and organization source configuration at startup.
 :::
 
 #### Prerequisites

--- a/docs/administrator-documentation/moderne-platform/how-to-guides/connector-configuration/configure-recipe-marketplace-repositories.md
+++ b/docs/administrator-documentation/moderne-platform/how-to-guides/connector-configuration/configure-recipe-marketplace-repositories.md
@@ -115,6 +115,69 @@ java -jar connector-{version}.jar \
 </TabItem>
 </Tabs>
 
+### AWS CodeArtifact
+
+When a Maven repository URL points at an [AWS CodeArtifact](https://docs.aws.amazon.com/codeartifact/latest/ug/welcome.html) endpoint (`<domain>-<account-id>.d.codeartifact.<region>.amazonaws.com`) and you leave the password unset, the Connector mints and refreshes CodeArtifact authorization tokens itself. CodeArtifact tokens are short-lived (up to 12 hours), so this removes the need to manually generate and rotate a token before it expires. The Connector resolves AWS credentials through the [default credential provider chain](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials-chain.html) (IAM role, profile, environment variables, etc.), mints one token per CodeArtifact domain, and re-mints ahead of expiry so the request path does not block.
+
+To enable it, configure the repository with its CodeArtifact URL and leave `password` unset; the Connector authenticates as the CodeArtifact user `aws` automatically. A statically configured `password` always takes precedence, so a manually minted token remains fully supported (for example, when the Connector runs without an AWS identity).
+
+:::info
+This applies to any Maven repository configured for the Connector, including the [LST Maven poll sources](./configure-a-connector-with-maven-repository-access.md).
+:::
+
+#### Prerequisites
+
+The AWS identity available to the Connector must be allowed to mint tokens for your CodeArtifact domain and read from the repository:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": "codeartifact:GetAuthorizationToken",
+            "Resource": "arn:aws:codeartifact:<region>:<account-id>:domain/<domain>"
+        },
+        {
+            "Effect": "Allow",
+            "Action": "codeartifact:ReadFromRepository",
+            "Resource": "arn:aws:codeartifact:<region>:<account-id>:repository/<domain>/<repository>"
+        },
+        {
+            "Effect": "Allow",
+            "Action": "sts:GetServiceBearerToken",
+            "Resource": "*"
+        }
+    ]
+}
+```
+
+`codeartifact:GetAuthorizationToken` mints the token and is scoped to the domain. `codeartifact:ReadFromRepository` authorizes the artifact downloads the token is then used for, and is scoped to the repository; without it, token minting succeeds but every artifact download returns HTTP 403. `sts:GetServiceBearerToken` does not support resource-level restrictions and must use `"*"`.
+
+<Tabs groupId="agent-type">
+<TabItem value="oci-container" label="OCI Container">
+
+```bash
+docker run \
+# ... Existing variables
+-e MODERNE_RECIPE_MARKETPLACE_REPOSITORIES_MAVEN_0_URI=https://my-domain-111122223333.d.codeartifact.us-east-1.amazonaws.com/maven/my-repo/ \
+# ... Additional variables
+```
+
+</TabItem>
+
+<TabItem value="executable-jar" label="Executable JAR">
+
+```bash
+java -jar connector-{version}.jar \
+# ... Existing arguments
+--moderne.recipe.marketplace.repositories.maven[0].uri=https://my-domain-111122223333.d.codeartifact.us-east-1.amazonaws.com/maven/my-repo/ \
+# ... Additional arguments
+```
+
+</TabItem>
+</Tabs>
+
 ## NPM
 
 NPM repositories support either basic authentication (`username` + `password`) or bearer token authentication (`bearerToken`), but not both at the same time.


### PR DESCRIPTION
## Problem

The Connector can now mint AWS CodeArtifact authorization tokens on its own for recipe marketplace Maven repositories whose URL points at a CodeArtifact endpoint. CodeArtifact tokens are short-lived (up to 12 hours), and until now an operator had to generate and rotate the token manually before it expired, or artifact resolution would break. The documentation had no coverage of this: nothing described the blank-password trigger, the IAM permissions the Connector's AWS identity requires, or the fact that CodeArtifact cannot be used as an LST source.

## Solution

Document the behavior on the two connector-configuration pages where a Maven repository is configured:

- Recipe marketplace repositories: a new AWS CodeArtifact section covering the URL-triggered minting, the blank-password trigger, the automatic `aws` username, static-password precedence, the AWS default credential provider chain, and the required IAM permissions (`codeartifact:GetAuthorizationToken`, `codeartifact:ReadFromRepository`, `sts:GetServiceBearerToken`), with OCI Container and executable JAR examples.
- LST Maven poll sources: a short AWS CodeArtifact section stating it is not supported as an LST or organization source and why (no maven-indexer index for poll discovery; immutable package assets prevent re-publishing an updated organization CSV), matching the Connector's startup validation, with a pointer to the recipe marketplace section for what is supported.
