### PR TITLE
Document JavaScript and Python in the default build pipeline

### DIFF
--- a/docs/user-documentation/moderne-cli/how-to-guides/build-steps.md
+++ b/docs/user-documentation/moderne-cli/how-to-guides/build-steps.md
@@ -9,7 +9,9 @@ description: Explains what build steps are and the various ways you can configur
 
 The Moderne CLI detects build tools, produces a list of build “steps”, and executes each of those steps to produce LSTs. Any file parsed by a previous build step is skipped by its successors.
 
-In the default configuration, the CLI first looks for Gradle build files, then Bazel, then Maven, and then sbt. These external build tool steps are followed by the JavaScript and Python language steps, and finally by a resource parsing step that scoops up any files that weren't parsed by the preceding steps, because not every file in a repository is part of a source set under management by a build tool. For example, the top level `README.md` in a repository is generally parsed by the resource parsing step because it isn't located in a place that it would be part of a source set defined by an external build tool.
+In the default configuration, the CLI first looks for Gradle build files, then Bazel, then Maven, and then sbt. These external build tool steps are followed by the JavaScript and Python language steps, and finally by a resource parsing step.
+
+The resource step scoops up any files that weren't parsed by the preceding steps, because not every file in a repository is part of a source set managed by a build tool. For example, the top level `README.md` in a repository is generally parsed by the resource parsing step because it isn't located where it would be part of a source set defined by an external build tool.
 
 ## Build step types
 
@@ -19,7 +21,7 @@ The CLI supports the following build step types:
 * **Language-specific steps**: `python`, `javascript`, `dotnet`, `go`, and `mainframe`. These use dedicated parsers to handle their respective language ecosystems.
 * **Resource step**: `resource`. A catch-all step that parses files not handled by other steps (YAML, XML, JSON, Terraform, properties, etc.).
 
