### PR TITLE
Point /admin/reports at telemetry exports and fix v2 audit log UI claim

### DIFF
--- a/docs/administrator-documentation/moderne-platform/references/audit-logging.md
+++ b/docs/administrator-documentation/moderne-platform/references/audit-logging.md
@@ -15,7 +15,7 @@ The Moderne Platform records a structured audit log of every user-initiated and 
 Tenant administrators (users in your organization that have been granted the `admin` role) can query audit logs through a paginated GraphQL API, or export them in CEF (Common Event Format) or CSV for ingestion into a SIEM or other log aggregation system. Access to the audit log is itself audited.
 
 :::note
-There is no audit log UI in the Moderne Platform. Audit logs are available through the GraphQL API and as CEF or CSV downloads only.
+There is no audit log UI in the Moderne Platform. Audit logs are available through the [GraphQL API](../../../user-documentation/moderne-platform/references/graphql-api-reference.md) (`auditLogs`, `auditLogsDownloads`, and the `downloadAuditLogs` mutation) and as CEF or CSV downloads only.
 :::
 
 ## Centralized audit framework

--- a/docs/administrator-documentation/moderne-platform/references/audit-logging.md
+++ b/docs/administrator-documentation/moderne-platform/references/audit-logging.md
@@ -12,7 +12,11 @@ import VersionBanner from '@site/src/components/VersionBanner';
 
 The Moderne Platform records a structured audit log of every user-initiated and system-initiated action. All audit events are persisted to a dedicated PostgreSQL database with a retention period of one year. Events are categorized by a CRUD action type (Create, Read, Update, Delete), tagged with the acting user's identity (or identified as a system-initiated action when performed automatically by the platform), timestamped in UTC, and marked with an outcome of Success or Failed.
 
-Tenant administrators (users in your organization that have been granted the `admin` role) can query audit logs through the Moderne UI, a paginated GraphQL API, or export them in CEF (Common Event Format) or CSV for ingestion into a SIEM or other log aggregation system. Access to the audit log is itself audited.
+Tenant administrators (users in your organization that have been granted the `admin` role) can query audit logs through a paginated GraphQL API, or export them in CEF (Common Event Format) or CSV for ingestion into a SIEM or other log aggregation system. Access to the audit log is itself audited.
+
+:::note
+There is no audit log UI in the Moderne Platform. Audit logs are available through the GraphQL API and as CEF or CSV downloads only.
+:::
 
 ## Centralized audit framework
 
@@ -64,7 +68,7 @@ All timestamps are recorded in UTC (RFC 3339 / ISO-8601 format: `YYYY-MM-DDTHH:M
 
 ## Access control
 
-Audit log access (both UI and API) is restricted to users with the `admin` role. Attempts to access audit logs without the `admin` role are denied. Access to the audit log itself is also logged.
+Audit log access is restricted to users with the `admin` role. Attempts to access audit logs without the `admin` role are denied. Access to the audit log itself is also logged.
 
 For more on roles, see the [user roles](./user-roles.md) reference documentation.
 

--- a/docs/releases/saas-v2-migration.md
+++ b/docs/releases/saas-v2-migration.md
@@ -112,8 +112,7 @@ Both have been removed. Status information now lives at `https://status.<tenant>
 
 **Removed:**
 
-* `/admin/status`: moved to `status.<tenant>.moderne.io`
-* `/status`: no direct replacement
+* `/admin/status` and `/status`: status information now lives at `status.<tenant>.moderne.io`. See [Atlas status pages](./saas-v2-changes.md#atlas-status-pages).
 * `/admin/reports`: the recipe run, commit, and usage report downloads (and their `downloadRecipeRunReport`-style GraphQL mutations) are gone. The same data is now delivered as telemetry replicated continuously into a bucket or storage account you own, which you query with your own BI stack. See [Configuring telemetry exports and reports](../administrator-documentation/moderne-platform/how-to-guides/configuring-telemetry-exports/overview.md). Audit logs are unaffected and remain available as a CEF or CSV download.
 * `/batch-changes`: folded into the Activity view
 

--- a/docs/releases/saas-v2-migration.md
+++ b/docs/releases/saas-v2-migration.md
@@ -110,11 +110,11 @@ Both have been removed. Status information now lives at `https://status.<tenant>
 * `/devcenter/{organization}/configure` → `/devcenter/configure?organizationId={organization}`
 * `/results/{recipeRunId}` → `/results/{organization}/{recipeRunId}`. Results are now org-scoped; the same applies to data tables, repositories, and visualization sub-pages.
 
-**Removed (no direct replacement):**
+**Removed:**
 
 * `/admin/status`: moved to `status.<tenant>.moderne.io`
-* `/status`
-* `/admin/reports`
+* `/status`: no direct replacement
+* `/admin/reports`: the recipe run, commit, and usage report downloads (and their `downloadRecipeRunReport`-style GraphQL mutations) are gone. The same data is now delivered as telemetry replicated continuously into a bucket or storage account you own, which you query with your own BI stack. See [Configuring telemetry exports and reports](../administrator-documentation/moderne-platform/how-to-guides/configuring-telemetry-exports/overview.md). Audit logs are unaffected and remain available as a CEF or CSV download.
 * `/batch-changes`: folded into the Activity view
 
 **Newly added:**


### PR DESCRIPTION
Two SaaS v2 docs gaps found while tracing what replaced v1's usage reports.

## `/admin/reports` had no forwarding address

`docs/releases/saas-v2-migration.md` listed `/admin/reports` under **"Removed (no direct replacement)"**. There *is* a replacement — [Configuring telemetry exports and reports](https://docs.moderne.io/administrator-documentation/moderne-platform/configuring-telemetry-exports) — but nothing in the migration guide pointed at it, so an admin who relied on v1's recipe run / commit / usage report downloads had no trail to follow.

The entry now explains that those downloads (and their `downloadRecipeRunReport`-style GraphQL mutations) are gone, that the same data arrives as replicated telemetry you query with your own BI stack, and that audit logs are unaffected.

The section heading changed from "Removed (no direct replacement)" to "Removed", since `/admin/status` and `/batch-changes` already listed replacements underneath it. `/status` now carries the "no direct replacement" note explicitly.

## v2 audit logging referenced a UI that doesn't exist

`docs/administrator-documentation/moderne-platform/references/audit-logging.md` said admins can query audit logs "through the Moderne UI, a paginated GraphQL API, or export them in CEF or CSV". But `docs/releases/saas-v2-changes.md:139` says the audit log UI was removed in v2 and logs are download-only. The v1 URL (`/admin/audit-logs`) is documented only on the v1 reporting page.

Dropped the UI from the intro, added a note making the absence explicit, and removed "(both UI and API)" from the access control section.

## Validation

* `yarn build` — exit 0, no broken links or warnings.
* `yarn lint:markdown` — only two pre-existing warnings in `cli-wrapper.md`, untouched here.

## For reviewers

Please confirm the audit log UI really is gone in v2 — I'm going off the v2 changelog entry, not the running platform. If it came back, the note is the thing to delete.