### PR TITLE
Add Code Genome Project docs section

### DIFF
--- a/docs/user-documentation/code-genome-project/accessing-the-code-genome-project.md
+++ b/docs/user-documentation/code-genome-project/accessing-the-code-genome-project.md
@@ -4,28 +4,19 @@ description: How to sign in, get a token, and configure Maven, Gradle, and MCP c
 
 # Accessing the Code Genome Project
 
-The [Code Genome Project](https://codegenomeproject.org) hosts a Maven-compatible
-repository of OpenRewrite recipes and the Moderne CLI. To download from it, you need an
-identity (so the project knows who you are) and, for licensed content, an entitlement (so
-the project knows what you are allowed to download).
+The [Code Genome Project](https://codegenomeproject.org) hosts a Maven-compatible repository of OpenRewrite recipes and the Moderne CLI. To download from it, you need an identity (so the project knows who you are) and, for licensed content, an entitlement (so the project knows what you are allowed to download).
 
-This guide walks you through getting a download token, and then configuring Maven, Gradle,
-and Model Context Protocol (MCP) clients to use it. Customers should read the
-[section for customers](#accessing-licensed-content-as-a-customer), because your sign-in
-path is different from the open source one.
+This guide walks you through getting a download token, and then configuring Maven, Gradle, and Model Context Protocol (MCP) clients to use it. Customers should read the [section for customers](#accessing-licensed-content-as-a-customer), because your sign-in path is different from the open source one.
 
 ## What the repository hosts
 
-The repository serves three kinds of content, and your entitlement decides which you can
-download:
+The repository serves three kinds of content, and your entitlement decides which you can download:
 
-* **OpenRewrite OSS recipes** (Apache 2.0) and the **Moderne CLI**: available to any
-  signed-in user.
+* **OpenRewrite OSS recipes** (Apache 2.0) and the **Moderne CLI**: available to any signed-in user.
 * **Moderne Source Available License (MSAL) recipes**: available to customers only.
 * **Moderne proprietary recipes**: available to customers only.
 
-Your entitlement is checked live on every request, so access granted or revoked by Moderne
-takes effect on your next download without you needing a new token.
+Your entitlement is checked live on every request, so access granted or revoked by Moderne takes effect on your next download without you needing a new token.
 
 ## Getting a token as an open source user
 
@@ -33,39 +24,28 @@ If you only need the OSS recipes and the Moderne CLI, you can sign in with a soc
 
 1. Go to [codegenomeproject.org](https://codegenomeproject.org) and open the sign-in page.
 2. Choose **Continue with GitHub** or **Continue with Google**.
-3. Copy the download token that is shown. The token is tied to your verified email address
-   and is permanent until you stop using it.
+3. Copy the download token that is shown. The token is tied to your verified email address and is permanent until you stop using it.
 
 :::warning
-Your token is displayed only once, when it is created. Copy it before you leave the page. If
-you lose it, sign in again to generate a new one.
+Your token is displayed only once, when it is created. Copy it before you leave the page. If you lose it, sign in again to generate a new one.
 :::
 
-The token page also gives you a **Download setup guide** button that produces a
-`codegenome-setup.md` file with every configuration snippet below already filled in with
-your token.
+The token page also gives you a **Download setup guide** button that produces a `codegenome-setup.md` file with every configuration snippet below already filled in with your token.
 
 :::info
-Signing in with GitHub or Google grants access to OSS recipes and the Moderne CLI only. It
-does not grant access to MSAL or proprietary recipes, even if your email belongs to a
-customer organization. Customers should use the credentials Moderne provides instead, as
-described below.
+Signing in with GitHub or Google grants access to OSS recipes and the Moderne CLI only. It does not grant access to MSAL or proprietary recipes, even if your email belongs to a customer organization. Customers should use the credentials Moderne provides instead, as described below.
 :::
 
 ## Accessing licensed content as a customer
 
-If your organization has a commercial relationship with Moderne, you will receive three
-things directly from Moderne:
+If your organization has a commercial relationship with Moderne, you will receive three things directly from Moderne:
 
 * A **username**.
 * A **password**.
 * A **first download token** to get you started immediately.
 
 :::warning
-Use the username and password that Moderne provides. Do not create your own account with
-GitHub or Google sign-in. A self-created social account is treated as an open source user
-and will not have access to MSAL or proprietary recipes. Your entitlement is attached to
-the Moderne-provided credentials, not to a personal account.
+Use the username and password that Moderne provides. Do not create your own account with GitHub or Google sign-in. A self-created social account is treated as an open source user and will not have access to MSAL or proprietary recipes. Your entitlement is attached to the Moderne-provided credentials, not to a personal account.
 :::
 
 ### Signing in and managing your tokens
@@ -75,14 +55,10 @@ Use your Moderne-provided credentials to sign in and manage tokens:
 1. Go to [codegenomeproject.org](https://codegenomeproject.org) and open the sign-in page.
 2. Enter the **username** and **password** Moderne gave you and select **Sign in**.
 3. You will land on your token management page, where you can:
-   * **Generate a download token**: mint a new token to use as a credential. Copy it when
-     it is shown, because, like all tokens, it appears only once.
-   * **Revoke**: revoke any existing token by its short id. Revoked tokens stop working
-     immediately.
+   * **Generate a download token**: mint a new token to use as a credential. Copy it when it is shown, because, like all tokens, it appears only once.
+   * **Revoke**: revoke any existing token by its short id. Revoked tokens stop working immediately.
 
-This management page is how you rotate credentials over time. Generate a separate token for
-each place you use it (for example, one per CI pipeline) so you can revoke one without
-affecting the others.
+This management page is how you rotate credentials over time. Generate a separate token for each place you use it (for example, one per CI pipeline) so you can revoke one without affecting the others.
 
 ### Choosing a credential
 
@@ -91,17 +67,11 @@ As a customer you have two working credentials, and either can authenticate your
 * Any **download token** you generate (including the first one Moderne sent you).
 * Your **username and password** directly.
 
-Using a generated token is recommended for automation, because you can hand a single token
-to a CI system and revoke just that token later. Keep your account username and password for
-signing in to the management page.
+Using a generated token is recommended for automation, because you can hand a single token to a CI system and revoke just that token later. Keep your account username and password for signing in to the management page.
 
 ## Configuring your build tools
 
-The repository lives at `https://artifacts.codegenomeproject.org/maven`. Authenticate with
-HTTP Basic auth, using a token as the password. For the username, use your email address
-(open source users) or your Moderne-provided username (customers); the username is not
-validated for token credentials, so any value works, but using your identity keeps things
-clear.
+The repository lives at `https://artifacts.codegenomeproject.org/maven`. Authenticate with HTTP Basic auth, using a token as the password. For the username, use your email address (open source users) or your Moderne-provided username (customers); the username is not validated for token credentials, so any value works, but using your identity keeps things clear.
 
 ### Configuring Maven
 
@@ -131,9 +101,7 @@ Then declare the repository in your `pom.xml` file, referencing the same `id`:
 ```
 
 :::info
-Use the repository URL exactly as shown. Do not append a storage prefix such as `/oss` to
-the URL. The gateway adds the correct prefix for you, and an extra one causes the request
-to be rejected.
+Use the repository URL exactly as shown. Do not append a storage prefix such as `/oss` to the URL. The gateway adds the correct prefix for you, and an extra one causes the request to be rejected.
 :::
 
 ### Configuring Gradle
@@ -168,8 +136,7 @@ repositories {
 
 ## Connecting an MCP client
 
-The Code Genome Project also exposes a Model Context Protocol (MCP) endpoint at
-`https://api.codegenomeproject.org/mcp`, authenticated with a bearer token.
+The Code Genome Project also exposes a Model Context Protocol (MCP) endpoint at `https://api.codegenomeproject.org/mcp`, authenticated with a bearer token.
 
 For clients that read an `.mcp.json` file (such as Claude Code, Cursor, and VS Code):
 
@@ -192,16 +159,10 @@ claude mcp add --transport http codegenome https://api.codegenomeproject.org/mcp
 ```
 
 :::tip
-Cursor, VS Code, Windsurf, Cline, and Zed take the same URL with an `Authorization: Bearer`
-header. For clients that only speak stdio, bridge with `npx mcp-remote`.
+Cursor, VS Code, Windsurf, Cline, and Zed take the same URL with an `Authorization: Bearer` header. For clients that only speak stdio, bridge with `npx mcp-remote`.
 :::
 
 ## Troubleshooting
 
-* **`401 Unauthorized`**: your request had no credentials, or the token is invalid or
-  revoked. Check that your build tool is sending the token, and generate a new one if
-  needed.
-* **`403 Forbidden`**: you are authenticated, but your identity is not entitled to that
-  artifact. OSS recipes and the CLI are available to everyone; MSAL and proprietary recipes
-  require a customer entitlement. If you are a customer seeing this, confirm you signed in
-  with your Moderne-provided credentials rather than a personal GitHub or Google account.
+* **`401 Unauthorized`**: your request had no credentials, or the token is invalid or revoked. Check that your build tool is sending the token, and generate a new one if needed.
+* **`403 Forbidden`**: you are authenticated, but your identity is not entitled to that artifact. OSS recipes and the CLI are available to everyone; MSAL and proprietary recipes require a customer entitlement. If you are a customer seeing this, confirm you signed in with your Moderne-provided credentials rather than a personal GitHub or Google account.

--- a/docs/user-documentation/code-genome-project/accessing-the-code-genome-project.md
+++ b/docs/user-documentation/code-genome-project/accessing-the-code-genome-project.md
@@ -1,0 +1,207 @@
+---
+description: How to sign in, get a token, and configure Maven, Gradle, and MCP clients to download from the Code Genome Project.
+---
+
+# Accessing the Code Genome Project
+
+The [Code Genome Project](https://codegenomeproject.org) hosts a Maven-compatible
+repository of OpenRewrite recipes and the Moderne CLI. To download from it, you need an
+identity (so the project knows who you are) and, for licensed content, an entitlement (so
+the project knows what you are allowed to download).
+
+This guide walks you through getting a download token, and then configuring Maven, Gradle,
+and Model Context Protocol (MCP) clients to use it. Customers should read the
+[section for customers](#accessing-licensed-content-as-a-customer), because your sign-in
+path is different from the open source one.
+
+## What the repository hosts
+
+The repository serves three kinds of content, and your entitlement decides which you can
+download:
+
+* **OpenRewrite OSS recipes** (Apache 2.0) and the **Moderne CLI**: available to any
+  signed-in user.
+* **Moderne Source Available License (MSAL) recipes**: available to customers only.
+* **Moderne proprietary recipes**: available to customers only.
+
+Your entitlement is checked live on every request, so access granted or revoked by Moderne
+takes effect on your next download without you needing a new token.
+
+## Getting a token as an open source user
+
+If you only need the OSS recipes and the Moderne CLI, you can sign in with a social account:
+
+1. Go to [codegenomeproject.org](https://codegenomeproject.org) and open the sign-in page.
+2. Choose **Continue with GitHub** or **Continue with Google**.
+3. Copy the download token that is shown. The token is tied to your verified email address
+   and is permanent until you stop using it.
+
+:::warning
+Your token is displayed only once, when it is created. Copy it before you leave the page. If
+you lose it, sign in again to generate a new one.
+:::
+
+The token page also gives you a **Download setup guide** button that produces a
+`codegenome-setup.md` file with every configuration snippet below already filled in with
+your token.
+
+:::info
+Signing in with GitHub or Google grants access to OSS recipes and the Moderne CLI only. It
+does not grant access to MSAL or proprietary recipes, even if your email belongs to a
+customer organization. Customers should use the credentials Moderne provides instead, as
+described below.
+:::
+
+## Accessing licensed content as a customer
+
+If your organization has a commercial relationship with Moderne, you will receive three
+things directly from Moderne:
+
+* A **username**.
+* A **password**.
+* A **first download token** to get you started immediately.
+
+:::warning
+Use the username and password that Moderne provides. Do not create your own account with
+GitHub or Google sign-in. A self-created social account is treated as an open source user
+and will not have access to MSAL or proprietary recipes. Your entitlement is attached to
+the Moderne-provided credentials, not to a personal account.
+:::
+
+### Signing in and managing your tokens
+
+Use your Moderne-provided credentials to sign in and manage tokens:
+
+1. Go to [codegenomeproject.org](https://codegenomeproject.org) and open the sign-in page.
+2. Enter the **username** and **password** Moderne gave you and select **Sign in**.
+3. You will land on your token management page, where you can:
+   * **Generate a download token**: mint a new token to use as a credential. Copy it when
+     it is shown, because, like all tokens, it appears only once.
+   * **Revoke**: revoke any existing token by its short id. Revoked tokens stop working
+     immediately.
+
+This management page is how you rotate credentials over time. Generate a separate token for
+each place you use it (for example, one per CI pipeline) so you can revoke one without
+affecting the others.
+
+### Choosing a credential
+
+As a customer you have two working credentials, and either can authenticate your downloads:
+
+* Any **download token** you generate (including the first one Moderne sent you).
+* Your **username and password** directly.
+
+Using a generated token is recommended for automation, because you can hand a single token
+to a CI system and revoke just that token later. Keep your account username and password for
+signing in to the management page.
+
+## Configuring your build tools
+
+The repository lives at `https://artifacts.codegenomeproject.org/maven`. Authenticate with
+HTTP Basic auth, using a token as the password. For the username, use your email address
+(open source users) or your Moderne-provided username (customers); the username is not
+validated for token credentials, so any value works, but using your identity keeps things
+clear.
+
+### Configuring Maven
+
+Add the repository credentials to your `~/.m2/settings.xml` file:
+
+```xml
+<settings>
+  <servers>
+    <server>
+      <id>codegenome</id>
+      <username>you@example.com</username>
+      <password>YOUR_TOKEN</password>
+    </server>
+  </servers>
+</settings>
+```
+
+Then declare the repository in your `pom.xml` file, referencing the same `id`:
+
+```xml
+<repositories>
+  <repository>
+    <id>codegenome</id>
+    <url>https://artifacts.codegenomeproject.org/maven</url>
+  </repository>
+</repositories>
+```
+
+:::info
+Use the repository URL exactly as shown. Do not append a storage prefix such as `/oss` to
+the URL. The gateway adds the correct prefix for you, and an extra one causes the request
+to be rejected.
+:::
+
+### Configuring Gradle
+
+For Kotlin build scripts (`build.gradle.kts`):
+
+```kotlin
+repositories {
+    maven {
+        url = uri("https://artifacts.codegenomeproject.org/maven")
+        credentials {
+            username = "you@example.com"
+            password = "YOUR_TOKEN"
+        }
+    }
+}
+```
+
+For Groovy build scripts (`build.gradle`):
+
+```groovy
+repositories {
+    maven {
+        url = 'https://artifacts.codegenomeproject.org/maven'
+        credentials {
+            username = 'you@example.com'
+            password = 'YOUR_TOKEN'
+        }
+    }
+}
+```
+
+## Connecting an MCP client
+
+The Code Genome Project also exposes a Model Context Protocol (MCP) endpoint at
+`https://api.codegenomeproject.org/mcp`, authenticated with a bearer token.
+
+For clients that read an `.mcp.json` file (such as Claude Code, Cursor, and VS Code):
+
+```json
+{
+  "mcpServers": {
+    "codegenome": {
+      "type": "http",
+      "url": "https://api.codegenomeproject.org/mcp",
+      "headers": { "Authorization": "Bearer YOUR_TOKEN" }
+    }
+  }
+}
+```
+
+For the Claude Code CLI:
+
+```shell
+claude mcp add --transport http codegenome https://api.codegenomeproject.org/mcp --header "Authorization: Bearer YOUR_TOKEN"
+```
+
+:::tip
+Cursor, VS Code, Windsurf, Cline, and Zed take the same URL with an `Authorization: Bearer`
+header. For clients that only speak stdio, bridge with `npx mcp-remote`.
+:::
+
+## Troubleshooting
+
+* **`401 Unauthorized`**: your request had no credentials, or the token is invalid or
+  revoked. Check that your build tool is sending the token, and generate a new one if
+  needed.
+* **`403 Forbidden`**: you are authenticated, but your identity is not entitled to that
+  artifact. OSS recipes and the CLI are available to everyone; MSAL and proprietary recipes
+  require a customer entitlement. If you are a customer seeing this, confirm you signed in
+  with your Moderne-provided credentials rather than a personal GitHub or Google account.

--- a/docs/user-documentation/code-genome-project/overview.md
+++ b/docs/user-documentation/code-genome-project/overview.md
@@ -4,55 +4,34 @@ description: What the Code Genome Project is, what you can do with it, and why i
 
 # Code Genome Project overview
 
-Enterprise software is built on a vast substrate of open source and third-party components,
-stitched together for business functionality. Artifact repositories store that substrate, but
-they do not help you understand it. The [Code Genome Project](https://codegenomeproject.org)
-does: it sequences the open source genome and gives you the tools to splice it.
+Enterprise software is built on a vast substrate of open source and third-party components, stitched together for business functionality. Artifact repositories store that substrate, but they do not help you understand it. The [Code Genome Project](https://codegenomeproject.org) does: it sequences the open source genome and gives you the tools to splice it.
 
 Concretely, the Code Genome Project lets you:
 
-* **Search the open source substrate.** A trigram index over the source code of open source
-  libraries lets you search the corpus by text or by resolved type relationships, and do
-  reverse lookups such as every call site of a method. It is available through a web UI and
-  through a Model Context Protocol (MCP) endpoint, so your agents can put the genome to work
-  in their own workflows.
-* **Get the tools that edit it.** A hosted catalogue of OpenRewrite recipes and the Moderne
-  CLI, served from a Maven-compatible repository you can resolve from your builds.
+* **Search the open source substrate.** A trigram index over the source code of open source libraries lets you search the corpus by text or by resolved type relationships, and do reverse lookups such as every call site of a method. It is available through a web UI and through a Model Context Protocol (MCP) endpoint, so your agents can put the genome to work in their own workflows.
+* **Get the tools that edit it.** A hosted catalogue of OpenRewrite recipes and the Moderne CLI, served from a Maven-compatible repository you can resolve from your builds.
 
-Searching is open to everyone and needs no account. Downloading artifacts requires a free
-token, and some recipes require a customer entitlement. See
-[Accessing the Code Genome Project](./accessing-the-code-genome-project.md) to get set up,
-and [Searching recipes and open source code](./searching-the-code-genome-project.md) to
-start searching.
+Searching is open to everyone and needs no account. Downloading artifacts requires a free token, and some recipes require a customer entitlement. See [Accessing the Code Genome Project](./accessing-the-code-genome-project.md) to get set up, and [Searching recipes and open source code](./searching-the-code-genome-project.md) to start searching.
 
 ## What you can do with it
 
 The Code Genome Project has four parts that work together:
 
-* **Search**: run code search across the indexed open source corpus, by text or by type
-  graph, and follow references back to where they come from.
-* **Recipes**: browse the catalogue of OpenRewrite recipes and see the artifact and license
-  for each one.
+* **Search**: run code search across the indexed open source corpus, by text or by type graph, and follow references back to where they come from.
+* **Recipes**: browse the catalogue of OpenRewrite recipes and see the artifact and license for each one.
 * **MCP**: connect an agent to the search endpoint and query the genome programmatically.
 * **CLI**: resolve the Moderne CLI from the same repository that hosts the recipes.
 
 ## Why now
 
-The Code Genome Project is launching now because the way OpenRewrite's recipes have been
-distributed is changing. Those recipes have historically been published to the Central
-Repository (Maven Central), operated by Sonatype. Sonatype is introducing limits on public
-publishing, including a cap on the number of releases per month and a size cap per release.
+The Code Genome Project is launching now because the way OpenRewrite's recipes have been distributed is changing. Those recipes have historically been published to the Central Repository (Maven Central), operated by Sonatype. Sonatype is introducing limits on public publishing, including a cap on the number of releases per month and a size cap per release.
 
 Those limits do not fit how OpenRewrite is built and shipped:
 
-* A single release of OpenRewrite's primary repository exceeds both the release-count and
-  size limits on its own.
+* A single release of OpenRewrite's primary repository exceeds both the release-count and size limits on its own.
 * OpenRewrite releases frequently, often several times per week.
 
-Rather than let another party's constraints dictate how these tools reach you, Moderne now
-hosts OpenRewrite's recipes and the Moderne CLI in the Code Genome Project. The recipes and
-CLI stay reliably available to everyone, customers get a single place to get the licensed
-recipes as well, and the same infrastructure powers the search and MCP capabilities above.
+Rather than let another party's constraints dictate how these tools reach you, Moderne now hosts OpenRewrite's recipes and the Moderne CLI in the Code Genome Project. The recipes and CLI stay reliably available to everyone, customers get a single place to get the licensed recipes as well, and the same infrastructure powers the search and MCP capabilities above.
 
 ## What is supported today
 
@@ -63,16 +42,11 @@ Today, the Code Genome Project supports the **Maven** ecosystem:
 
 ## What is planned
 
-Support for additional package ecosystems is on the roadmap. The intent is to extend both
-the repository and the search dataset beyond Maven to other ecosystems such as **PyPI**
-(Python), **npm** (JavaScript and TypeScript), and **NuGet** (.NET) over time.
+Support for additional package ecosystems is on the roadmap. The intent is to extend both the repository and the search dataset beyond Maven to other ecosystems such as **PyPI** (Python), **npm** (JavaScript and TypeScript), and **NuGet** (.NET) over time.
 
-If a specific ecosystem is important to your team, let your Moderne contact know so it can be
-prioritized.
+If a specific ecosystem is important to your team, let your Moderne contact know so it can be prioritized.
 
 ## Next steps
 
-* [Accessing the Code Genome Project](./accessing-the-code-genome-project.md): sign in, get
-  a token, and configure Maven, Gradle, and MCP clients.
-* [Searching recipes and open source code](./searching-the-code-genome-project.md): browse
-  the recipe catalog and search indexed source code.
+* [Accessing the Code Genome Project](./accessing-the-code-genome-project.md): sign in, get a token, and configure Maven, Gradle, and MCP clients.
+* [Searching recipes and open source code](./searching-the-code-genome-project.md): browse the recipe catalog and search indexed source code.

--- a/docs/user-documentation/code-genome-project/overview.md
+++ b/docs/user-documentation/code-genome-project/overview.md
@@ -1,0 +1,78 @@
+---
+description: What the Code Genome Project is, what you can do with it, and why it is launching now.
+---
+
+# Code Genome Project overview
+
+Enterprise software is built on a vast substrate of open source and third-party components,
+stitched together for business functionality. Artifact repositories store that substrate, but
+they do not help you understand it. The [Code Genome Project](https://codegenomeproject.org)
+does: it sequences the open source genome and gives you the tools to splice it.
+
+Concretely, the Code Genome Project lets you:
+
+* **Search the open source substrate.** A trigram index over the source code of open source
+  libraries lets you search the corpus by text or by resolved type relationships, and do
+  reverse lookups such as every call site of a method. It is available through a web UI and
+  through a Model Context Protocol (MCP) endpoint, so your agents can put the genome to work
+  in their own workflows.
+* **Get the tools that edit it.** A hosted catalogue of OpenRewrite recipes and the Moderne
+  CLI, served from a Maven-compatible repository you can resolve from your builds.
+
+Searching is open to everyone and needs no account. Downloading artifacts requires a free
+token, and some recipes require a customer entitlement. See
+[Accessing the Code Genome Project](./accessing-the-code-genome-project.md) to get set up,
+and [Searching recipes and open source code](./searching-the-code-genome-project.md) to
+start searching.
+
+## What you can do with it
+
+The Code Genome Project has four parts that work together:
+
+* **Search**: run code search across the indexed open source corpus, by text or by type
+  graph, and follow references back to where they come from.
+* **Recipes**: browse the catalogue of OpenRewrite recipes and see the artifact and license
+  for each one.
+* **MCP**: connect an agent to the search endpoint and query the genome programmatically.
+* **CLI**: resolve the Moderne CLI from the same repository that hosts the recipes.
+
+## Why now
+
+The Code Genome Project is launching now because the way OpenRewrite's recipes have been
+distributed is changing. Those recipes have historically been published to the Central
+Repository (Maven Central), operated by Sonatype. Sonatype is introducing limits on public
+publishing, including a cap on the number of releases per month and a size cap per release.
+
+Those limits do not fit how OpenRewrite is built and shipped:
+
+* A single release of OpenRewrite's primary repository exceeds both the release-count and
+  size limits on its own.
+* OpenRewrite releases frequently, often several times per week.
+
+Rather than let another party's constraints dictate how these tools reach you, Moderne now
+hosts OpenRewrite's recipes and the Moderne CLI in the Code Genome Project. The recipes and
+CLI stay reliably available to everyone, customers get a single place to get the licensed
+recipes as well, and the same infrastructure powers the search and MCP capabilities above.
+
+## What is supported today
+
+Today, the Code Genome Project supports the **Maven** ecosystem:
+
+* The repository serves Maven and Gradle clients over HTTP.
+* The code search dataset indexes the sources of Java artifacts published to Maven Central.
+
+## What is planned
+
+Support for additional package ecosystems is on the roadmap. The intent is to extend both
+the repository and the search dataset beyond Maven to other ecosystems such as **PyPI**
+(Python), **npm** (JavaScript and TypeScript), and **NuGet** (.NET) over time.
+
+If a specific ecosystem is important to your team, let your Moderne contact know so it can be
+prioritized.
+
+## Next steps
+
+* [Accessing the Code Genome Project](./accessing-the-code-genome-project.md): sign in, get
+  a token, and configure Maven, Gradle, and MCP clients.
+* [Searching recipes and open source code](./searching-the-code-genome-project.md): browse
+  the recipe catalog and search indexed source code.

--- a/docs/user-documentation/code-genome-project/searching-the-code-genome-project.md
+++ b/docs/user-documentation/code-genome-project/searching-the-code-genome-project.md
@@ -4,60 +4,38 @@ description: How to browse the recipe catalog and search indexed open source cod
 
 # Searching recipes and open source code
 
-The Code Genome Project gives you two things to search, both from
-[codegenomeproject.org](https://codegenomeproject.org) and both open to everyone without an
-account:
+The Code Genome Project gives you two things to search, both from [codegenomeproject.org](https://codegenomeproject.org) and both open to everyone without an account:
 
-* The **recipe catalog**, so you can find OpenRewrite recipes and see the artifact and
-  license for each one.
-* The **code search dataset**, so you can search across the source code of indexed open
-  source libraries by text or by resolved type relationships.
+* The **recipe catalog**, so you can find OpenRewrite recipes and see the artifact and license for each one.
+* The **code search dataset**, so you can search across the source code of indexed open source libraries by text or by resolved type relationships.
 
-Searching is free and needs no token. You only need a token to *download* an artifact, as
-described in [Accessing the Code Genome Project](./accessing-the-code-genome-project.md).
+Searching is free and needs no token. You only need a token to *download* an artifact, as described in [Accessing the Code Genome Project](./accessing-the-code-genome-project.md).
 
 ## Browsing the recipe catalog
 
-The **Recipes** tab lists every recipe available in the repository. For each recipe you can
-see its name and description, the Maven artifact you add to get it, and its license
-(Apache 2.0, Moderne Source Available License, or Moderne proprietary).
+The **Recipes** tab lists every recipe available in the repository. For each recipe you can see its name and description, the Maven artifact you add to get it, and its license (Apache 2.0, Moderne Source Available License, or Moderne proprietary).
 
-Use the catalog to find a recipe and the artifact that provides it, then add that artifact to
-your build using the snippets in the
-[access guide](./accessing-the-code-genome-project.md#configuring-your-build-tools). OSS
-recipes are available to anyone with a token; MSAL and proprietary recipes require a customer
-entitlement.
+Use the catalog to find a recipe and the artifact that provides it, then add that artifact to your build using the snippets in the [access guide](./accessing-the-code-genome-project.md#configuring-your-build-tools). OSS recipes are available to anyone with a token; MSAL and proprietary recipes require a customer entitlement.
 
 ## Searching open source code
 
-The **Search** tab searches the code search dataset, which indexes the published sources of
-open source Java libraries. Because the index is built with the same engine as the Moderne
-CLI, you can search not only by text but also by resolved type relationships, such as every
-call site of a method or every implementer of an interface.
+The **Search** tab searches the code search dataset, which indexes the published sources of open source Java libraries. Because the index is built with the same engine as the Moderne CLI, you can search not only by text but also by resolved type relationships, such as every call site of a method or every implementer of an interface.
 
-Enter a query in the search bar and results stream in as matching files are found. Select any
-result to view the surrounding source, and select an artifact to scope your next search to
-it.
+Enter a query in the search bar and results stream in as matching files are found. Select any result to view the surrounding source, and select an artifact to scope your next search to it.
 
 ### Searching by text
 
 Text queries match against file content:
 
-* `LoggerFactory.getLogger` matches that literal. Literals must be at least three characters,
-  because the index is trigram-based.
-* Multiple terms are combined with an implicit AND, so `foo bar` requires both terms, not the
-  phrase.
+* `LoggerFactory.getLogger` matches that literal. Literals must be at least three characters, because the index is trigram-based.
+* Multiple terms are combined with an implicit AND, so `foo bar` requires both terms, not the phrase.
 * `"exact phrase"` matches the quoted text, including whitespace and punctuation.
-* `/re.?gex/` matches a regular expression. Regex and literal matching are case-sensitive by
-  default; add `case:no` to relax it.
-* Combine terms with `OR`, `AND`, `NOT`, or a leading `-`, and group with parentheses. `AND`
-  binds more tightly than `OR`.
+* `/re.?gex/` matches a regular expression. Regex and literal matching are case-sensitive by default; add `case:no` to relax it.
+* Combine terms with `OR`, `AND`, `NOT`, or a leading `-`, and group with parentheses. `AND` binds more tightly than `OR`.
 
 ### Searching the type graph
 
-Type-graph operators resolve against the parsed code, not just its text, so they find true
-usages rather than string matches. Each takes a fully qualified name (`java.util.List`), a
-simple name (`List`), a glob, or a `/regex/`:
+Type-graph operators resolve against the parsed code, not just its text, so they find true usages rather than string matches. Each takes a fully qualified name (`java.util.List`), a simple name (`List`), a glob, or a `/regex/`:
 
 * `ref:` finds references to a type.
 * `calls:` finds call sites of a method.
@@ -67,53 +45,38 @@ simple name (`List`), a glob, or a `/regex/`:
 * `throws:` finds methods that declare an exception.
 * `annotated:` finds elements carrying an annotation.
 
-For example, `ref:java.util.List` finds where `List` is used as a type, and
-`calls:org.slf4j.Logger.info` finds call sites of `Logger.info`.
+For example, `ref:java.util.List` finds where `List` is used as a type, and `calls:org.slf4j.Logger.info` finds call sites of `Logger.info`.
 
 :::info
-In globs, `*` matches within a single package segment and `..` matches any number of
-packages, following the OpenRewrite and AspectJ convention rather than grep. So `..List`
-matches any package, while `*.List` matches a single segment. If you think in grep, use a
-`/regex/` instead, which matches against the whole fully qualified name (for example,
-`/.*List/`).
+In globs, `*` matches within a single package segment and `..` matches any number of packages, following the OpenRewrite and AspectJ convention rather than grep. So `..List` matches any package, while `*.List` matches a single segment. If you think in grep, use a `/regex/` instead, which matches against the whole fully qualified name (for example, `/.*List/`).
 :::
 
 ### Scoping and filtering a search
 
 Filter names are lowercase, and you can combine them with any query:
 
-* `gav:groupId:artifactId:version` scopes the search to a single artifact. Selecting an
-  artifact in the results adds this filter for you.
+* `gav:groupId:artifactId:version` scopes the search to a single artifact. Selecting an artifact in the results adds this filter for you.
 * `lang:` restricts results by language.
 * `file:` filters by file path.
 * `sym:` jumps to a symbol by name.
 * `content:` searches file content explicitly.
 
-You can also change how a search runs with `case:` (case sensitivity), `type:`
-(file, path, or symbol), `select:` (narrow symbol results), `count:` (maximum results), and
-`patternType:` or `struct:` for Comby structural patterns.
+You can also change how a search runs with `case:` (case sensitivity), `type:` (file, path, or symbol), `select:` (narrow symbol results), `count:` (maximum results), and `patternType:` or `struct:` for Comby structural patterns.
 
 :::tip
-Press <kbd>⌘</kbd> + <kbd>/</kbd> (or <kbd>Ctrl</kbd> + <kbd>/</kbd>) in the search bar to
-open the full query syntax reference, which is generated from the live grammar so it always
-matches what the bar parses.
+Press <kbd>⌘</kbd> + <kbd>/</kbd> (or <kbd>Ctrl</kbd> + <kbd>/</kbd>) in the search bar to open the full query syntax reference, which is generated from the live grammar so it always matches what the bar parses.
 :::
 
 ## Searching programmatically
 
-The search bar is backed by a JSON endpoint that you can call directly. A `GET` request to
-`/search` on the site returns the same results:
+The search bar is backed by a JSON endpoint that you can call directly. A `GET` request to `/search` on the site returns the same results:
 
 ```shell
 curl "https://codegenomeproject.org/search?q=calls:org.slf4j.Logger.info&max=20"
 ```
 
-You can pass `groupId`, `artifactId`, and `version` parameters (or a `gav:` token in `q`) to
-scope the search to one artifact, and `max`, `offset`, and `context` to control the result
-window and how many surrounding lines each match returns.
+You can pass `groupId`, `artifactId`, and `version` parameters (or a `gav:` token in `q`) to scope the search to one artifact, and `max`, `offset`, and `context` to control the result window and how many surrounding lines each match returns.
 
 ## Requesting an artifact be indexed
 
-The dataset grows over time as artifacts are indexed. If you search for an artifact that has
-not been indexed yet, it can be queued for indexing so that it becomes searchable once its
-sources have been processed. Already-indexed artifacts return their results immediately.
+The dataset grows over time as artifacts are indexed. If you search for an artifact that has not been indexed yet, it can be queued for indexing so that it becomes searchable once its sources have been processed. Already-indexed artifacts return their results immediately.

--- a/docs/user-documentation/code-genome-project/searching-the-code-genome-project.md
+++ b/docs/user-documentation/code-genome-project/searching-the-code-genome-project.md
@@ -1,0 +1,119 @@
+---
+description: How to browse the recipe catalog and search indexed open source code on the Code Genome Project.
+---
+
+# Searching recipes and open source code
+
+The Code Genome Project gives you two things to search, both from
+[codegenomeproject.org](https://codegenomeproject.org) and both open to everyone without an
+account:
+
+* The **recipe catalog**, so you can find OpenRewrite recipes and see the artifact and
+  license for each one.
+* The **code search dataset**, so you can search across the source code of indexed open
+  source libraries by text or by resolved type relationships.
+
+Searching is free and needs no token. You only need a token to *download* an artifact, as
+described in [Accessing the Code Genome Project](./accessing-the-code-genome-project.md).
+
+## Browsing the recipe catalog
+
+The **Recipes** tab lists every recipe available in the repository. For each recipe you can
+see its name and description, the Maven artifact you add to get it, and its license
+(Apache 2.0, Moderne Source Available License, or Moderne proprietary).
+
+Use the catalog to find a recipe and the artifact that provides it, then add that artifact to
+your build using the snippets in the
+[access guide](./accessing-the-code-genome-project.md#configuring-your-build-tools). OSS
+recipes are available to anyone with a token; MSAL and proprietary recipes require a customer
+entitlement.
+
+## Searching open source code
+
+The **Search** tab searches the code search dataset, which indexes the published sources of
+open source Java libraries. Because the index is built with the same engine as the Moderne
+CLI, you can search not only by text but also by resolved type relationships, such as every
+call site of a method or every implementer of an interface.
+
+Enter a query in the search bar and results stream in as matching files are found. Select any
+result to view the surrounding source, and select an artifact to scope your next search to
+it.
+
+### Searching by text
+
+Text queries match against file content:
+
+* `LoggerFactory.getLogger` matches that literal. Literals must be at least three characters,
+  because the index is trigram-based.
+* Multiple terms are combined with an implicit AND, so `foo bar` requires both terms, not the
+  phrase.
+* `"exact phrase"` matches the quoted text, including whitespace and punctuation.
+* `/re.?gex/` matches a regular expression. Regex and literal matching are case-sensitive by
+  default; add `case:no` to relax it.
+* Combine terms with `OR`, `AND`, `NOT`, or a leading `-`, and group with parentheses. `AND`
+  binds more tightly than `OR`.
+
+### Searching the type graph
+
+Type-graph operators resolve against the parsed code, not just its text, so they find true
+usages rather than string matches. Each takes a fully qualified name (`java.util.List`), a
+simple name (`List`), a glob, or a `/regex/`:
+
+* `ref:` finds references to a type.
+* `calls:` finds call sites of a method.
+* `extends:` finds subtypes of a class.
+* `implements:` finds implementers of an interface.
+* `returns:` finds methods that return a type.
+* `throws:` finds methods that declare an exception.
+* `annotated:` finds elements carrying an annotation.
+
+For example, `ref:java.util.List` finds where `List` is used as a type, and
+`calls:org.slf4j.Logger.info` finds call sites of `Logger.info`.
+
+:::info
+In globs, `*` matches within a single package segment and `..` matches any number of
+packages, following the OpenRewrite and AspectJ convention rather than grep. So `..List`
+matches any package, while `*.List` matches a single segment. If you think in grep, use a
+`/regex/` instead, which matches against the whole fully qualified name (for example,
+`/.*List/`).
+:::
+
+### Scoping and filtering a search
+
+Filter names are lowercase, and you can combine them with any query:
+
+* `gav:groupId:artifactId:version` scopes the search to a single artifact. Selecting an
+  artifact in the results adds this filter for you.
+* `lang:` restricts results by language.
+* `file:` filters by file path.
+* `sym:` jumps to a symbol by name.
+* `content:` searches file content explicitly.
+
+You can also change how a search runs with `case:` (case sensitivity), `type:`
+(file, path, or symbol), `select:` (narrow symbol results), `count:` (maximum results), and
+`patternType:` or `struct:` for Comby structural patterns.
+
+:::tip
+Press <kbd>⌘</kbd> + <kbd>/</kbd> (or <kbd>Ctrl</kbd> + <kbd>/</kbd>) in the search bar to
+open the full query syntax reference, which is generated from the live grammar so it always
+matches what the bar parses.
+:::
+
+## Searching programmatically
+
+The search bar is backed by a JSON endpoint that you can call directly. A `GET` request to
+`/search` on the site returns the same results:
+
+```shell
+curl "https://codegenomeproject.org/search?q=calls:org.slf4j.Logger.info&max=20"
+```
+
+You can pass `groupId`, `artifactId`, and `version` parameters (or a `gav:` token in `q`) to
+scope the search to one artifact, and `max`, `offset`, and `context` to control the result
+window and how many surrounding lines each match returns.
+
+## Requesting an artifact be indexed
+
+The dataset grows over time as artifacts are indexed. If you search for an artifact that has
+not been indexed yet, it can be queued for indexing so that it becomes searchable once its
+sources have been processed. Already-indexed artifacts return their results immediately.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -1205,9 +1205,32 @@ const licensing = {
   ],
 };
 
+const codeGenomeProject = {
+  type: 'category' as const,
+  label: 'Code Genome Project',
+  customProps: {
+    gemIcon: 'green-triangle',
+    megaMenu: true,
+    homepageHref: '/user-documentation/code-genome-project/overview',
+  },
+  link: {
+    type: 'generated-index' as const,
+    title: 'Code Genome Project',
+    description: 'A Maven-compatible repository of OpenRewrite recipes and the Moderne CLI, plus a public open source code search dataset, hosted at codegenomeproject.org.',
+    slug: '/user-documentation/code-genome-project',
+    keywords: ['code genome project', 'recipes', 'maven', 'token', 'search'],
+  },
+  items: [
+    'user-documentation/code-genome-project/overview',
+    'user-documentation/code-genome-project/accessing-the-code-genome-project',
+    'user-documentation/code-genome-project/searching-the-code-genome-project',
+  ],
+};
+
 // Final sidebar composition
 const sidebars: SidebarsConfig = {
   docs: [
+    codeGenomeProject,
     platform.practitioner,
     cli,
     agentTools,

--- a/src/config/megaMenuData.ts
+++ b/src/config/megaMenuData.ts
@@ -36,6 +36,7 @@ const derivedProducts = deriveProductsFromSidebars();
  * Products not in this list will appear at the end
  */
 const secondaryNavOrder = [
+  'Code Genome Project',
   'Platform',
   'CLI',
   'Agent tools',
@@ -49,6 +50,7 @@ const secondaryNavOrder = [
  * Preferred order for homepage product cards (matches design)
  */
 const homepageCardOrder = [
+  'Code Genome Project',
   'Platform',
   'CLI',
   'Agent tools',


### PR DESCRIPTION
## Background / problem

The Code Genome Project (codegenomeproject.org) is launching, with a customer preview live now and GA on August 11, but the documentation has no section covering it. Customers need to understand what it is, how to access it (sign in, get a token, and configure Maven, Gradle, and MCP clients), and how to search the recipe catalogue and the open source code index.

## Solution

This adds a new Code Genome Project section under user documentation with three pages. The overview leads with the capability story, that the project sequences the open source substrate and gives you the tools to splice it, and includes a "Why now" section that explains the Sonatype Maven Central publishing limits that prompted Moderne to host the recipes and CLI itself. The access guide walks through the two sign-in paths (social login for open source users, and Moderne-provided username and password for customers), token generation and revocation, and the Maven, Gradle, and MCP configuration snippets. The search guide covers browsing the recipe catalogue and searching indexed open source code, including the text and type-graph query syntax and scoping to an artifact.

The section is wired into the sidebar and, through the derived top-bar mega menu, appears as the first product with its own gem icon.

## Test plan

- [x] `yarn build` succeeds with the three new pages
- [x] Code Genome Project appears first in the left sidebar, top-bar mega menu, and homepage product cards
- [x] Internal links between the three pages resolve
