### PR TITLE
Morpheus rebrand: landing hero

### DIFF
--- a/src/css/morpheus-tokens.css
+++ b/src/css/morpheus-tokens.css
@@ -151,13 +151,13 @@
   --mor-link: #1245ae;
   --mor-link-deep: #16306b;
 
-  /* Primary button — brand digital blue, matching production (docs.moderne.io),
-     deliberately overriding the design kit's navy. #2f42ff / #1e2ec2 are the old
-     brand blue, outside the Morpheus palette, so they're literals; static in both
-     modes like production's button. */
-  --mor-btn-primary-bg: #2f42ff;
+  /* Primary button — Morpheus high-contrast neutral. Light mode: midnight navy
+     fill (matches --mor-text) with near-white text. It inverts in dark mode (see
+     the [data-theme='dark'] override) so the primary action stays the highest-
+     contrast element in either theme. */
+  --mor-btn-primary-bg: #232342;
   --mor-btn-primary-fg: #fbfaf6;
-  --mor-btn-primary-hover: #1e2ec2;
+  --mor-btn-primary-hover: #2c2c50;
 
   /* Illustration tiles */
   --mor-ill-panel: #fbfaf6;
@@ -207,8 +207,11 @@
   --mor-link: #7fa9f9;
   --mor-link-deep: #7fa9f9;
 
-  /* Primary button is a static brand blue with white fg (set on :root); no dark
-     override needed. */
+  /* Primary button inverts in dark mode: near-white fill with near-black text,
+     keeping it the highest-contrast element against the dark canvas. */
+  --mor-btn-primary-bg: #f1f0ea;
+  --mor-btn-primary-fg: #17171c;
+  --mor-btn-primary-hover: #ffffff;
 
   /* Illustration tiles */
   --mor-ill-panel: #26262e;

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -39,13 +39,15 @@
 
 .heroHeading {
   font-family: var(--ifm-font-family-base);
-  font-size: 54px;
-  font-weight: var(--mor-font-weight-medium);
+  font-size: 44px;
+  font-weight: var(--mor-font-weight-bold);
+  letter-spacing: -0.03em;
   line-height: 1.1;
+  color: var(--mor-text);
   margin: 0;
 }
 
-/* Signature Morpheus spectral gradient on the first headline line.
+/* Signature Morpheus spectral gradient on the "go further" phrase.
    Light mode ends on a dark, high-contrast stop (--mor-link) so the pale
    green/lime tail of the full spectral run doesn't fall below WCAG contrast on
    the cream canvas; dark mode keeps the full spectral, which reads fine there. */
@@ -77,27 +79,41 @@
   }
 }
 
