### PR TITLE
Skip RPC toolchain setup on latest-versions-only runs

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -29,16 +29,20 @@ jobs:
           distribution: temurin
           java-version: 21
       - uses: actions/setup-python@v6
+        if: ${{ env.LATEST_VERSIONS_ONLY != 'true' }}
         with:
           python-version: '3.12'
       - uses: actions/setup-dotnet@v5
+        if: ${{ env.LATEST_VERSIONS_ONLY != 'true' }}
         with:
           dotnet-version: '9.0.x'
       - uses: gradle/actions/setup-gradle@v5
       - uses: actions/setup-go@v6
+        if: ${{ env.LATEST_VERSIONS_ONLY != 'true' }}
         with:
           go-version: '1.25'        # recipes-go and rewrite-go both require go 1.25 (their go.mod)
       - name: Build the rewrite-go-rpc server
+        if: ${{ env.LATEST_VERSIONS_ONLY != 'true' }}
         run: |
           # Pin GOROOT to the toolchain setup-go just put on PATH. Otherwise GoRewriteRpc discovers
           # GOROOT via GoExecutor.find(), which prefers /usr/bin/go (the runner image's older default


### PR DESCRIPTION
The scheduled run passes `-PlatestVersionsOnly=true`, and the generator returns from that path before it loads any recipe — no TypeScript, Python, C# or Go RPC process is ever started. Installing Python, the .NET SDK and Go, and building `rewrite-go-rpc` from source, costs ~50s a night for toolchains nothing invokes.

The one piece of C# work that does run on this path is `CSharpRecipeLoader.buildVersionAnchorOrigins`, which anchors the NuGet rows in the version table. It resolves versions over HTTPS from `api.nuget.org` via OkHttp and never shells out to the SDK, so it keeps working without `setup-dotnet`.

Gate the four steps on the flag the generator already keys off, so the manually dispatched full run is unaffected.

- Companion to openrewrite/rewrite-recipe-markdown-generator#362, which cuts the dependency resolution that dominates the rest of the same job.