### PR TITLE
Docs rebrand (Morpheus): antialias body text (consistent font weight)

### DIFF
--- a/src/css/morpheus-theme.css
+++ b/src/css/morpheus-theme.css
@@ -31,6 +31,15 @@
   --ifm-font-family-monospace: var(--mor-font-mono);
 }
 
+/* Antialiased rendering (as in the Morpheus prototype's `body`). Without this,
+   WebKit renders light-on-dark vs dark-on-light text at different apparent
+   weights, so Geist headings look heavier/inconsistent between light and dark.
+   Grayscale AA normalizes the weight across modes (and reads crisper). */
+body {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
 /* Light mode. `:root` beats Neo's :root by source order; the paired
    [data-theme='light'] selector matches custom.css's own light overrides so we
    win those too. */


### PR DESCRIPTION
## Antialias body text

Adds grayscale antialiasing to `body` — a small, site-wide typography fix.

### Why
The Morpheus prototype sets `body { -webkit-font-smoothing: antialiased }`, but the rebrand never ported it. Without it, WebKit renders **light-on-dark** vs **dark-on-light** text at different apparent weights — so Geist headings (e.g. the category-index hero title "Moderne Platform") looked **heavier in light mode than dark**, despite being the same `font-weight`.

### Change — `src/css/morpheus-theme.css`
```css
body {
  -webkit-font-smoothing: antialiased;
  -moz-osx-font-smoothing: grayscale;
}
```
Normalizes rendered weight across light/dark and reads crisper overall.

### Validation
- `yarn validate:css` ✅ · `yarn build` ✅

---
## Screenshots
> Drag-and-drop. Best shown as a light/dark heading comparison before vs after.

**Before (weights differ light vs dark)**
<!-- paste -->

**After (weights match)**
<!-- paste -->
