### PR TITLE
Fix unreadable announcement bar text in dark mode

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -52,8 +52,11 @@
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
   --ifm-color-announcement-bar-bg: var(--ifm-color-mint);
 
-  /* Morpheus:Announcement bar text */
-  --ifm-color-announcement-bar-text: var(--mor-text);
+  /* Announcement bar text — static dark: the bar background is always the mint
+     green (--ifm-color-mint), independent of theme, so the text must not follow
+     the color mode. A mode-aware token (--mor-text) flips to near-white in dark
+     mode, leaving unreadable light-on-light text on the green bar. */
+  --ifm-color-announcement-bar-text: #232342;
 
   --ifm-navbar-background-color: transparent;
   --ifm-navbar-padding-vertical: 0;


### PR DESCRIPTION
## Regression

A user reported the announcement bar text is unreadable in **dark mode** — near-white text on the mint-green bar.

- **Cause (introduced by the neo-design → Morpheus migration, #922):** the migration mechanically mapped
- `--ifm-color-announcement-bar-text` from a *static* dark color (`neo-typography-input-default` = `#1f2937`) to the *mode-aware* `--mor-text` (`#232342` light / `#f1f0ea` dark). The announcement bar background (`--ifm-color-mint` = `#85fe99`) is a fixed light mint green in both themes, so in dark mode the text flipped to near-white → light-on-light, unreadable.

## Fix

- Restore a **static dark** text color for the announcement bar (`#232342`), since its background is theme-independent. Readable dark-on-mint in both modes, matching the pre-migration behavior.

## Verified
- Dark mode: announcement bar text computes to `#232342` (navy) on `#85fe99` (mint) — high contrast, readable ✓
- Light mode unchanged (was already dark text)
- `yarn validate:css` passes