### PR TITLE
Morpheus docs landing page

### DIFF
--- a/src/components/ProductCardsGrid/ProductCardsGrid.module.css
+++ b/src/components/ProductCardsGrid/ProductCardsGrid.module.css
@@ -1,30 +1,46 @@
 /**
- * ProductCardsGrid - Displays products in a responsive 4-column grid
+ * ProductCardsGrid — Morpheus "Browse by area" cards.
+ *
+ * Consumes the --mo-* custom properties defined on the landing page's
+ * .homePage scope (src/pages/index.module.css). This component is only
+ * rendered on the landing page; mount it elsewhere and the variables
+ * must be provided by that scope.
  */
 
 .browseByProduct {
   display: flex;
   flex-direction: column;
-  gap: var(--neo-spacing_3);
+  gap: 22px;
+}
+
+.sectionHead {
+  display: flex;
+  align-items: baseline;
+  gap: 14px;
+  border-bottom: 1px solid var(--mo-line);
+  padding-bottom: 12px;
 }
 
 .sectionTitle {
-  font-size: var(--neo-font-size-default);
-  font-weight: var(--neo-font-weight-medium);
-  color: var(--ifm-heading-color);
+  font-family: var(--mo-font);
+  font-size: 22px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: var(--mo-text);
   margin: 0;
+}
+
+.sectionMeta {
+  font-family: var(--mo-font-mono);
+  font-size: 11px;
+  color: var(--mo-muted);
+  margin-left: auto;
 }
 
 .productGrid {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: var(--neo-spacing_3);
-}
-
-@media (max-width: 996px) {
-  .productGrid {
-    grid-template-columns: repeat(2, 1fr);
-  }
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 16px;
 }
 
 @media (max-width: 576px) {
@@ -35,61 +51,69 @@
 
 .productCard {
   display: flex;
-  padding: var(--neo-spacing_3);
-  background: transparent;
-  border: 1px solid var(--neo-border-card);
-  border-radius: var(--neo-border-radius-x-s);
+  gap: 15px;
+  align-items: flex-start;
+  padding: 18px;
+  background: var(--mo-card);
+  border: 1px solid var(--mo-line);
+  border-radius: 12px;
+  color: var(--mo-text);
   text-decoration: none;
   transition: background-color var(--ifm-transition-fast) ease,
-              border-color var(--ifm-transition-fast) ease,
-              box-shadow var(--ifm-transition-fast) ease;
+              border-color var(--ifm-transition-fast) ease;
 }
 
 .productCard:hover {
-  background: var(--neo-surfaces-white);
-  border-color: transparent;
-  box-shadow: var(--neo-shadow-card);
+  background: var(--mo-row-hover);
   text-decoration: none;
+  color: var(--mo-text);
+}
+
+.productCardTile {
+  width: 44px;
+  height: 44px;
+  flex: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--mo-tile-panel);
+  border: 1px solid var(--mo-tile-stroke);
+  border-radius: 10px;
+  color: var(--mo-tile-accent);
 }
 
 .productCardContent {
   display: flex;
   flex-direction: column;
-  gap: var(--neo-spacing_1_2);
+  gap: 4px;
   min-width: 0;
 }
 
 .productCardTitle {
-  font-size: var(--neo-font-size-default);
-  font-weight: var(--neo-font-weight-semi-bold);
-  color: var(--ifm-heading-color);
+  font-family: var(--mo-font);
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--mo-text);
   margin: 0;
   line-height: 1.3;
 }
 
 .productCardDescription {
-  font-size: var(--neo-font-size-sm);
-  font-weight: var(--neo-font-weight-regular);
-  color: var(--neo-typography-body-secondary);
+  font-family: var(--mo-font);
+  font-size: 13px;
+  font-weight: 400;
+  color: var(--mo-muted);
   margin: 0;
-  line-height: 1.4;
+  line-height: 1.5;
 }
 
