### PR TITLE
Pin GOROOT to the setup-go toolchain so Go recipe docs generate again

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -40,6 +40,12 @@ jobs:
           go-version: '1.25'        # recipes-go and rewrite-go both require go 1.25 (their go.mod)
       - name: Build the rewrite-go-rpc server
         run: |
+          # Pin GOROOT to the toolchain setup-go just put on PATH. Otherwise GoRewriteRpc discovers
+          # GOROOT via GoExecutor.find(), which prefers /usr/bin/go (the runner image's older default
+          # Go) over PATH, and hands the RPC server a GOROOT from a different release than the `go` it
+          # shells out to: `compile: version "go1.24.13" does not match go tool version "go1.25.12"`.
+          echo "GOROOT=$(go env GOROOT)" >> "$GITHUB_ENV"
+
           # The generator's Go loader launches `rewrite-go-rpc` from PATH. It isn't published as a
           # binary, so build it from source. `go install` names the binary after its package dir (`rpc`),
           # so symlink it to the name the loader expects, and expose it to later steps via $GITHUB_PATH.


### PR DESCRIPTION
## Problem

`update-docs` has been generating **zero** Go recipes since 2026-07-16, and because a full run does `rm -rf recipe-catalog` before copying, it deleted all 187 `recipe-catalog/golang/codequality/*` pages that the 2026-06-29 run had added. Nothing from [`recipes-go`](https://github.com/moderneinc/recipes-go) is on docs.moderne.io today — including `GoModTidy`, which shipped in recipes-go v0.5.0 and has never had a page.

The run stays green because `GoRecipeLoader` catches the failure and returns an empty list.

From [run 29733602969](https://github.com/moderneinc/moderne-docs/actions/runs/29733602969) (2026-07-20):

```
Installing Go recipes from module: github.com/moderneinc/recipes-go@v0.5.3
Warning: Failed to load recipes from recipes-go: Install package failed: build helper:
  compile: version "go1.24.13" does not match go tool version "go1.25.12"
Retrieved 0 Go recipe descriptor(s) via RPC
```

| Commit | Date | recipes-go pages |
|---|---|---|
| `6d4ed4a` | 06-29 | +187 (rewrite-go 8.86.1) |
| `22d5e9a` | 07-16 | **-187** (rewrite-go 8.87.2) |
| `4b3b2ba` | 07-20 | still 0 (rewrite-go 8.87.4) |

## Cause

`GoRewriteRpc.ensureGoRoot` injects `GOROOT` into the `rewrite-go-rpc` child process. Up to rewrite-go 8.86.1 it discovered that with a plain `ProcessBuilder("go", ...)` PATH lookup, which found setup-go's toolchain and stayed self-consistent.

- [rewrite#8164](https://github.com/openrewrite/rewrite/pull/8164) (released in 8.86.2) replaced that with `GoExecutor.find()`, which tries hardcoded absolute paths — `/usr/local/go/bin/go`, `/opt/homebrew/bin/go`, `/usr/local/bin/go`, `/usr/bin/go` — *before* falling back to `which go`. GitHub's ubuntu image symlinks its default Go (1.24.13) into `/usr/bin`, so that wins over the 1.25.12 setup-go prepended to PATH.

The RPC server then runs `exec.Command("go", "build", ...)` inheriting that env: `go` resolves from PATH to 1.25.12 while `GOROOT`/`GOTOOLDIR` point at the 1.24.13 tree. `GOTOOLCHAIN=local` blocks auto-switching, so the helper build fails.

## Fix

Export `GOROOT` from the toolchain setup-go put on PATH. `ensureGoRoot` returns early when `GOROOT` is already set, so the RPC server and the `go` it shells out to agree.

## Follow-ups (not in this PR)

* `GoExecutor.find()` should prefer PATH over hardcoded absolute paths upstream in `openrewrite/rewrite` — this will bite any host with two Go installs, not just CI.
* A configured Go module yielding 0 descriptors shouldn't be a silent warning, and the workflow shouldn't `rm -rf` the catalog on a partially-failed generation. That's what turned a CI hiccup into 187 deleted pages.

## Verifying

CI on this PR does not exercise `update-docs`. After merge, dispatch `update-docs` with `latest-versions-only=false` and confirm the log shows `Installed N recipe(s) from github.com/moderneinc/recipes-go` — that same run restores the deleted pages and adds `GoModTidy`. Note the nightly cron only refreshes the versions file, so it will not do this on its own.