### PR TITLE
Document wrapper version-lookup caching and distributionUrlEarlyAccess

### DIFF
--- a/docs/user-documentation/moderne-cli/how-to-guides/cli-wrapper.md
+++ b/docs/user-documentation/moderne-cli/how-to-guides/cli-wrapper.md
@@ -121,11 +121,31 @@ The `moderne-wrapper.properties` file supports these properties:
 |-------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
 | `version`               | CLI version to use. `RELEASE` resolves the latest release from Maven Central. `LATEST` resolves the latest snapshot. Or pin a specific version like `4.x.x`. | `RELEASE`     |
 | `distributionUrl`       | URL template for the distribution archive. Use `${version}` and `${platform}` as placeholders.                                                               | Maven Central |
+| `distributionUrlEarlyAccess` | Base URL of the repository used to resolve `LATEST`/snapshot versions. Overrides Sonatype (Maven Central Snapshots) — point it at your own snapshot repository in restricted environments. | Sonatype (Maven Central Snapshots) |
 | `distributionUsername`  | Username for basic authentication when downloading the distribution.                                                                                         | _(none)_      |
 | `distributionPassword`  | Password for basic authentication when downloading the distribution.                                                                                         | _(none)_      |
 | `distributionToken`     | Bearer token for authentication when downloading the distribution. Takes precedence over username/password if both are set.                                   | _(none)_      |
 | `distributionSha256Sum` | Expected SHA-256 of the downloaded archive. Verified if set.                                                                                                 | _(none)_      |
+| `distributionUrlCacheTtl` | How long to cache the resolved `RELEASE` version before re-checking the distribution repository, as an ISO-8601 duration (e.g. `PT1H`, `PT10M`). `PT0S` disables caching. | `PT1H` |
+| `distributionUrlEarlyAccessCacheTtl` | How long to cache the resolved `LATEST`/snapshot version before re-checking the early-access repository, as an ISO-8601 duration. `PT0S` disables caching. | `PT1H` |
 | `jdkUrl`                | URL to a JDK archive for auto-download. Set to `skip` to disable JDK auto-download entirely.                                                                 | Adoptium API  |