-/* Dark mode adjustments */
-:global(html[data-theme='dark']) .productCard {
-  background: transparent;
-  border-color: var(--neo-grey-700);
-}
-
-:global(html[data-theme='dark']) .productCard:hover {
-  background: var(--neo-grey-800);
-  border-color: var(--neo-grey-600);
-}
-
-:global(html[data-theme='dark']) .productCardTitle {
-  color: var(--neo-surfaces-white);
-}
-
-:global(html[data-theme='dark']) .productCardDescription {
-  color: var(--neo-grey-300);
+.productCardGo {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-family: var(--mo-font);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--mo-link);
+  margin-top: 4px;
 }

--- a/src/components/ProductCardsGrid/ProductCardsGrid.tsx
+++ b/src/components/ProductCardsGrid/ProductCardsGrid.tsx
@@ -1,5 +1,17 @@
 import Link from '@docusaurus/Link';
 import type { ProductItem } from '@site/src/components/NeoMegaMenu/types';
+import type { LucideIcon } from 'lucide-react';
+import {
+  ArrowRight,
+  Blocks,
+  BookOpen,
+  Globe,
+  MessageSquare,
+  Package,
+  Shield,
+  Sparkles,
+  Terminal,
+} from 'lucide-react';
 import type { FunctionComponent } from 'react';
 import styles from './ProductCardsGrid.module.css';
 
@@ -8,30 +20,52 @@ export type ProductCardsGridProps = {
   products: ProductItem[];
 };
 
