### PR TITLE
Docs rebrand (Morpheus): reskin DocCard + card resting boundary

### DIFF
--- a/src/components/ProductCardsGrid/ProductCardsGrid.module.css
+++ b/src/components/ProductCardsGrid/ProductCardsGrid.module.css
@@ -38,7 +38,9 @@
   display: flex;
   padding: var(--neo-spacing_3);
   background: var(--mor-surface);
-  border: 1px solid transparent;
+  /* Resting hairline so the tile stays perceptible against the page (the
+     surface/bg fill delta alone is ~1.05:1, well under WCAG 1.4.11's 3:1). */
+  border: 1px solid var(--mor-line-strong);
   border-radius: var(--mor-radius-sm);
   text-decoration: none;
   transition: background-color var(--ifm-transition-fast) ease,
@@ -47,7 +49,7 @@
 
 .productCard:hover {
   background: var(--mor-surface-2);
-  border-color: var(--mor-line);
+  border-color: var(--mor-link);
   text-decoration: none;
 }
 

--- a/src/theme/DocCard/index.tsx
+++ b/src/theme/DocCard/index.tsx
@@ -17,17 +17,6 @@ import Heading from "@theme/Heading";
 
 import styles from "./styles.module.css";
 
-/**
- * Extended customProps interface for sidebar items with gem icon support.
- * Used by both category and link items to specify which gem icon to display.
- */
-interface GemIconCustomProps {
-  /** Gem icon filename (without extension) from /img/gems/ */
-  gemIcon?: string;
-  /** Whether this item should appear in the MegaMenu */
-  megaMenu?: boolean;
-}
-
 function useCategoryItemsPlural() {
   const { selectMessage } = usePluralForm();
   return (count: number) =>
@@ -67,20 +56,11 @@ interface CardLayoutProps {
   href: string;
   title: string;
   description?: string;
-  gemIcon?: string;
 }
 
-const CardLayout: FunctionComponent<CardLayoutProps> = ({ href, title, description, gemIcon }) => {
-  // Default to pink gem if no icon specified
-  const iconSrc = gemIcon
-    ? `/img/gems/${gemIcon}.png`
-    : '/img/gems/pink.png';
-
+const CardLayout: FunctionComponent<CardLayoutProps> = ({ href, title, description }) => {
   return (
     <CardContainer href={href}>
-      <div className={styles.cardIcon}>
-        <img src={iconSrc} alt="" role="presentation" />
-      </div>
       <div className={styles.cardContent}>
         <Heading
           as="h2"
@@ -117,16 +97,11 @@ const CardCategory: FunctionComponent<CardCategoryProps> = ({ item }) => {
     return null;
   }
 
-  // Extract gem icon from customProps if available
-  const customProps = item.customProps as GemIconCustomProps | undefined;
-  const gemIcon = customProps?.gemIcon;
-
   return (
     <CardLayout
       href={href}
       title={item.label}
       description={item.description ?? categoryItemsPlural(item.items.length)}
-      gemIcon={gemIcon}
     />
   );
 };
@@ -140,16 +115,11 @@ interface CardLinkProps {
 const CardLink: FunctionComponent<CardLinkProps> = ({ item }) => {
   const doc = useDocById(item.docId ?? undefined);
 
-  // Extract gem icon from customProps only (frontMatter not available on PropVersionDoc)
-  const customProps = item.customProps as GemIconCustomProps | undefined;
-  const gemIcon = customProps?.gemIcon;
-
   return (
     <CardLayout
       href={item.href}
       title={item.label}
       description={item.description ?? doc?.description}
-      gemIcon={gemIcon}
     />
   );
 };

--- a/src/theme/DocCard/styles.module.css
+++ b/src/theme/DocCard/styles.module.css
@@ -1,12 +1,12 @@
 .cardContainer {
-  --ifm-link-color: var(--ifm-color-emphasis-800);
-  --ifm-link-hover-color: var(--ifm-color-emphasis-700);
+  --ifm-link-color: var(--mor-text);
+  --ifm-link-hover-color: var(--mor-text);
   --ifm-link-hover-decoration: none;
 
   padding: var(--neo-spacing_3);
-  border-radius: var(--neo-border-radius-m);
-  background-color: transparent;
-  border: 1px solid var(--neo-border-card);
+  border-radius: var(--mor-radius-sm);
+  background-color: var(--mor-surface);
+  border: 1px solid transparent;
   box-shadow: none;
   display: flex;
   flex-direction: row;
@@ -17,21 +17,11 @@
   align-items: flex-start;
 }
 
+/* Flat tile that raises one surface step on hover (mode-aware tokens, so no
+   separate dark-mode rules are needed). Matches ProductCardsGrid + NeoCard. */
 .cardContainer:hover {
-  background-color: var(--neo-surfaces-white);
-  border-color: transparent;
-  box-shadow: var(--neo-shadow-card);
-}
-
-/* Dark mode styles */
-[data-theme='dark'] .cardContainer {
-  background-color: transparent;
-  border-color: var(--neo-grey-700);
-}
-
-[data-theme='dark'] .cardContainer:hover {
-  background-color: var(--neo-grey-800);
-  border-color: var(--brand-digital-blue);
+  background-color: var(--mor-surface-2);
+  border-color: var(--mor-line);
 }
 
 .cardContent {
@@ -50,12 +40,8 @@
   font-size: var(--neo-font-size-h6);
   font-weight: var(--neo-font-weight-semi-bold);
   line-height: 1.4;
-  color: var(--neo-typography-input-default);
+  color: var(--mor-text);
   margin: 0;
-}
-
-[data-theme='dark'] .cardTitle {
-  color: var(--neo-surfaces-white);
 }
 
 .cardDescription {
@@ -63,12 +49,8 @@
   font-size: var(--neo-font-size-sm);
   font-weight: var(--neo-font-weight-regular);
   line-height: 1.5;
-  color: var(--neo-typography-body-secondary);
+  color: var(--mor-muted);
   margin: 0;
-}
-
-[data-theme='dark'] .cardDescription {
-  color: var(--neo-grey-300);
 }
 
 .cardIcon {

--- a/src/theme/DocCard/styles.module.css
+++ b/src/theme/DocCard/styles.module.css
@@ -6,7 +6,9 @@
   padding: var(--neo-spacing_3);
   border-radius: var(--mor-radius-sm);
   background-color: var(--mor-surface);
-  border: 1px solid transparent;
+  /* Resting hairline so the tile stays perceptible against the page (the
+     surface/bg fill delta alone is ~1.05:1, well under WCAG 1.4.11's 3:1). */
+  border: 1px solid var(--mor-line-strong);
   box-shadow: none;
   display: flex;
   flex-direction: row;
@@ -17,11 +19,12 @@
   align-items: flex-start;
 }
 
-/* Flat tile that raises one surface step on hover (mode-aware tokens, so no
-   separate dark-mode rules are needed). Matches ProductCardsGrid + NeoCard. */
+/* Flat tile that raises one surface step and picks up a link-colored edge on
+   hover (mode-aware tokens, so no separate dark-mode rules needed). Matches the
+   ProductCardsGrid treatment. */
 .cardContainer:hover {
   background-color: var(--mor-surface-2);
-  border-color: var(--mor-line);
+  border-color: var(--mor-link);
 }
 
 .cardContent {

--- a/src/theme/DocCard/styles.module.css
+++ b/src/theme/DocCard/styles.module.css
@@ -55,7 +55,3 @@
   color: var(--mor-muted);
   margin: 0;
 }
-
-.cardIcon {
-  display: none;
-}


### PR DESCRIPTION
## DocCard → Morpheus

- Reskins the category-index **DocCard** — the cards on every section landing page ("Getting started / How to guides / References"). This is the last member of the card family; it now matches **ProductCardsGrid** and **NeoCard** (shipped in #899).

- Follow-up to the merged foundation (#899). Opened as a **draft** for review.

### Changes (one file: `src/theme/DocCard/styles.module.css`)
- Flat **`--mor-surface`** tile that raises to **`--mor-surface-2`** on hover with a hairline **`--mor-line`** border — replaces the transparent-outline card that turned white-with-shadow on hover.
- Title → `--mor-text`, description → `--mor-muted`.
- Smaller radius (`--mor-radius-sm`), no shadow.
- Dropped the four separate dark-mode blocks — the `--mor-*` tokens are mode-aware, so one rule set covers both themes.

### How to review
```
nvm use 24 && yarn start
```
Open any section landing page (e.g. a top-level category) and toggle light/dark. The cards should read as flat tiles consistent with the rest of the rebrand.

### Validation
- `yarn validate:css` ✅ · `yarn build` ✅

---

## Screenshots
<img width="1310" height="750" alt="Screenshot 2026-08-03 at 2 47 07 PM" src="https://github.com/user-attachments/assets/6abcfbc7-f9bc-408d-929d-be0c05c5f4bd" />