+
+### Caching the version lookup
+
+When `version` is dynamic (`RELEASE` or `LATEST`), the wrapper resolves it to a concrete version by fetching `maven-metadata.xml` on every invocation — a network round-trip to the artifact repository before each command runs. In environments where that repository is remote, slow, or rate-limited, this adds latency to every `mod` call.
+
+To avoid it, the wrapper caches the resolved version under `~/.moderne/cli/version-cache/` for a configurable time-to-live, so routine runs reuse the last lookup instead of re-fetching. The two resolution channels are cached independently: `distributionUrlCacheTtl` governs the `RELEASE` lookup and `distributionUrlEarlyAccessCacheTtl` the `LATEST`/snapshot lookups. Both are [ISO-8601 durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (for example `PT1H` for one hour or `PT10M` for ten minutes) and default to one hour. Set a channel's value to `PT0S` to disable caching for it.
+
+```properties
+version=RELEASE
+distributionUrlCacheTtl=PT1H
+```
+
+The cache only affects how quickly the wrapper *notices* a newer published version — it never blocks an upgrade you have already pinned. To force a fresh lookup for a single run (bypassing and refreshing the cache), set `MODERNE_WRAPPER_REFRESH=1`:
+
+```bash
+MODERNE_WRAPPER_REFRESH=1 mod --version
+```
 
 ### Air-gapped or restricted environments
 
@@ -141,7 +161,12 @@ jdkUrl=skip
 Setting `jdkUrl=skip` disables the JDK auto-download, which is useful when you know a compatible JDK is already available on the system.
 
 :::warning
-In an environment that cannot reach Maven Central, you must pin a concrete `version` (such as `4.x.x`) rather than leaving it at the default `RELEASE` (or `LATEST`). The wrapper's `RELEASE` and `LATEST` resolution always queries Maven Central for `maven-metadata.xml`, regardless of any `distributionUrl` setting. If Maven Central is unreachable and the version is left dynamic, every `mod` invocation will fail at version resolution. Pinning a concrete version skips that lookup entirely.
+`distributionUrl` controls only where the distribution archive is *downloaded* from, not where a dynamic `version` is *resolved*. `RELEASE` resolution queries Maven Central for `maven-metadata.xml`, and `LATEST`/snapshot resolution queries Sonatype (Maven Central Snapshots). If neither is reachable and the version is left dynamic, every `mod` invocation fails at version resolution.
+
+In an air-gapped environment you therefore have two options:
+
+- **Pin a concrete `version`** (such as `4.x.x`), which skips the metadata lookup entirely — the simplest choice.
+- **Redirect the snapshot lookup** with `distributionUrlEarlyAccess`, pointing it at your own snapshot repository, if you need to keep tracking `LATEST` from an internal mirror.
 :::
 
 :::note
@@ -239,6 +264,7 @@ GraalVM distributions are **not compatible** with the CLI's AOT cache. The wrapp
 | `MODERNE_WRAPPER_DISTRIBUTION_TOKEN`    | Bearer token for distribution downloads (overrides user/pass)      |
 | `MODERNE_WRAPPER_DISTRIBUTION_URL`      | Override `distributionUrl` without a properties file               |
 | `MODERNE_WRAPPER_VERSION`               | Override `version` without a properties file                       |
+| `MODERNE_WRAPPER_REFRESH`               | Force a fresh version lookup this run, bypassing the TTL cache      |
 
 ## Directory layout
 

--- a/docs/user-documentation/moderne-cli/references/cli-4-0-0-changes.md
+++ b/docs/user-documentation/moderne-cli/references/cli-4-0-0-changes.md
@@ -202,6 +202,17 @@ The wrapper will replace `${version}`, `${platform}`, and `${extension}` automat
 
 Setting `jdkUrl=skip` tells the wrapper not to download a JDK on its own. In this case, you will need Java 25+ available via `MODERNE_JAVA_HOME` or your `PATH`.
 
+`distributionUrl` controls where the distribution archive is downloaded from, but not where a dynamic `version` is *resolved*. `RELEASE` resolution queries Maven Central and `LATEST`/snapshot resolution queries Sonatype (Maven Central Snapshots). If you track `LATEST` from an internal snapshot repository, set `distributionUrlEarlyAccess` to that repository's base URL so the snapshot lookup is redirected away from Sonatype:
+
+```properties
+version=LATEST
+distributionUrlEarlyAccess=https://nexus.corp.example.com/repository/snapshots
+```
+
+### Caching the version lookup
+
+For a dynamic `version`, the wrapper resolves it by fetching `maven-metadata.xml` on every invocation, which is a network round-trip to the artifact repository before each command. The wrapper caches that resolved version under `~/.moderne/cli/version-cache/` for a configurable time-to-live, so routine runs don't re-check on every call. `distributionUrlCacheTtl` governs the `RELEASE` lookup and `distributionUrlEarlyAccessCacheTtl` the `LATEST`/snapshot lookups; both are ISO-8601 durations (for example `PT1H` or `PT10M`), default to one hour, and accept `PT0S` to disable caching. Set `MODERNE_WRAPPER_REFRESH=1` to force a fresh lookup for a single run. See the [CLI wrapper guide](../how-to-guides/cli-wrapper.md#caching-the-version-lookup) for details.
+
 ### Authenticated mirrors
 
 If your internal mirror requires authentication, the wrapper supports basic auth and bearer token credentials via environment variables or properties. This is especially important for first-time installs where no properties file exists yet.


### PR DESCRIPTION
- Companion docs for moderneinc/moderne-cli#4408, which resolves moderneinc/customer-requests#2835.

The CLI wrapper now caches the resolved `RELEASE`/`LATEST` version for a configurable TTL instead of fetching `maven-metadata.xml` on every `mod`/`modw` invocation. This PR updates the two pages the issue calls out:

**`how-to-guides/cli-wrapper.md`**
- Added a **Caching the version lookup** section explaining the behavior, the two per-channel TTL properties, and the `MODERNE_WRAPPER_REFRESH=1` escape hatch.
- Added `distributionUrlEarlyAccess`, `distributionUrlCacheTtl`, and `distributionUrlEarlyAccessCacheTtl` rows to the properties reference table.
- Corrected the air-gapped warning: `distributionUrl` controls only the *download*, not version *resolution* — `RELEASE` resolves against Maven Central and `LATEST`/snapshot against Sonatype, redirectable via `distributionUrlEarlyAccess`.
- Added `MODERNE_WRAPPER_REFRESH` to the environment-variables table.

**`references/cli-4-0-0-changes.md`**
- Documented `distributionUrlEarlyAccess` and a **Caching the version lookup** subsection under the internal-mirror section, cross-linking to the wrapper guide.

Fills a pre-existing gap the issue flags: `distributionUrlEarlyAccess` was previously undocumented, even though the air-gapped/restricted-environment scenario is exactly where you'd redirect early-access/snapshot lookups away from Sonatype.