+/** Flat Morpheus icon tiles, keyed by product name. Unknown products fall back to BookOpen. */
+const productTileIcons: Record<string, LucideIcon> = {
+  Platform: Globe,
+  CLI: Terminal,
+  'Agent tools': Sparkles,
+  Recipes: Package,
+  DX: Shield,
+  Moddy: MessageSquare,
+  'IDE plugins': Blocks,
+};
+
 /**
  * ProductCardsGrid displays product documentation links in a responsive grid.
- * Shows 3 columns on desktop, 2 on tablet, 1 on mobile.
- * Each card includes an icon, title, and description.
+ * Each card includes a flat icon tile, title, description, and explore link.
  */
 export const ProductCardsGrid: FunctionComponent<ProductCardsGridProps> = ({
   products,
 }) => {
   return (
     <section className={styles.browseByProduct}>
-      <h2 className={styles.sectionTitle}>Browse by area</h2>
+      <div className={styles.sectionHead}>
+        <h2 className={styles.sectionTitle}>Browse by area</h2>
+        <span className={styles.sectionMeta}>{products.length} areas</span>
+      </div>
       <div className={styles.productGrid}>
-        {products.map((product) => (
-          <Link
-            key={product.name}
-            href={product.homepageHref || product.href}
-            className={styles.productCard}
-          >
-            <div className={styles.productCardContent}>
-              <h3 className={styles.productCardTitle}>{product.name}</h3>
-              <p className={styles.productCardDescription}>{product.description}</p>
-            </div>
-          </Link>
-        ))}
+        {products.map((product) => {
+          const TileIcon = productTileIcons[product.name] ?? BookOpen;
+          return (
+            <Link
+              key={product.name}
+              href={product.homepageHref || product.href}
+              className={styles.productCard}
+            >
+              <span className={styles.productCardTile}>
+                <TileIcon size={22} strokeWidth={2} aria-hidden="true" />
+              </span>
+              <div className={styles.productCardContent}>
+                <h3 className={styles.productCardTitle}>{product.name}</h3>
+                <p className={styles.productCardDescription}>{product.description}</p>
+                <span className={styles.productCardGo}>
+                  Explore <ArrowRight size={12} aria-hidden="true" />
+                </span>
+              </div>
+            </Link>
+          );
+        })}
       </div>
     </section>
   );

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -724,3 +724,50 @@ html[data-theme='dark'] {
   margin: 0 calc(-1 * var(--ifm-pre-padding));
   padding: 0 calc(var(--ifm-pre-padding) - 3px) 0 var(--ifm-pre-padding);
 }
+
+/* Morpheus landing-page scope
+   The --mo-* tokens power the redesigned landing page only. The class is applied
+   solely by src/pages/index.tsx, so these values never reach site chrome or docs
+   pages. Reference: https://moderneinc.github.io/prototypes/docs-morpheus.html */
+.morpheus-landing {
+  --mo-font: 'Geist', var(--ifm-font-family-base);
+  --mo-font-mono: 'Geist Mono', monospace;
+  --mo-spectral: linear-gradient(92deg, #e6399b, #9d5be8, #3e7bf6, #25d0c0, #30f284, #b7e84c);
+  --mo-bg: #f2f0ea;
+  --mo-field: #fbfaf6;
+  --mo-card: #f4f2eb;
+  --mo-surface: #edebe2;
+  --mo-surface2: #e4e1d6;
+  --mo-row-hover: #edebe2;
+  --mo-line: rgba(35, 35, 66, 0.12);
+  --mo-line-strong: rgba(35, 35, 66, 0.5);
+  --mo-text: #232342;
+  --mo-muted: #62627a;
+  --mo-link: #1245ae;
+  --mo-btn-primary-bg: #232342;
+  --mo-btn-primary-bg-hover: #2c2c50;
+  --mo-btn-primary-fg: #fbfaf6;
+  --mo-tile-panel: #fbfaf6;
+  --mo-tile-stroke: rgba(35, 35, 66, 0.5);
+  --mo-tile-accent: #3e5be8;
+}
+
+html[data-theme='dark'] .morpheus-landing {
+  --mo-bg: #141419;
+  --mo-field: #222229;
+  --mo-card: #26262e;
+  --mo-surface: #2a2a32;
+  --mo-surface2: #33333d;
+  --mo-row-hover: #2e2e38;
+  --mo-line: rgba(240, 240, 246, 0.12);
+  --mo-line-strong: rgba(240, 240, 246, 0.38);
+  --mo-text: #f1f0ea;
+  --mo-muted: #9c9ca8;
+  --mo-link: #7fa9f9;
+  --mo-btn-primary-bg: #f1f0ea;
+  --mo-btn-primary-bg-hover: #ffffff;
+  --mo-btn-primary-fg: #17171c;
+  --mo-tile-panel: #26262e;
+  --mo-tile-stroke: rgba(240, 240, 246, 0.38);
+  --mo-tile-accent: #8ca0f5;
+}

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -1,21 +1,33 @@
-.homePage {
-  background-color: var(--background, #f7f7fe);
-  min-height: calc(100vh - var(--ifm-navbar-height));
-  position: relative;
-  overflow: hidden;
-}
+/**
+ * Landing page — Morpheus theme.
+ *
+ * The --mo-* custom properties are defined in src/css/custom.css under the
+ * .morpheus-landing scope, which index.tsx applies alongside .homePage, so
+ * nothing leaks into site chrome or docs pages. Reference prototype:
+ * https://moderneinc.github.io/prototypes/docs-morpheus.html
+ */
 
-[data-theme='dark'] .homePage {
-  background-color: var(--brand-midnight);
+.homePage {
+  background-color: var(--mo-bg);
+  font-family: var(--mo-font);
+  color: var(--mo-text);
+  position: relative;
+
+  /* The navbar is transparent and the page background normally stops below it.
+     Pull the cream canvas up behind the header chrome, then restore the exact
+     same offset as padding so content lands where .main-wrapper would put it. */
+  margin-top: calc(-1 * (var(--ifm-navbar-height) + var(--ifm-secondary-nav-height) + var(--ifm-announcement-bar-height)));
+  padding-top: calc(var(--ifm-navbar-height) + var(--ifm-secondary-nav-height) + var(--ifm-announcement-bar-height));
+  min-height: 100vh;
 }
 
 .pageBody {
-  max-width: 1440px;
+  max-width: 1120px;
   margin: 0 auto;
-  padding: 80px 100px 100px;
+  padding: 64px 36px 90px;
   display: flex;
   flex-direction: column;
-  gap: var(--neo-spacing_5, 40px);
+  gap: 44px;
   position: relative;
   z-index: 1;
 }
@@ -23,8 +35,8 @@
 /* Tablet breakpoint */
 @media (max-width: 996px) {
   .pageBody {
-    padding: var(--neo-spacing_4, 32px) var(--neo-spacing_3, 24px);
-    gap: var(--neo-spacing_4, 32px);
+    padding: 32px 24px 64px;
+    gap: 32px;
   }
 }
 
@@ -32,50 +44,93 @@
   display: flex;
   align-items: flex-start;
   width: 100%;
+  padding-top: 24px;
 }
 
 .heroContent {
   display: flex;
   flex-direction: column;
-  gap: var(--neo-spacing_3, 24px);
-  max-width: 600px;
+  gap: 18px;
+  max-width: 640px;
 }
 
 .heroHeading {
-  font-family: var(--ifm-font-family-base);
-  font-size: 54px;
-  font-weight: var(--neo-font-weight-medium);
+  font-family: var(--mo-font);
+  font-size: 44px;
+  font-weight: 700;
+  letter-spacing: -0.03em;
   line-height: 1.1;
+  color: var(--mo-text);
   margin: 0;
 }
 
-.heroHeadingBlue {
-  color: var(--brand-digital-blue);
-}
-
-.heroHeadingDark {
-  color: var(--brand-midnight);
-}
-
-[data-theme='dark'] .heroHeadingBlue {
-  color: var(--brand-digital-green);
-}
-
-[data-theme='dark'] .heroHeadingDark {
-  color: var(--neo-surfaces-white);
+.heroHeadingSpectral {
+  background: var(--mo-spectral);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
 }
 
 .heroSubheading {
-  font-family: var(--ifm-font-family-base);
-  font-size: 28px;
-  font-weight: var(--neo-font-weight-medium);
-  line-height: 1.4;
-  color: var(--brand-midnight);
+  font-family: var(--mo-font);
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 1.6;
+  color: var(--mo-muted);
+  max-width: 560px;
   margin: 0;
 }
 
-[data-theme='dark'] .heroSubheading {
-  color: var(--neo-surfaces-white);
+.heroActions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 10px;
+}
+
+/* Morpheus button overrides for NeoButton. Doubled class selectors so they
+   reliably out-rank NeoButton's own variant + state rules. */
+.morpheusButtonPrimary.morpheusButtonPrimary {
+  font-family: var(--mo-font);
+  font-size: 13px;
+  font-weight: 600;
+  padding: 10px 17px;
+  border-radius: 4px;
+  background-color: var(--mo-btn-primary-bg);
+  color: var(--mo-btn-primary-fg);
+  border: 1px solid transparent;
+}
+
+.morpheusButtonPrimary.morpheusButtonPrimary:hover:not(:disabled) {
+  background-color: var(--mo-btn-primary-bg-hover);
+  color: var(--mo-btn-primary-fg);
+}
+
+.morpheusButtonPrimary.morpheusButtonPrimary:focus-visible {
+  outline: 2px solid var(--mo-link);
+  outline-offset: 2px;
+}
+
+.morpheusButtonSecondary.morpheusButtonSecondary {
+  font-family: var(--mo-font);
+  font-size: 13px;
+  font-weight: 600;
+  padding: 10px 17px;
+  border-radius: 4px;
+  background-color: var(--mo-field);
+  color: var(--mo-text);
+  border: 1px solid var(--mo-line-strong);
+}
+
+.morpheusButtonSecondary.morpheusButtonSecondary:hover:not(:disabled) {
+  background-color: var(--mo-surface);
+  color: var(--mo-text);
+}
+
+.morpheusButtonSecondary.morpheusButtonSecondary:focus-visible {
+  outline: 2px solid var(--mo-link);
+  outline-offset: 2px;
 }
 
 /* Mobile breakpoint */
@@ -85,78 +140,97 @@
   }
 
   .heroSubheading {
-    font-size: var(--neo-font-size-default, 16px);
+    font-size: 15px;
   }
 
   .pageBody {
-    padding: var(--neo-spacing_3, 24px) var(--neo-spacing_2, 16px);
+    padding: 24px 16px 48px;
   }
 }
 
-/* What is Moderne Section */
-.whatIsSection {
+/* Spectral accent bar shared by the prose sections */
+.spectralBar {
+  width: 64px;
+  height: 4px;
+  border-radius: 2px;
+  background: var(--mo-spectral);
+}
+
+/* What is Moderne / More about Moderne — Morpheus prose cards */
+.whatIsSection,
+.platformSection {
   display: flex;
   flex-direction: column;
-  gap: var(--neo-spacing_5, 40px);
+  gap: 18px;
   width: 100%;
+  background-color: var(--mo-card);
+  border: 1px solid var(--mo-line);
+  border-radius: 12px;
+  padding: 28px 30px;
 }
 
 .sectionHeader {
   display: flex;
   flex-direction: column;
-  gap: var(--neo-spacing_3, 24px);
+  gap: 12px;
   width: 100%;
 }
 
 .sectionTitle {
-  font-family: var(--ifm-font-family-base);
-  font-size: 24px;
-  font-weight: var(--neo-font-weight-semi-bold);
-  line-height: 1.4;
-  color: var(--brand-midnight);
+  font-family: var(--mo-font);
+  font-size: 22px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1.3;
+  color: var(--mo-text);
   margin: 0;
-}
-
-[data-theme='dark'] .sectionTitle {
-  color: var(--neo-surfaces-white);
+  /* Land the #what-is-moderne anchor below the fixed header with breathing room */
+  scroll-margin-top: 24px;
 }
 
 .sectionDescription {
-  font-family: var(--ifm-font-family-base);
-  font-size: 15px;
-  font-weight: var(--neo-font-weight-regular, 400);
-  line-height: 1.4;
-  color: var(--brand-midnight);
-  max-width: 700px;
+  font-family: var(--mo-font);
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1.65;
+  color: var(--mo-muted);
+  max-width: 720px;
   margin: 0;
 }
 
-[data-theme='dark'] .sectionDescription {
-  color: var(--neo-surfaces-white);
+.sectionDescription strong {
+  color: var(--mo-text);
+  font-weight: 600;
+}
+
+.sectionDescription a {
+  color: var(--mo-link);
+  text-decoration: none;
+}
+
+.sectionDescription a:hover {
+  text-decoration: underline;
+  text-underline-offset: 3px;
 }
 
 .videoGrid {
   display: flex;
-  gap: var(--neo-spacing_5, 40px);
+  gap: 24px;
   flex-wrap: wrap;
 }
 
 /* Hairline outer border + 8px padding around home-page video thumbnails */
 .videoThumbnail {
-  padding: var(--neo-spacing_1);
-  background-color: transparent;
-  border: 1px solid var(--neo-grey-200);
-  border-radius: var(--neo-border-radius-m);
-  box-shadow: var(--neo-shadow-card);
+  padding: 8px;
+  background-color: var(--mo-field);
+  border: 1px solid var(--mo-line);
+  border-radius: 12px;
+  box-shadow: none;
   box-sizing: content-box;
 }
 
-[data-theme='dark'] .videoThumbnail {
-  border-color: var(--neo-grey-700);
-}
-
 .videoThumbnail > * {
-  border-radius: var(--neo-border-radius-x-s);
+  border-radius: 8px;
   overflow: hidden;
 }
 
@@ -164,101 +238,39 @@
 .videoThumbnail :global(video),
 .videoThumbnail :global(img) {
   display: block;
-  border-radius: var(--neo-border-radius-x-s);
-}
-
-
-@media (max-width: 996px) {
-  .videoGrid {
-    gap: var(--neo-spacing_3, 24px);
-  }
-
-}
-
-/* Platform Details Section */
-.platformSection {
-  display: flex;
-  flex-direction: column;
-  gap: var(--neo-spacing_3, 24px);
-  width: 100%;
+  border-radius: 8px;
 }
 
 .platformContent {
-  font-family: var(--ifm-font-family-base);
-  font-size: 15px;
-  font-weight: var(--neo-font-weight-regular, 400);
-  line-height: 1.4;
-  color: var(--brand-midnight);
-  max-width: 700px;
-}
-
-[data-theme='dark'] .platformContent {
-  color: var(--neo-surfaces-white);
+  font-family: var(--mo-font);
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1.65;
+  color: var(--mo-muted);
+  max-width: 720px;
 }
 
 .platformContent p {
-  margin: 0 0 var(--neo-spacing_2, 16px) 0;
+  margin: 0 0 12px 0;
 }
 
 .platformContent p:last-child {
   margin-bottom: 0;
 }
 
+.platformContent strong {
+  color: var(--mo-text);
+  font-weight: 600;
+}
+
 .platformContent a {
-  color: var(--brand-digital-blue);
+  color: var(--mo-link);
   text-decoration: none;
 }
 
 .platformContent a:hover {
   text-decoration: underline;
-}
-
-[data-theme='dark'] .platformContent a {
-  color: var(--brand-digital-green);
-}
-
-.gemDecorations {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  pointer-events: none;
-  z-index: 0;
-}
-
-.gem {
-  position: absolute;
-  opacity: 0.9;
-  transition: opacity 0.3s ease;
-}
-
-/* Large edge gems */
-.gemLargeRight {
-  top: -10px;
-  right: -140px;
-  width: 410px;
-  height: auto;
-  opacity: 0.9;
-  transform: rotate(30deg);
-}
-
-.gemLargeLeft {
-  top: 155px;
-  left: -414px;
-  width: 780px;
-  height: auto;
-  opacity: 0.9;
-  transform: rotate(342.44deg);
-}
-
-/* Dark mode: show large gems */
-[data-theme='dark'] .gemLargeRight {
-  opacity: 0.6;
-}
-
-[data-theme='dark'] .gemLargeLeft {
-  opacity: 0.6;
+  text-underline-offset: 3px;
 }
 
 /* Small mobile */
@@ -266,11 +278,9 @@
   .heroHeading {
     font-size: 28px;
   }
-}
 
-/* Hide gems on mobile */
-@media (max-width: 996px) {
-  .gemDecorations {
-    display: none;
+  .whatIsSection,
+  .platformSection {
+    padding: 20px;
   }
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -15,23 +15,33 @@ export const HeroSection: FunctionComponent = () => {
     <section className={styles.hero}>
       <div className={styles.heroContent}>
         <h1 className={styles.heroHeading}>
-          <span className={styles.heroHeadingBlue}>Explore documentation</span>
+          Explore documentation
           <br />
-          <span className={styles.heroHeadingDark}>and tutorials to go further</span>
+          and tutorials to{' '}
+          <span className={styles.heroHeadingSpectral}>go further</span>
         </h1>
         <p className={styles.heroSubheading}>
-          Discover how to fix vulnerabilities, standardize code quality, 
+          Discover how to fix vulnerabilities, standardize code quality,
           perform type-aware code searches, and accelerate refactoring at enterprise scale.
         </p>
-        <div>
+        <div className={styles.heroActions}>
           <NeoButton
             variant="primary"
             size="medium"
+            className={styles.morpheusButtonPrimary}
             href="/user-documentation/moderne-platform/getting-started/running-your-first-recipe"
             icon={<ArrowRight size={16} />}
             iconPosition="right"
           >
             Get started
+          </NeoButton>
+          <NeoButton
+            variant="secondary"
+            size="medium"
+            className={styles.morpheusButtonSecondary}
+            href="#what-is-moderne"
+          >
+            What is Moderne?
           </NeoButton>
         </div>
       </div>
@@ -64,12 +74,13 @@ export const WhatIsModerneSection: FunctionComponent = () => {
 
   return (
     <section className={styles.whatIsSection}>
+      <div className={styles.spectralBar} />
       <div className={styles.sectionHeader}>
         <h2 className={styles.sectionTitle} id='what-is-moderne'>What is Moderne?</h2>
         <p className={styles.sectionDescription}>
           Moderne builds the knowledge, discovery, and execution tools coding agents rely on to operate faster, more accurately, and at far lower cost across real-world software systems. Powered by the <Link href="https://docs.openrewrite.org/">OpenRewrite</Link> <Link href="/user-documentation/recipes/authoring-recipes/concepts/lossless-semantic-trees">Lossless Semantic Tree (LST)</Link>, the industry's most comprehensive context model for understanding and transforming your code at scale.
         </p>
-        <p className={styles.sectionDescription}>  
+        <p className={styles.sectionDescription}>
           With Moderne, organizations can automate framework migrations, remediate security vulnerabilities, perform organization-wide code search, and standardize code quality across thousands of repositories.
         </p>
       </div>
@@ -92,6 +103,7 @@ export const WhatIsModerneSection: FunctionComponent = () => {
 export const AboutModerneSection: FunctionComponent = () => {
   return (
     <section className={styles.platformSection}>
+      <div className={styles.spectralBar} />
       <h2 className={styles.sectionTitle}>More about Moderne</h2>
       <div className={styles.platformContent}>
         <p>
@@ -123,38 +135,28 @@ export const AboutModerneSection: FunctionComponent = () => {
   );
 }
 
-
-export const GemDecorations: FunctionComponent = () => {
-  return (
-    <div className={styles.gemDecorations}>
-      {/* Large gems on edges */}
-      <img
-        src="/img/gems/pink-large.png"
-        alt=""
-        className={clsx(styles.gem, styles.gemLargeRight)}
-      />
-      <img
-        src="/img/gems/pink.png"
-        alt=""
-        className={clsx(styles.gem, styles.gemLargeLeft)}
-      />
-    </div>
-  );
-}
-
 const Home: FunctionComponent = () => {
   return (
     <>
       <Head>
         <meta property="og:image" content="/img/og-home.png" />
         <meta name="twitter:card" content="summary_large_image" />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link
+          rel="preconnect"
+          href="https://fonts.gstatic.com"
+          crossOrigin="anonymous"
+        />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500&display=swap"
+          rel="stylesheet"
+        />
       </Head>
       <Layout
         title="Moderne Documentation"
         description="Explore documentation and tutorials for automated code remediation. Fix vulnerabilities, standardize code quality, perform type-aware code searches, and accelerate refactoring at enterprise scale with Moderne Platform, CLI, DX, and more."
       >
-        <main className={styles.homePage}>
-          <GemDecorations />
+        <main className={clsx(styles.homePage, 'morpheus-landing')}>
           <div className={styles.pageBody}>
             <HeroSection />
             <ProductCardsGrid products={homepageProducts} />


### PR DESCRIPTION

<img width="1313" height="1318" alt="Screenshot 2026-07-23 at 9 01 53 AM" src="https://github.com/user-attachments/assets/e2b23033-6c12-4c46-a2e5-9f4b55bffde1" />


## What

Applies the Morpheus design language to the docs **landing page only** — site chrome, docs pages, and all other routes are untouched.

Design reference (merged prototype): https://moderneinc.github.io/prototypes/docs-morpheus.html

- * **Warm cream canvas + ink typography** (`#F2F0EA` / `#232342`), with full dark-mode equivalents. All values live as `--mo-*` tokens in a `.morpheus-landing` scope in `custom.css`; only the homepage applies that class, so nothing leaks site-wide.
* **Gem/glass-block decorations removed** from the hero area.
* **Hero**: spectral-gradient accent on "go further", ink primary **Get started** button (4px radius), new secondary **What is Moderne?** anchor button. Geist / Geist Mono load page-scoped via the page `<Head>`.
* **Browse by area**: cards restyled as Morpheus surfaces with flat 44px lucide icon tiles (Globe / Terminal / Sparkles / Package / Shield / MessageSquare / Blocks) and "Explore →" affordances.
* **What is Moderne? / More about Moderne**: re-housed in prose cards with spectral accent bars. All copy, links, and videos preserved verbatim.

## Validation

* `yarn validate:css` — clean (44 files, 1044 `var()` usages)
* `yarn typecheck` — clean
* Full `yarn build` was not completed locally; relying on CI for the production build + broken-link check.

## Notes for review

* `ProductCardsGrid` is only mounted on the landing page; its module CSS now consumes the `--mo-*` scope (noted in a file comment).
* The cream canvas is pulled up behind the transparent navbar via a matched negative-margin/padding pair on `.homePage`, so the whole viewport reads Morpheus without touching the navbar itself.
