### PR TITLE
Render both install commands for dual-published Python recipes

### DIFF
--- a/docs/user-documentation/moderne-cli/how-to-guides/python.md
+++ b/docs/user-documentation/moderne-cli/how-to-guides/python.md
@@ -136,12 +136,21 @@ mod config recipes pip install openrewrite-migrate-python=={{VERSION_ORG_OPENREW
 ```
 
 :::info
-The Python migration recipes are split across two packages that work together. The `openrewrite-migrate-python` pip package holds the source migrations and the `UpgradeToPython3XX` composites, while the `org.openrewrite.recipe:rewrite-migrate-python` JAR holds the project file, Dockerfile, CloudFormation, and Mend `.whitesource` updates that those composites call into. Install both, or the composites will silently skip the steps they delegate:
+The Python migration recipes are split across packages that call into each other as they run:
+
+* `openrewrite-migrate-python` (pip) holds the source migrations and the `UpgradeToPython3XX` composites.
+* `org.openrewrite.recipe:rewrite-migrate-python` (JAR) holds the project file, Dockerfile, CloudFormation, and Mend `.whitesource` updates that those composites delegate to.
+* `org.openrewrite:rewrite-python` (JAR) is the core language module that both of the above call into for dependency handling.
+
+The CLI resolves these delegates before it runs anything, so a missing package fails the whole run rather than skipping a step. Install all three:
 
 ```bash
 mod config recipes pip install openrewrite-migrate-python=={{VERSION_ORG_OPENREWRITE_RECIPE_REWRITE_MIGRATE_PYTHON}}
 mod config recipes jar install org.openrewrite.recipe:rewrite-migrate-python:{{VERSION_ORG_OPENREWRITE_RECIPE_REWRITE_MIGRATE_PYTHON}}
+mod config recipes jar install org.openrewrite:rewrite-python:{{VERSION_ORG_OPENREWRITE_REWRITE_PYTHON}}
 ```
+
+If you keep your marketplace in sync with a [recipe marketplace CSV](./curate-recipe-marketplace.md), these are already installed for you and you can skip this step.
 :::
 
 :::tip

--- a/docs/user-documentation/moderne-cli/how-to-guides/python.md
+++ b/docs/user-documentation/moderne-cli/how-to-guides/python.md
@@ -125,7 +125,7 @@ Presuming everything has been set up correctly, you should see output similar to
 
 ## Step 4: Install recipes
 
-In order to run recipes, you'll need to make sure the recipes are installed on your local machine. For example, you can install recipes from a JAR or a pip package:
+In order to run recipes, you'll need to make sure the recipes are installed on your local machine. Python recipes come from JARs, pip packages, or both:
 
 ```bash
 mod config recipes jar install org.openrewrite:rewrite-python:{{VERSION_ORG_OPENREWRITE_REWRITE_PYTHON}}
@@ -134,6 +134,15 @@ mod config recipes jar install org.openrewrite:rewrite-python:{{VERSION_ORG_OPEN
 ```bash
 mod config recipes pip install openrewrite-migrate-python=={{VERSION_ORG_OPENREWRITE_RECIPE_REWRITE_MIGRATE_PYTHON}}
 ```
+
+:::info
+The Python migration recipes are split across two packages that work together. The `openrewrite-migrate-python` pip package holds the source migrations and the `UpgradeToPython3XX` composites, while the `org.openrewrite.recipe:rewrite-migrate-python` JAR holds the project file, Dockerfile, CloudFormation, and Mend `.whitesource` updates that those composites call into. Install both, or the composites will silently skip the steps they delegate:
+
+```bash
+mod config recipes pip install openrewrite-migrate-python=={{VERSION_ORG_OPENREWRITE_RECIPE_REWRITE_MIGRATE_PYTHON}}
+mod config recipes jar install org.openrewrite.recipe:rewrite-migrate-python:{{VERSION_ORG_OPENREWRITE_RECIPE_REWRITE_MIGRATE_PYTHON}}
+```
+:::
 
 :::tip
 You can find the specific installation command for any recipe on its page in the [recipe catalog](https://docs.moderne.io/user-documentation/recipes/recipe-catalog/).

--- a/src/components/RunRecipe/RunRecipe.test.tsx
+++ b/src/components/RunRecipe/RunRecipe.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import RunRecipe from './index';
+
+const pythonProps = {
+  recipeName: 'org.openrewrite.python.migrate.UpgradeToPython314',
+  displayName: 'Upgrade to Python 3.14',
+  pipPackage: 'openrewrite-migrate-python',
+  versionKey: 'VERSION_ORG_OPENREWRITE_RECIPE_REWRITE_MIGRATE_PYTHON',
+};
+
+const text = () => screen.getByRole('main').textContent ?? '';
+
+const renderRecipe = (props: React.ComponentProps<typeof RunRecipe>) =>
+  render(
+    <main>
+      <RunRecipe {...props} />
+    </main>
+  );
+
+describe('RunRecipe', () => {
+  it('installs only the pip package when a Python recipe has no companion jar', () => {
+    renderRecipe(pythonProps);
+
+    expect(text()).toContain('mod config recipes pip install openrewrite-migrate-python==');
+    expect(text()).not.toContain('jar install');
+  });
+
+  it('installs both packages when a Python recipe module publishes a pip package and a jar', () => {
+    renderRecipe({
+      ...pythonProps,
+      groupId: 'org.openrewrite.recipe',
+      artifactId: 'rewrite-migrate-python',
+    });
+
+    // The wheel's UpgradeToPython3XX composites delegate their project-file steps back to the jar, so a
+    // reader who follows only the pip command gets a recipe that silently skips those steps.
+    expect(text()).toContain('mod config recipes pip install openrewrite-migrate-python==');
+    expect(text()).toContain('mod config recipes jar install org.openrewrite.recipe:rewrite-migrate-python:');
+    expect(text()).toContain('mod run . --recipe org.openrewrite.python.migrate.UpgradeToPython314');
+  });
+
+  it('resolves both install commands to the same version placeholder', () => {
+    renderRecipe({
+      ...pythonProps,
+      groupId: 'org.openrewrite.recipe',
+      artifactId: 'rewrite-migrate-python',
+    });
+
+    expect(text()).not.toContain('{{VERSION_');
+    const versions = [...text().matchAll(/rewrite-migrate-python[=:]=?([\d.]+)/g)].map((m) => m[1]);
+    expect(versions).toHaveLength(2);
+    expect(versions[0]).toEqual(versions[1]);
+  });
+
+  it('carries required recipe options into the run command for a jar-sourced Python recipe', () => {
+    renderRecipe({
+      recipeName: 'org.openrewrite.python.migrate.FindMethods',
+      displayName: 'Find Python function and method usages',
+      pipPackage: 'openrewrite-migrate-python',
+      groupId: 'org.openrewrite.recipe',
+      artifactId: 'rewrite-migrate-python',
+      versionKey: 'VERSION_ORG_OPENREWRITE_RECIPE_REWRITE_MIGRATE_PYTHON',
+      requiresConfiguration: true,
+      cliOptions: ' --recipe-option "methodPattern=dumps(..)"',
+    });
+
+    expect(text()).toContain('mod run . --recipe org.openrewrite.python.migrate.FindMethods --recipe-option "methodPattern=dumps(..)"');
+  });
+});

--- a/src/components/RunRecipe/RunRecipe.test.tsx
+++ b/src/components/RunRecipe/RunRecipe.test.tsx
@@ -34,11 +34,41 @@ describe('RunRecipe', () => {
       artifactId: 'rewrite-migrate-python',
     });
 
-    // The wheel's UpgradeToPython3XX composites delegate their project-file steps back to the jar, so a
-    // reader who follows only the pip command gets a recipe that silently skips those steps.
+    // The wheel's UpgradeToPython3XX composites delegate their project-file steps to the jar. Verified
+    // against the CLI: with only the pip package installed the run fails outright with
+    // "delegatesTo org.openrewrite.python.migrate.UpgradePythonVersionTo314 but no recipe found".
     expect(text()).toContain('mod config recipes pip install openrewrite-migrate-python==');
     expect(text()).toContain('mod config recipes jar install org.openrewrite.recipe:rewrite-migrate-python:');
     expect(text()).toContain('mod run . --recipe org.openrewrite.python.migrate.UpgradeToPython314');
+  });
+
+  it('installs companion jars the recipe delegates into', () => {
+    renderRecipe({
+      ...pythonProps,
+      groupId: 'org.openrewrite.recipe',
+      artifactId: 'rewrite-migrate-python',
+      companionJars: [
+        { groupId: 'org.openrewrite', artifactId: 'rewrite-python', versionKey: 'VERSION_ORG_OPENREWRITE_REWRITE_PYTHON' },
+      ],
+    });
+
+    // The jar recipes in turn delegate into the core language module; without it the CLI fails with
+    // "delegatesTo org.openrewrite.python.UpgradeDependencyVersion but no recipe found".
+    expect(text()).toContain('mod config recipes jar install org.openrewrite:rewrite-python:');
+    expect(text().match(/mod config recipes jar install/g)).toHaveLength(2);
+  });
+
+  it('drops an install command whose version placeholder does not resolve', () => {
+    renderRecipe({
+      ...pythonProps,
+      companionJars: [
+        { groupId: 'org.openrewrite', artifactId: 'rewrite-nonexistent', versionKey: 'VERSION_NOT_A_REAL_KEY' },
+      ],
+    });
+
+    // Better to omit the command than to paste a literal {{VERSION_...}} into the reader's shell.
+    expect(text()).not.toContain('{{VERSION_');
+    expect(text()).not.toContain('rewrite-nonexistent');
   });
 
   it('resolves both install commands to the same version placeholder', () => {

--- a/src/components/RunRecipe/index.tsx
+++ b/src/components/RunRecipe/index.tsx
@@ -66,22 +66,36 @@ export default function RunRecipe({
     );
   }
 
-  // Python recipes
+  // Python recipes. A recipe module can publish its recipes across both a pip package and a jar, with
+  // recipes in one half delegating to the other at runtime; when both coordinates are given, installing
+  // only one half leaves the delegated steps unresolvable, so both commands are shown together.
   if (pipPackage) {
     const pipPackageSpec = version ? `${pipPackage}==${version}` : pipPackage;
+    const installCommands = [`mod config recipes pip install ${pipPackageSpec}`];
+    if (hasDependency && version) {
+      installCommands.push(`mod config recipes jar install ${groupId}:${artifactId}:${version}`);
+    }
+    const dualPublished = installCommands.length > 1;
     return (
       <>
         <p>
           In order to run Python recipes, you will need to use the{' '}
           <a href="https://docs.moderne.io/user-documentation/moderne-cli/getting-started/cli-intro">Moderne CLI</a>.
         </p>
-        <p>Once the CLI is installed, you can install this Python recipe package by running the following command:</p>
-        <CodeBlock language="shell" title="Install the recipe package">
-          {`mod config recipes pip install ${pipPackageSpec}`}
+        <p>
+          {dualPublished
+            ? 'This recipe comes from a module that publishes its recipes to both PyPI and Maven Central, and recipes in one package call into the other. Once the CLI is installed, install both packages:'
+            : 'Once the CLI is installed, you can install this Python recipe package by running the following command:'}
+        </p>
+        <CodeBlock
+          language="shell"
+          title={dualPublished ? 'Install the recipe packages' : 'Install the recipe package'}
+        >
+          {installCommands.join('\n')}
         </CodeBlock>
         <p>Then, you can run the recipe via:</p>
         <CodeBlock language="shell" title="Run the recipe">
-          {`mod run . --recipe ${recipeName}`}
+          {`mod run . --recipe ${recipeName}${cliOptions}`}
         </CodeBlock>
       </>
     );

--- a/src/components/RunRecipe/index.tsx
+++ b/src/components/RunRecipe/index.tsx
@@ -2,6 +2,12 @@ import React from 'react';
 import CodeBlock from '@theme/CodeBlock';
 import latestVersions from '@site/src/plugins/latest-versions';
 
+interface CompanionJar {
+  groupId: string;
+  artifactId: string;
+  versionKey?: string;
+}
+
 interface RunRecipeProps {
   recipeName: string;
   displayName: string;
@@ -15,6 +21,7 @@ interface RunRecipeProps {
   pipPackage?: string;
   nugetPackage?: string;
   goPackage?: string;
+  companionJars?: CompanionJar[];
 }
 
 export default function RunRecipe({
@@ -30,6 +37,7 @@ export default function RunRecipe({
   pipPackage,
   nugetPackage,
   goPackage,
+  companionJars,
 }: RunRecipeProps) {
   // Replace {{VERSION_...}} placeholders with actual version numbers
   const resolveVersions = (text: string): string => {
@@ -38,11 +46,19 @@ export default function RunRecipe({
     });
   };
 
+  // An unknown key resolves to itself, which would otherwise paste a literal {{VERSION_...}} into a
+  // shell command. Treat that as "no version" so the caller can drop the command instead.
+  const resolveVersion = (key?: string): string => {
+    if (!key) return '';
+    const resolved = resolveVersions(`{{${key}}}`);
+    return resolved.startsWith('{{') ? '' : resolved;
+  };
+
   const hasDependency = !!(groupId && artifactId);
   const cliRecipeName = useFullyQualifiedCliName
     ? recipeName
     : recipeName.substring(recipeName.lastIndexOf('.') + 1);
-  const version = versionKey ? resolveVersions(`{{${versionKey}}}`) : '';
+  const version = resolveVersion(versionKey);
 
   // JavaScript recipes
   if (npmPackage) {
@@ -66,16 +82,23 @@ export default function RunRecipe({
     );
   }
 
-  // Python recipes. A recipe module can publish its recipes across both a pip package and a jar, with
-  // recipes in one half delegating to the other at runtime; when both coordinates are given, installing
-  // only one half leaves the delegated steps unresolvable, so both commands are shown together.
+  // Python recipes. Python recipes delegate across packages at runtime — a pip composite calls into a
+  // jar recipe, which in turn calls into the core language module — and the CLI resolves those
+  // delegates eagerly, failing the whole run when one is missing rather than skipping a step. So every
+  // package the recipe reaches is listed, not just the one it is published in.
   if (pipPackage) {
     const pipPackageSpec = version ? `${pipPackage}==${version}` : pipPackage;
     const installCommands = [`mod config recipes pip install ${pipPackageSpec}`];
     if (hasDependency && version) {
       installCommands.push(`mod config recipes jar install ${groupId}:${artifactId}:${version}`);
     }
-    const dualPublished = installCommands.length > 1;
+    for (const jar of companionJars ?? []) {
+      const jarVersion = resolveVersion(jar.versionKey);
+      if (jarVersion) {
+        installCommands.push(`mod config recipes jar install ${jar.groupId}:${jar.artifactId}:${jarVersion}`);
+      }
+    }
+    const multiplePackages = installCommands.length > 1;
     return (
       <>
         <p>
@@ -83,13 +106,13 @@ export default function RunRecipe({
           <a href="https://docs.moderne.io/user-documentation/moderne-cli/getting-started/cli-intro">Moderne CLI</a>.
         </p>
         <p>
-          {dualPublished
-            ? 'This recipe comes from a module that publishes its recipes to both PyPI and Maven Central, and recipes in one package call into the other. Once the CLI is installed, install both packages:'
+          {multiplePackages
+            ? 'This recipe calls into other OpenRewrite packages as it runs, and the CLI needs every one of them in its marketplace. Once the CLI is installed, install all of the following:'
             : 'Once the CLI is installed, you can install this Python recipe package by running the following command:'}
         </p>
         <CodeBlock
           language="shell"
-          title={dualPublished ? 'Install the recipe packages' : 'Install the recipe package'}
+          title={multiplePackages ? 'Install the recipe packages' : 'Install the recipe package'}
         >
           {installCommands.join('\n')}
         </CodeBlock>

--- a/src/components/recipe/shared/types.ts
+++ b/src/components/recipe/shared/types.ts
@@ -3,10 +3,13 @@ export interface SubRecipe { name: string; href: string; }
 export interface ExampleVariant { language: string; before: string; after: string; diff?: string; newFile?: boolean; }
 export interface ExampleParameter { parameter: string; value: string; }
 export interface RecipeExample { name?: string; parameters?: ExampleParameter[]; unchanged?: { language: string; code: string }; variants: ExampleVariant[]; }
+/** A jar that has to be installed alongside the recipe's own package for it to resolve at runtime. */
+export interface CompanionJar { groupId: string; artifactId: string; versionKey?: string; }
 export interface UsageProps {
   recipeName: string; displayName: string; groupId?: string; artifactId?: string; versionKey?: string;
   requiresConfiguration?: boolean; cliOptions?: string; useFullyQualifiedCliName?: boolean;
   npmPackage?: string; pipPackage?: string; nugetPackage?: string; goPackage?: string;
+  companionJars?: CompanionJar[];
 }
 export interface RecipeOption { type: string; name: string; required: boolean; description: string; example?: string; }
 export interface RecipeDataTable { name: string; displayName: string; description: string; columns: DataTableColumn[]; }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,7 @@ import path from 'path';
 export default defineConfig({
   // @docusaurus/tsconfig sets jsx: preserve for the editor, which leaves JSX in .tsx test files
   // untransformed. Vite's own automatic runtime handles it instead.
-  oxc: { jsx: 'automatic' },
+  oxc: { jsx: { runtime: 'automatic' } },
   test: {
     environment: 'happy-dom',
     globals: true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from 'vitest/config';
 import path from 'path';
 
 export default defineConfig({
+  // @docusaurus/tsconfig sets jsx: preserve for the editor, which leaves JSX in .tsx test files
+  // untransformed. Vite's own automatic runtime handles it instead.
+  oxc: { jsx: 'automatic' },
   test: {
     environment: 'happy-dom',
     globals: true,


### PR DESCRIPTION
Fixes #900. Docs half of the fix; the generator half is openrewrite/rewrite-recipe-markdown-generator#361.

## Problem

Python recipes delegate across packages at runtime, and the CLI resolves those delegates **before the run starts**. A package missing from the marketplace therefore fails the whole run rather than skipping the delegated step. Catalog pages showed one install command.

Verified against Moderne CLI 4.4.3 in an isolated `MODERNE_CLI_HOME`:

| marketplace | `mod run --recipe UpgradeToPython314` |
| --- | --- |
| pip `openrewrite-migrate-python` only — *what the page used to say* | ❌ `delegatesTo org.openrewrite.python.migrate.UpgradePythonVersionTo314 but no recipe found` |
| + jar `org.openrewrite.recipe:rewrite-migrate-python` | ❌ `delegatesTo org.openrewrite.python.UpgradeDependencyVersion` |
| + jar `org.openrewrite:rewrite-python` | ✅ |

## Change

* **`RunRecipe`** renders every package the recipe reaches as one install block — the pip package, the module's own jar, then any `companionJars`.
* An unresolved `{{VERSION_...}}` placeholder now **drops** its install command rather than pasting the literal token into the reader's shell. That was a latent bug on the existing single-jar path too.
* The Python branch appends `cliOptions` to the run command; the jar half has required-option recipes (`FindMethods`, `FindTypes`, `DependencyInsight`, `MigrateToPyprojectToml`) that would otherwise lose their example invocation.
* **CLI Python guide** names all three packages and points at the marketplace-CSV guide for users who don't need them.
* **`vitest.config.ts`** sets `oxc.jsx` — `@docusaurus/tsconfig` uses `jsx: preserve`, so no `.tsx` test could run before this.
* **`RunRecipe.test.tsx`** covers pip-only, dual-published, companion jars, matching versions, required options, and the unresolved-placeholder case.

## Verification

* End-to-end against the real CLI: seeding a marketplace from the curated `recipes-v5.csv` **minus** `rewrite-python` and both migrate-python halves reproduces a real broken machine; the three commands this renders then give a green run changing both files, with `requires-python` coming solely from the jar half.
* `SKIP_RECIPE_CATALOG=1 CI_STRICT_LINKS=1 DOCUSAURUS_IGNORE_SSG_WARNINGS=true yarn build` — passes (CI's env).
* `yarn typecheck`, `yarn lint:markdown` — pass.
* `yarn test:run` — all pass except a **pre-existing** failure in `filterUtils.test.ts` (`should return empty array for unknown paths`), red on `main` too.

## Rollout

Catalog pages aren't touched here — they're regenerated by `[Auto] Update docs` and pick up `companionJars` once #361 is released. `companionJars` is an additive optional prop, so pages generated by the current generator keep rendering exactly as they do today.

## Note

`pr-validation.yml` has no test job, so nothing runs the Vitest suite in CI. Worth adding once the stale `filterUtils` test is sorted.