-.heroHeadingDark {
-  color: var(--mor-text);
-}
-
+/* Lede: smaller, muted supporting copy under the headline. */
 .heroSubheading {
   font-family: var(--ifm-font-family-base);
-  font-size: 28px;
-  font-weight: var(--mor-font-weight-medium);
-  line-height: 1.4;
-  color: var(--mor-text);
+  font-size: var(--mor-font-size-lg);
+  font-weight: var(--mor-font-weight-regular);
+  line-height: 1.6;
+  color: var(--mor-muted);
+  max-width: 560px;
   margin: 0;
+}
+
+.heroActions {
+  display: flex;
+  align-items: center;
+  gap: var(--mor-space-3);
+}
+
+/* Hero buttons use the design system's square-ish button radius (4px), matching
+   the Morpheus prototype rather than ModButton's default pill. */
+.heroButton {
+  border-radius: var(--mor-radius-button);
+}
+
+/* ModButton's secondary border (--mor-line) sits ~1.3:1 against the cream canvas,
+   below WCAG 1.4.11's 3:1 for a control boundary. Bump the hero instance to the
+   mode-aware --mor-line-strong (~3:1), matching the Morpheus prototype. Three
+   classes so it beats ModButton's own dark-mode secondary rule. */
+.heroActions .heroButton.heroButtonSecondary {
+  border-color: var(--mor-line-strong);
 }
 
 /* Mobile breakpoint */
 @media (max-width: 768px) {
   .heroHeading {
     font-size: 32px;
-  }
-
-  .heroSubheading {
-    font-size: var(--mor-font-size-lg);
   }
 
   .pageBody {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,7 +4,6 @@ import { ModButton } from '@site/src/components/ModButton';
 import { ProductCardsGrid } from '@site/src/components/ProductCardsGrid';
 import { homepageProducts } from '@site/src/config/megaMenuData';
 import Layout from '@theme/Layout';
-import { ArrowRight } from 'lucide-react';
 import type { FunctionComponent } from 'react';
 import VideoPlayer from '@site/src/components/VideoPlayer';
 import styles from './index.module.css';
@@ -14,23 +13,30 @@ export const HeroSection: FunctionComponent = () => {
     <section className={styles.hero}>
       <div className={styles.heroContent}>
         <h1 className={styles.heroHeading}>
-          <span className={styles.heroHeadingGrad}>Explore documentation</span>
+          Explore documentation
           <br />
-          <span className={styles.heroHeadingDark}>and tutorials to go further</span>
+          and tutorials to <span className={styles.heroHeadingGrad}>go further</span>
         </h1>
         <p className={styles.heroSubheading}>
-          Discover how to fix vulnerabilities, standardize code quality, 
+          Discover how to fix vulnerabilities, standardize code quality,
           perform type-aware code searches, and accelerate refactoring at enterprise scale.
         </p>
-        <div>
+        <div className={styles.heroActions}>
           <ModButton
             variant="primary"
             size="medium"
+            className={styles.heroButton}
             href="/user-documentation/moderne-platform/getting-started/running-your-first-recipe"
-            icon={<ArrowRight size={16} />}
-            iconPosition="right"
           >
             Get started
+          </ModButton>
+          <ModButton
+            variant="secondary"
+            size="medium"
+            className={`${styles.heroButton} ${styles.heroButtonSecondary}`}
+            href="#what-is-moderne"
+          >
+            What is Moderne?
           </ModButton>
         </div>
       </div>


### PR DESCRIPTION
## What

Rebuilds the landing-page hero to match the Morpheus prototype ([docs-morpheus.html](https://moderneinc.github.io/prototypes/docs-morpheus.html)).
<img width="1900" height="1223" alt="Screenshot 2026-08-07 at 2 20 16 PM" src="https://github.com/user-attachments/assets/fcfe796f-bfe7-461d-abe8-4bbff68cabdc" />
<img width="1898" height="1218" alt="Screenshot 2026-08-07 at 2 20 08 PM" src="https://github.com/user-attachments/assets/48fec1c5-f1bb-44f4-9ab4-2434161005e6" />

<img width="685" height="1227" alt="Screenshot 2026-08-07 at 2 21 11 PM" src="https://github.com/user-attachments/assets/4ad2ceb0-8ae4-4b3f-ba27-3ff2b019cc29" />
<img width="687" height="1231" alt="Screenshot 2026-08-07 at 2 20 51 PM" src="https://github.com/user-attachments/assets/538c39fd-4479-44fc-8ed7-36e0bd08cc62" />



## Changes

**`src/pages/index.tsx`**
* Gradient now sits on **"go further"** only (the trailing phrase); the rest of the headline is solid `--mor-text`. (Previously the whole first line was gradient, second line dark.)
* Added the second CTA — **"What is Moderne?"** (`secondary`), anchoring to `#what-is-moderne`. Wrapped both in a `.heroActions` row.
* Dropped the arrow icon on "Get started" to match the prototype (removed the now-unused `ArrowRight` import).

**`src/pages/index.module.css`**
* Heading → prototype type: `44px` / weight `700` / `letter-spacing -0.03em` (was `54px` / medium).
* Subhead → prototype `.lede`: `16px`, regular, `line-height 1.6`, `--mor-muted`, `max-width 560px` (was `28px` medium in full-strength text).
* Hero buttons use `--mor-radius-button` (4px) — the design system's stated button radius — instead of `ModButton`'s default pill, matching the prototype.
* Removed the now-unused `.heroHeadingDark` rule.

**`src/css/morpheus-tokens.css` — primary-button token (site-wide)**
- * `--mor-btn-primary-bg` changed from the production digital blue `#2f42ff` to the Morpheus high-contrast neutral: navy `#232342` in light, inverting to near-white `#f1f0ea` in dark (with matching `-fg`/`-hover`). This reverses the earlier deliberate "match production blue" override so the primary button uses the true Morpheus style.
* **Blast radius:** every primary button on the docs changes blue → navy (light) / near-white (dark). The four non-button consumers are focus outlines (ModButton, PlatformToggle, Navbar/Logo), which shift blue→navy.

## Accessibility (WCAG)

* Primary button text on fill — light near-white on navy ≈ **13:1**; dark near-black on near-white ≈ **17:1**. ✓
* Subhead `--mor-muted` on cream — **5.20:1** ✓ (body text ≥4.5:1).
* "go further" gradient (large text, 3:1) — lightest light-mode stops: pink 3.40:1, violet 3.63:1, blue 3.45:1, ending on `--mor-link`. ✓
* Secondary button boundary — `ModButton`'s `secondary` border (`--mor-line`) measures ~1.3:1 against the canvas, below 1.4.11's 3:1. Bumped the hero instance to the mode-aware `--mor-line-strong` (~3:1), matching the prototype. (The global `ModButton` `secondary` variant still carries the fainter border — noted as a separate follow-up.)

## Validation

* `yarn validate:css` — clean
* `yarn typecheck` — clean
* `SKIP_RECIPE_CATALOG=1 yarn build` — succeeds (pre-existing MDX `<p>` minifier diagnostics on unrelated content pages; only expected recipe-catalog broken links from the skip flag)