-In the default configuration, the external build tool steps, the `javascript` and `python` language steps, and the resource step all run automatically (JavaScript and Python were added to the default pipeline in CLI v4.3.0; on earlier versions they required explicit configuration). The `dotnet`, `go`, and `mainframe` steps must be [explicitly configured](#configuring-build-steps-explicitly) in your `moderne.yml` file.
+In the default configuration, the external build tool steps, the `javascript` and `python` language steps, and the resource step all run automatically. JavaScript and Python were added to the default pipeline in CLI v4.3.0; on earlier versions, they required explicit configuration. The `dotnet`, `go`, and `mainframe` steps must be [explicitly configured](#configuring-build-steps-explicitly) in your `moderne.yml` file.
 
 :::tip
 For a JVM build tool the CLI does not natively support, such as a homegrown or internal build system, you can hand-author the prebuild tree yourself and the CLI will parse it with full type attribution. See [authoring a prebuild for a custom JVM build tool](./custom-build-tool-prebuild.md).
@@ -74,7 +76,7 @@ insurance-policy-administration/
 
 ### Language-specific steps
 
-Language-specific steps use dedicated parsers via RPC to handle their respective ecosystems. The `javascript` and `python` steps run in the default pipeline (since CLI v4.3.0); in that default configuration a failure in either step does not stop the build — the affected files fall through to the resource step and are parsed as plain text instead. The `dotnet`, `go`, and `mainframe` steps must be explicitly configured.
+Language-specific steps use dedicated parsers via RPC to handle their respective ecosystems. The `javascript` and `python` steps run in the default pipeline as of CLI v4.3.0. In that default configuration, a failure in either step does not stop the build. Instead, the affected files fall through to the resource step and are parsed as plain text. The `dotnet`, `go`, and `mainframe` steps must be explicitly configured.
 
 * **`python`** - Parses Python projects. Detects projects via `pyproject.toml`, `setup.py`, or `.py` files. Requires Python 3.9+. See [Python configuration](./python.md) for setup details.
 * **`javascript`** - Parses JavaScript and TypeScript projects. Detects projects via `package.json` files. Automatically discovers the appropriate package manager (npm, yarn, pnpm, or bun) and Node.js version. See [JavaScript configuration](./javascript.md) for setup details.
@@ -109,7 +111,7 @@ build:
         **/*
 ```
 
-This is a close equivalent rather than an exact one: the default pipeline also includes the generic JVM step for [hand-authored prebuild trees](./custom-build-tool-prebuild.md), which has no `moderne.yml` step type and only runs in the default configuration.
+This configuration is a close equivalent of the defaults, but not an exact one. The default pipeline also includes a generic JVM step for [hand-authored prebuild trees](./custom-build-tool-prebuild.md); that step has no `moderne.yml` step type and runs only in the default configuration.
 
 The order of the steps is important, as any file parsed by one step will be skipped by a subsequent step. In this way, the steps drive the order of precedence of build tools.
 
@@ -129,7 +131,9 @@ build:
 The available step types are: `maven`, `gradle`, `bazel`, `sbt`, `python`, `javascript`, `dotnet`, `go`, `mainframe`, and `resource`.
 
 :::danger
-An explicit `build.steps` list fully replaces the default pipeline rather than extending it. Any step type you leave out will never run — for instance, if your configuration omits the `bazel` step, Bazel files are parsed by the `resource` step as plain text even when Bazel files are present. When adding a step, start from the default list above and add to it rather than listing only the steps you are adding. This also means an explicit configuration written for an older CLI version may disable steps that newer versions run by default (such as `javascript` and `python`), so revisit explicit configurations when upgrading.
+An explicit `build.steps` list fully replaces the default pipeline rather than extending it, so any step type you leave out will never run. For instance, if your configuration omits the `bazel` step, Bazel files are parsed as plain text by the `resource` step, even when Bazel files are present.
+
+When you add a step, start from the default list above and add to it rather than listing only the steps you want. An explicit configuration written for an older CLI can also disable steps that newer versions run by default, such as `javascript` and `python`, so revisit your explicit configurations when you upgrade.
 :::
 
 ### Add a resource step to cause files/folders to be skipped by external build tools

--- a/docs/user-documentation/moderne-cli/how-to-guides/build-steps.md
+++ b/docs/user-documentation/moderne-cli/how-to-guides/build-steps.md
@@ -9,17 +9,17 @@ description: Explains what build steps are and the various ways you can configur
 
 The Moderne CLI detects build tools, produces a list of build “steps”, and executes each of those steps to produce LSTs. Any file parsed by a previous build step is skipped by its successors.
 
-In the default configuration, the CLI first looks for Gradle build files, then Bazel, and then Maven. These external build tools are followed by a resource parsing step that scoops up any files that weren't parsed by the external build tool steps, because not every file in a repository is part of a source set under management by a build tool. For example, the top level `README.md` in a repository is generally parsed by the resource parsing step because it isn't located in a place that it would be part of a source set defined by an external build tool.
+In the default configuration, the CLI first looks for Gradle build files, then Bazel, then Maven, and then sbt. These external build tool steps are followed by the JavaScript and Python language steps, and finally by a resource parsing step that scoops up any files that weren't parsed by the preceding steps, because not every file in a repository is part of a source set under management by a build tool. For example, the top level `README.md` in a repository is generally parsed by the resource parsing step because it isn't located in a place that it would be part of a source set defined by an external build tool.
 
 ## Build step types
 
 The CLI supports the following build step types:
 
-* **External build tool steps**: `maven`, `gradle`, and `bazel`. These invoke the respective build tool to extract build metadata — the project structure, source sets, and classpaths — and then the CLI parses the source code itself with full type attribution. The build tool is used only for discovery; the CLI does the parsing (see [discovery and parsing](#discovery-and-parsing)).
+* **External build tool steps**: `maven`, `gradle`, `bazel`, and `sbt`. These invoke the respective build tool to extract build metadata — the project structure, source sets, and classpaths — and then the CLI parses the source code itself with full type attribution. The build tool is used only for discovery; the CLI does the parsing (see [discovery and parsing](#discovery-and-parsing)).
 * **Language-specific steps**: `python`, `javascript`, `dotnet`, `go`, and `mainframe`. These use dedicated parsers to handle their respective language ecosystems.
 * **Resource step**: `resource`. A catch-all step that parses files not handled by other steps (YAML, XML, JSON, Terraform, properties, etc.).
 
-In the default configuration, only the external build tool steps and the resource step run automatically. Language-specific steps must be [explicitly configured](#configuring-build-steps-explicitly) in your `moderne.yml` file.
+In the default configuration, the external build tool steps, the `javascript` and `python` language steps, and the resource step all run automatically (JavaScript and Python were added to the default pipeline in CLI v4.3.0; on earlier versions they required explicit configuration). The `dotnet`, `go`, and `mainframe` steps must be [explicitly configured](#configuring-build-steps-explicitly) in your `moderne.yml` file.
 
 :::tip
 For a JVM build tool the CLI does not natively support, such as a homegrown or internal build system, you can hand-author the prebuild tree yourself and the CLI will parse it with full type attribution. See [authoring a prebuild for a custom JVM build tool](./custom-build-tool-prebuild.md).
@@ -74,7 +74,7 @@ insurance-policy-administration/
 
 ### Language-specific steps
 
-Language-specific steps use dedicated parsers via RPC to handle their respective ecosystems. Unlike external build tool steps, these do not run in the default pipeline and must be explicitly configured.
+Language-specific steps use dedicated parsers via RPC to handle their respective ecosystems. The `javascript` and `python` steps run in the default pipeline (since CLI v4.3.0); in that default configuration a failure in either step does not stop the build — the affected files fall through to the resource step and are parsed as plain text instead. The `dotnet`, `go`, and `mainframe` steps must be explicitly configured.
 
 * **`python`** - Parses Python projects. Detects projects via `pyproject.toml`, `setup.py`, or `.py` files. Requires Python 3.9+. See [Python configuration](./python.md) for setup details.
 * **`javascript`** - Parses JavaScript and TypeScript projects. Detects projects via `package.json` files. Automatically discovers the appropriate package manager (npm, yarn, pnpm, or bun) and Node.js version. See [JavaScript configuration](./javascript.md) for setup details.
@@ -86,7 +86,7 @@ Language-specific steps use dedicated parsers via RPC to handle their respective
 
 The resource build step parses resource files using OpenRewrite parsers in situations where there is no source set with binary dependency list necessary to [type-attribute](https://docs.openrewrite.org/concepts-and-explanations/lossless-semantic-trees) the resulting LSTs. These include YAML, XML, Terraform, properties, JSON, some Groovy DSLs, etc.
 
-In the default build steps, the resource build step runs after all external build tool steps, and serves as a vacuum that picks up the rest of the source files in a repository not explicitly managed by those build tools.
+In the default build steps, the resource build step runs after all other steps, and serves as a vacuum that picks up the rest of the source files in a repository not claimed by those steps.
 
 ## Configuring build steps explicitly
 
@@ -99,30 +99,37 @@ build:
     - type: gradle
     - type: bazel
     - type: maven
+    - type: sbt
+    - type: javascript
+      continueOnError: true
+    - type: python
+      continueOnError: true
     - type: resource
       inclusion: |-
         **/*
 ```
 
+This is a close equivalent rather than an exact one: the default pipeline also includes the generic JVM step for [hand-authored prebuild trees](./custom-build-tool-prebuild.md), which has no `moderne.yml` step type and only runs in the default configuration.
+
 The order of the steps is important, as any file parsed by one step will be skipped by a subsequent step. In this way, the steps drive the order of precedence of build tools.
 
-To add language-specific parsing, include the corresponding step types. For example, to parse a repository that contains both a Gradle project and Python code:
+To add a language-specific step that is not part of the default pipeline, include its step type. For example, to parse a repository that contains both a Gradle project and Go code:
 
 ```yaml
 specs: specs.moderne.ai/v1/cli
 build:
   steps:
     - type: gradle
-    - type: python
+    - type: go
     - type: resource
       inclusion: |-
         **/*
 ```
 
-The available step types are: `maven`, `gradle`, `bazel`, `python`, `javascript`, `dotnet`, `go`, `mainframe`, and `resource`.
+The available step types are: `maven`, `gradle`, `bazel`, `sbt`, `python`, `javascript`, `dotnet`, `go`, `mainframe`, and `resource`.
 
 :::danger
-Be careful if you remove a build step type as that will make it so that build type will never be used. For instance, if you removed the `bazel` build step, Bazel will never be used to build any files -- even if there were Bazel files present. Instead, Bazel files would be parsed with the `resource` parser.
+An explicit `build.steps` list fully replaces the default pipeline rather than extending it. Any step type you leave out will never run — for instance, if your configuration omits the `bazel` step, Bazel files are parsed by the `resource` step as plain text even when Bazel files are present. When adding a step, start from the default list above and add to it rather than listing only the steps you are adding. This also means an explicit configuration written for an older CLI version may disable steps that newer versions run by default (such as `javascript` and `python`), so revisit explicit configurations when upgrading.
 :::
 
 ### Add a resource step to cause files/folders to be skipped by external build tools

--- a/docs/user-documentation/moderne-cli/how-to-guides/javascript.md
+++ b/docs/user-documentation/moderne-cli/how-to-guides/javascript.md
@@ -23,6 +23,10 @@ This guide assumes that:
 
 ## Step 1: Update your `moderne.yml` file
 
+:::info
+As of CLI v4.3.0, the `javascript` build step is part of the [default build pipeline](./build-steps.md), so no `moderne.yml` change is needed to enable JavaScript support. Follow this step only if you are on an older CLI version, or if you already have an explicit `build.steps` configuration — an explicit configuration replaces the defaults, so it must list `- type: javascript` for JavaScript to be parsed.
+:::
+
 In order to enable JavaScript support, you will need to update the [build steps](./build-steps.md) in your `moderne.yml` file to include JavaScript. This file is located at `~/.moderne/cli/moderne.yml` and is created when you first set up the CLI.
 
 If your `moderne.yml` file already includes a `build` section, you can just add the `-type: javascript` line to the end of your build steps. If it doesn't, you will need to add the entire section as seen in the example below:

--- a/docs/user-documentation/moderne-cli/how-to-guides/javascript.md
+++ b/docs/user-documentation/moderne-cli/how-to-guides/javascript.md
@@ -12,6 +12,8 @@ Moderne recently announced support for JavaScript and TypeScript LSTs. With this
 
 In this guide, we'll walk you through how to configure the Moderne CLI to take advantage of this new JavaScript functionality.
 
+As of CLI v4.3.0, the CLI parses JavaScript and TypeScript out of the box, so most users don't need any `moderne.yml` changes to get started. If you're on an older CLI version or you use an explicit `build.steps` configuration, you'll need to [add the JavaScript build step manually](#adding-the-javascript-build-step-manually).
+
 <ReactPlayer className="reactPlayer" url='https://www.youtube.com/watch?v=b-IJNsozsnA' controls={true} />
 
 ## Prerequisites
@@ -21,39 +23,7 @@ This guide assumes that:
 * You have [installed and configured the Moderne CLI](../getting-started/cli-intro.md) (version `3.49.0` or higher)
 * You are familiar with running Moderne CLI commands (if not, work through our [CLI workshop](../getting-started/moderne-cli-workshop.md))
 
-## Step 1: Update your `moderne.yml` file
-
-:::info
-As of CLI v4.3.0, the `javascript` build step is part of the [default build pipeline](./build-steps.md), so no `moderne.yml` change is needed to enable JavaScript support. Follow this step only if you are on an older CLI version, or if you already have an explicit `build.steps` configuration — an explicit configuration replaces the defaults, so it must list `- type: javascript` for JavaScript to be parsed.
-:::
-
-In order to enable JavaScript support, you will need to update the [build steps](./build-steps.md) in your `moderne.yml` file to include JavaScript. This file is located at `~/.moderne/cli/moderne.yml` and is created when you first set up the CLI.
-
-If your `moderne.yml` file already includes a `build` section, you can just add the `-type: javascript` line to the end of your build steps. If it doesn't, you will need to add the entire section as seen in the example below:
-
-```yml title="moderne.yml"
-# Other keys and values...
-license:
-  key: some-license
-tenant:
-  host: https://app.moderne.io
-  apiHost: https://api.app.moderne.io
-  skipSsl: false
-  authorization: Bearer mat-some-token
-// highlight-start
-build:
-  steps:
-    - type: maven
-    - type: gradle
-    - type: bazel
-    - type: javascript
-    - type: resource
-      inclusion: |-
-        **/*
-// highlight-end
-```
-
-## Step 2: (Optionally) Configure your Node.js installation
+## Step 1: (Optionally) Configure your Node.js installation
 
 By default, the CLI uses the Node.js installation found on your `$PATH`.
 
@@ -131,7 +101,7 @@ During `mod git sync csv`, this value is written to each repository's `.moderne`
 
 You can set Node.js options via the `nodeOptions` column in your `repos.csv`. These are passed through the `NODE_OPTIONS` environment variable when building LSTs and running recipes. For more details, please check out our [repos.csv reference](../references/repos-csv.md).
 
-## Step 3: (Optionally) Clone a custom list of repositories
+## Step 2: (Optionally) Clone a custom list of repositories
 
 If you don't have the repositories you want to work with cloned locally already, you can clone a group of them by defining a `repos.csv` file that lists them out such as in the following example:
 
@@ -157,7 +127,7 @@ After creating the CSV, clone the repositories by running the following command:
 mod git sync csv . repos.csv --with-sources
 ```
 
-## Step 4: Build your JavaScript repositories
+## Step 3: Build your JavaScript repositories
 
 The next thing you'll need to do is build LSTs for each of your repositories. To build the LSTs, run:
 
@@ -179,7 +149,7 @@ Presuming everything has been set up correctly, you should see output similar to
     Cleaned 1 older builds
 ```
 
-## Step 5: Install recipes
+## Step 4: Install recipes
 
 In order to run recipes, you'll need to make sure the recipes are installed on your local machine.
 
@@ -189,7 +159,7 @@ You can install a specific JavaScript recipe module by running a command like:
 mod config recipes npm install @openrewrite/recipes-nodejs
 ```
 
-## Step 6: Run recipes
+## Step 5: Run recipes
 
 With the LSTs built and recipes installed, you can now run recipes against your JavaScript repositories. You can either specify the full recipe path for running such as in:
 
@@ -232,7 +202,7 @@ mod run . --recipe org.openrewrite.java.ChangeMethodName -PmethodPattern="* test
 ```
 :::
 
-## Step 7: View data tables
+## Step 6: View data tables
 
 Many recipes will also produce useful data tables that you can access via the `mod study` command such as in:
 
@@ -263,3 +233,35 @@ Done (9s)
 
 Data tables for each organization with rows are linked above
 ```
+
+## Adding the JavaScript build step manually
+
+You only need this step if you're on a CLI version older than v4.3.0, or if you maintain an explicit `build.steps` list in your `moderne.yml` file. An explicit list replaces the default pipeline, so it must include `- type: javascript` for JavaScript and TypeScript to be parsed. On CLI v4.3.0 and later with the default configuration, JavaScript support is already enabled and you can skip this.
+
+Update the [build steps](./build-steps.md) in your `moderne.yml` file to include JavaScript. This file is located at `~/.moderne/cli/moderne.yml` and is created when you first set up the CLI.
+
+If your `moderne.yml` file already includes a `build` section, add a `- type: javascript` step before the trailing `resource` step. If it doesn't, add the entire section as shown below:
+
+```yml title="moderne.yml"
+# Other keys and values...
+license:
+  key: some-license
+tenant:
+  host: https://app.moderne.io
+  apiHost: https://api.app.moderne.io
+  skipSsl: false
+  authorization: Bearer mat-some-token
+// highlight-start
+build:
+  steps:
+    - type: maven
+    - type: gradle
+    - type: bazel
+    - type: javascript
+    - type: resource
+      inclusion: |-
+        **/*
+// highlight-end
+```
+
+If you maintain an explicit configuration, start from the [full default pipeline](./build-steps.md#configuring-build-steps-explicitly) so you don't drop steps the CLI would otherwise run, such as `sbt` and `python`.

--- a/docs/user-documentation/moderne-cli/how-to-guides/python.md
+++ b/docs/user-documentation/moderne-cli/how-to-guides/python.md
@@ -10,6 +10,8 @@ Moderne supports Python LSTs, enabling _semantically-aware_ refactoring of Pytho
 
 In this guide, we'll walk you through how to configure the Moderne CLI to take advantage of Python support.
 
+As of CLI v4.3.0, the CLI parses Python out of the box, so most users don't need any `moderne.yml` changes to get started. If you're on an older CLI version or you use an explicit `build.steps` configuration, you'll need to [add the Python build step manually](#adding-the-python-build-step-manually).
+
 ## Prerequisites
 
 This guide assumes that:
@@ -18,39 +20,7 @@ This guide assumes that:
 * You are familiar with running Moderne CLI commands (if not, work through our [CLI workshop](../getting-started/moderne-cli-workshop.md))
 * You have Python installed on your machine
 
-## Step 1: Update your `moderne.yml` file
-
-:::info
-As of CLI v4.3.0, the `python` build step is part of the [default build pipeline](./build-steps.md), so no `moderne.yml` change is needed to enable Python support. Follow this step only if you are on an older CLI version, or if you already have an explicit `build.steps` configuration — an explicit configuration replaces the defaults, so it must list `- type: python` for Python to be parsed.
-:::
-
-In order to enable Python support, you will need to update the [build steps](./build-steps.md) in your `moderne.yml` file to include Python. This file is located at `~/.moderne/cli/moderne.yml` and is created when you first set up the CLI.
-
-If your `moderne.yml` file already includes a `build` section, you can just add the `- type: python` line to the end of your build steps. If it doesn't, you will need to add the entire section as seen in the example below:
-
-```yml title="moderne.yml"
-# Other keys and values...
-license:
-  key: some-license
-tenant:
-  host: https://app.moderne.io
-  apiHost: https://api.app.moderne.io
-  skipSsl: false
-  authorization: Bearer mat-some-token
-// highlight-start
-build:
-  steps:
-    - type: maven
-    - type: gradle
-    - type: bazel
-    - type: python
-    - type: resource
-      inclusion: |-
-        **/*
-// highlight-end
-```
-
-## Step 2: (Optionally) Configure your Python installation
+## Step 1: (Optionally) Configure your Python installation
 
 By default, the CLI automatically detects Python installations in standard locations on your machine.
 
@@ -108,7 +78,7 @@ To see the currently configured version:
 mod config python version show
 ```
 
-## Step 3: (Optionally) Clone a custom list of repositories
+## Step 2: (Optionally) Clone a custom list of repositories
 
 If you don't have the repositories you want to work with cloned locally already, you can clone a group of them by defining a `repos.csv` file that lists them out such as in the following example:
 
@@ -129,7 +99,7 @@ After creating the CSV, clone the repositories by running the following command:
 mod git sync csv . repos.csv --with-sources
 ```
 
-## Step 4: Build your Python repositories
+## Step 3: Build your Python repositories
 
 The next thing you'll need to do is build LSTs for each of your repositories. To build the LSTs, run:
 
@@ -153,7 +123,7 @@ Presuming everything has been set up correctly, you should see output similar to
     Cleaned 1 older builds
 ```
 
-## Step 5: Install recipes
+## Step 4: Install recipes
 
 In order to run recipes, you'll need to make sure the recipes are installed on your local machine. For example, you can install recipes from a JAR or a pip package:
 
@@ -169,7 +139,7 @@ mod config recipes pip install openrewrite-migrate-python=={{VERSION_ORG_OPENREW
 You can find the specific installation command for any recipe on its page in the [recipe catalog](https://docs.moderne.io/user-documentation/recipes/recipe-catalog/).
 :::
 
-## Step 6: Run recipes
+## Step 5: Run recipes
 
 With the LSTs built and recipes installed, you can now run recipes against your Python repositories. You can either specify the full recipe path for running such as in:
 
@@ -189,7 +159,7 @@ Then you can run the active recipe by:
 mod run . --active-recipe
 ```
 
-## Step 7: View data tables
+## Step 6: View data tables
 
 Many recipes will also produce useful data tables that you can access via the `mod study` command such as in:
 
@@ -219,3 +189,35 @@ Done (2s)
 
 Data tables for each organization with rows are linked above
 ```
+
+## Adding the Python build step manually
+
+You only need this step if you're on a CLI version older than v4.3.0, or if you maintain an explicit `build.steps` list in your `moderne.yml` file. An explicit list replaces the default pipeline, so it must include `- type: python` for Python to be parsed. On CLI v4.3.0 and later with the default configuration, Python support is already enabled and you can skip this.
+
+Update the [build steps](./build-steps.md) in your `moderne.yml` file to include Python. This file is located at `~/.moderne/cli/moderne.yml` and is created when you first set up the CLI.
+
+If your `moderne.yml` file already includes a `build` section, add a `- type: python` step before the trailing `resource` step. If it doesn't, add the entire section as shown below:
+
+```yml title="moderne.yml"
+# Other keys and values...
+license:
+  key: some-license
+tenant:
+  host: https://app.moderne.io
+  apiHost: https://api.app.moderne.io
+  skipSsl: false
+  authorization: Bearer mat-some-token
+// highlight-start
+build:
+  steps:
+    - type: maven
+    - type: gradle
+    - type: bazel
+    - type: python
+    - type: resource
+      inclusion: |-
+        **/*
+// highlight-end
+```
+
+If you maintain an explicit configuration, start from the [full default pipeline](./build-steps.md#configuring-build-steps-explicitly) so you don't drop steps the CLI would otherwise run, such as `sbt` and `javascript`.

--- a/docs/user-documentation/moderne-cli/how-to-guides/python.md
+++ b/docs/user-documentation/moderne-cli/how-to-guides/python.md
@@ -20,6 +20,10 @@ This guide assumes that:
 
 ## Step 1: Update your `moderne.yml` file
 
+:::info
+As of CLI v4.3.0, the `python` build step is part of the [default build pipeline](./build-steps.md), so no `moderne.yml` change is needed to enable Python support. Follow this step only if you are on an older CLI version, or if you already have an explicit `build.steps` configuration — an explicit configuration replaces the defaults, so it must list `- type: python` for Python to be parsed.
+:::
+
 In order to enable Python support, you will need to update the [build steps](./build-steps.md) in your `moderne.yml` file to include Python. This file is located at `~/.moderne/cli/moderne.yml` and is created when you first set up the CLI.
 
 If your `moderne.yml` file already includes a `build` section, you can just add the `- type: python` line to the end of your build steps. If it doesn't, you will need to add the entire section as seen in the example below:

--- a/docs/user-documentation/recipes/authoring-recipes/set-up/javascript-recipe-development-environment.md
+++ b/docs/user-documentation/recipes/authoring-recipes/set-up/javascript-recipe-development-environment.md
@@ -273,7 +273,7 @@ Also, we **strongly recommend** using an absolute path instead of a relative pat
 
 ### Step 3: Configure the CLI to build JavaScript LSTs
 
-In order for the Moderne CLI to build JavaScript/TypeScript LSTs, you'll need to make a few minor changes to the `.moderne.yml` file. Please follow along with our [JavaScript Moderne CLI documentation](../../../moderne-cli/how-to-guides/javascript.md#step-1-update-your-moderneyml-file) to make these changes.
+In order for the Moderne CLI to build JavaScript/TypeScript LSTs, it needs the `javascript` build step. As of CLI v4.3.0, this step runs by default, so no configuration is required. If you're on an older CLI version or use an explicit build configuration, follow our [JavaScript Moderne CLI documentation](../../../moderne-cli/how-to-guides/javascript.md#adding-the-javascript-build-step-manually) to add it.
 
 ### Step 4: Run your recipes
 


### PR DESCRIPTION
## Problem

The build steps documentation still says language-specific steps never run by default and must be enabled through `moderne.yml`. Since CLI v4.3.0 the default pipeline is Gradle, Bazel, Maven, sbt, JavaScript, Python, the generic JVM step, and the resource step, so the `javascript` and `python` guidance is out of date and leads users to add a `build.steps` configuration they no longer need. Worse, an explicit `build.steps` list replaces the default pipeline entirely, so following the old guidance on a current CLI silently drops the sbt and generic JVM steps.

## Solution

* Update the default pipeline description in `build-steps.md`: sbt listed as an external build tool step, `javascript` and `python` documented as default (with their fall-through-to-plain-text behavior on failure), `dotnet`, `go`, and `mainframe` remaining opt-in.
* Update the "explicit equivalent of the defaults" YAML example accordingly, and note the generic JVM step has no `moderne.yml` step type.
* Rework the danger callout to explain that an explicit `build.steps` list replaces the defaults rather than extending them, including when upgrading from a pre-4.3.0 configuration.
* Add a version note to the `python.md` and `javascript.md` setup guides so users on current CLI versions know Step 1 is not needed.

Verified against the CLI source (`BuildStep.defaultBuildPipeline()`, `BuildStepsProperty`) and with live `mod build` runs on 4.3.18 with and without an explicit configuration.