### PR TITLE
Render Go install command in RunRecipe

### DIFF
--- a/src/components/RunRecipe/index.tsx
+++ b/src/components/RunRecipe/index.tsx
@@ -14,6 +14,7 @@ interface RunRecipeProps {
   npmPackage?: string;
   pipPackage?: string;
   nugetPackage?: string;
+  goPackage?: string;
 }
 
 export default function RunRecipe({
@@ -28,6 +29,7 @@ export default function RunRecipe({
   npmPackage,
   pipPackage,
   nugetPackage,
+  goPackage,
 }: RunRecipeProps) {
   // Replace {{VERSION_...}} placeholders with actual version numbers
   const resolveVersions = (text: string): string => {
@@ -100,6 +102,30 @@ export default function RunRecipe({
         <p>Then, you can run the recipe via:</p>
         <CodeBlock language="shell" title="Run the recipe">
           {`mod run . --recipe ${recipeName}`}
+        </CodeBlock>
+      </>
+    );
+  }
+
+  // Go recipes
+  if (goPackage) {
+    // Go module tags carry a `v` prefix, while the version key resolves to a bare X.Y.Z
+    const goModuleSpec = version ? `${goPackage}@v${version}` : goPackage;
+    return (
+      <>
+        <p>
+          In order to run Go recipes, you will need to use the{' '}
+          <a href="https://docs.moderne.io/user-documentation/moderne-cli/getting-started/cli-intro">Moderne CLI</a>.
+          For Go specific configuration instructions, please see our{' '}
+          <a href="https://docs.moderne.io/user-documentation/moderne-cli/how-to-guides/go">configuring Go guide</a>.
+        </p>
+        <p>Once the CLI is installed, you can run the recipe via:</p>
+        <CodeBlock language="shell" title="Run the recipe">
+          {`mod run . --recipe ${cliRecipeName}${cliOptions}`}
+        </CodeBlock>
+        <p>If the recipe is not available locally, then you can install it using:</p>
+        <CodeBlock language="shell" title="Install the recipe module">
+          {`mod config recipes go install ${goModuleSpec}`}
         </CodeBlock>
       </>
     );

--- a/src/components/recipe/shared/types.ts
+++ b/src/components/recipe/shared/types.ts
@@ -6,7 +6,7 @@ export interface RecipeExample { name?: string; parameters?: ExampleParameter[];
 export interface UsageProps {
   recipeName: string; displayName: string; groupId?: string; artifactId?: string; versionKey?: string;
   requiresConfiguration?: boolean; cliOptions?: string; useFullyQualifiedCliName?: boolean;
-  npmPackage?: string; pipPackage?: string; nugetPackage?: string;
+  npmPackage?: string; pipPackage?: string; nugetPackage?: string; goPackage?: string;
 }
 export interface RecipeOption { type: string; name: string; required: boolean; description: string; example?: string; }
 export interface RecipeDataTable { name: string; displayName: string; description: string; columns: DataTableColumn[]; }


### PR DESCRIPTION
Adds a `goPackage` branch to `RunRecipe`, so Go recipe pages render a working install command.

## Why

Every page under `docs/user-documentation/recipes/recipe-catalog/golang/` currently renders:

```shell
mod config recipes jar install org.openrewrite.recipe:recipes-go:0.5.3
```

That command succeeds and installs zero recipes — the Maven artifact is a metadata-only stub, and the recipes actually ship as a Go module.

- openrewrite/rewrite-recipe-markdown-generator#358 fixes the generator side: Go recipe pages will be generated with `goPackage` instead of `groupId`/`artifactId`. Without this change, those pages would render no install command at all once #358 ships.

- Fixes moderneinc/moderne-docs#901.

## What changed

* `src/components/RunRecipe/index.tsx`: new `goPackage` branch, before the jar fallback, modelled on the `pipPackage` + `versionKey` pair.
* `src/components/recipe/shared/types.ts`: `goPackage` added to `UsageProps`. `UsageList` already spreads `usage` into `RunRecipe`, so nothing else needed threading.

Go module tags are `vX.Y.Z` while `versionKey` resolves to a bare `X.Y.Z`, so this branch renders `@v${version}` where npm/nuget use `@${version}`.

Nothing under `recipe-catalog/` is hand-edited — those files are generated.

## Verification

- Locally patched two golang pages to the post-#358 `usage` shape, ran `yarn start`, and read the rendered commands out of the DOM (patches reverted before committing):

`golang/orderimports` (no options):

```shell
mod run . --recipe OrderImports
mod config recipes go install github.com/moderneinc/recipes-go@v0.5.3
```

`golang/renamepackage` (with `cliOptions`):

```shell
mod run . --recipe RenamePackage --recipe-option "oldPackagePath=github.com/old/foo" --recipe-option "newPackagePath=github.com/new/foo"
mod config recipes go install github.com/moderneinc/recipes-go@v0.5.3
```

The install command matches the one already generated on [Latest versions of every OpenRewrite module](https://docs.moderne.io/user-documentation/recipes/lists/latest-versions-of-every-openrewrite-module) exactly. `yarn typecheck` passes.

Go recipes are Moderne proprietary, so this only affects docs.moderne.io; docs.openrewrite.org has no `golang/` pages.
