### PR TITLE
Document recipe module version alignment and marketplace resolution

### DIFF
--- a/docs/user-documentation/moderne-cli/how-to-guides/curate-recipe-marketplace.md
+++ b/docs/user-documentation/moderne-cli/how-to-guides/curate-recipe-marketplace.md
@@ -229,5 +229,6 @@ Without `mod config recipes delete`, `import` has no way to know that a recipe w
 ## Next steps
 
 * [`recipes.csv` reference](../references/recipes-csv.md): full CSV format, column semantics, and validation rules.
+* [Aligning recipe module versions](../../recipes/authoring-recipes/set-up/recipe-module-versions.md): how versions in your own recipe library relate to the versions loaded from the marketplace.
 * [Managing recipe categories](../../../administrator-documentation/moderne-platform/how-to-guides/categorize-recipes.md): for re-organizing recipes under custom category hierarchies.
 * [CLI reference](../cli-reference.md#mod-config-recipes): full command documentation for `mod config recipes`.

--- a/docs/user-documentation/moderne-platform/how-to-guides/new-recipe-builder.md
+++ b/docs/user-documentation/moderne-platform/how-to-guides/new-recipe-builder.md
@@ -94,6 +94,10 @@ The category a recipe appears under comes from the package structure of its ID. 
 
 If you'd rather organize your recipes differently, you can set the ID yourself when you create the recipe. The package segments you choose determine the category, and any nested subcategories, that your recipe appears under.
 
+:::info
+Recipes you compose or customize in the builder are declarative YAML recipes, which reference the recipes they include by name rather than by version. Those references are resolved against the recipe module versions currently deployed in your marketplace, which can differ from the versions the original recipe was compiled against. See [aligning recipe module versions](../../recipes/authoring-recipes/set-up/recipe-module-versions.md) for what that means in practice.
+:::
+
 ## How to create or add recipes from the marketplace
 
 From any recipe in the marketplace, you can click on the `Add to builder` button:

--- a/docs/user-documentation/moderne-platform/how-to-guides/writing-and-installing-recipes.md
+++ b/docs/user-documentation/moderne-platform/how-to-guides/writing-and-installing-recipes.md
@@ -27,7 +27,7 @@ If your recipe is more complex than that, please check out the [OpenRewrite reci
 You may also find it beneficial to work through our [recipe authoring workshop](../../../hands-on-learning/fundamentals/workshop-overview.md) that will take you through the process of writing and running many different types of recipes.
 
 :::tip
-As a Moderne customer, you have access to the [Moderne recipe bom](https://artifacts.codegenomeproject.org/maven/io/moderne/recipe/moderne-recipe-bom/) which can help you align versions of all Moderne recipe modules.
+As a Moderne customer, you have access to the [Moderne recipe bom](https://artifacts.codegenomeproject.org/maven/io/moderne/recipe/moderne-recipe-bom/) which can help you align versions of all Moderne recipe modules. For how to import it, and what those versions mean once your recipes run from the marketplace, see [aligning recipe module versions](../../recipes/authoring-recipes/set-up/recipe-module-versions.md).
 :::
 
 ## Step 2: Create a recipe JAR

--- a/docs/user-documentation/recipes/authoring-recipes/set-up/recipe-development-environment.md
+++ b/docs/user-documentation/recipes/authoring-recipes/set-up/recipe-development-environment.md
@@ -71,6 +71,10 @@ Rewrite provides a bill of materials (BOM) that, when imported into your build, 
 
 You can import the bill of materials into either Gradle or Maven and then include concrete dependencies on the various rewrite libraries without specifying their version.
 
+:::tip
+If your recipe library also depends on Moderne's recipe modules, import `moderne-recipe-bom` instead – it manages those modules and imports `rewrite-recipe-bom` for you. See [aligning recipe module versions](./recipe-module-versions.md) for details.
+:::
+
 <Tabs groupId="projectType">
 <TabItem value="gradle" label="Gradle">
 

--- a/docs/user-documentation/recipes/authoring-recipes/set-up/recipe-module-versions.md
+++ b/docs/user-documentation/recipes/authoring-recipes/set-up/recipe-module-versions.md
@@ -91,13 +91,13 @@ This isolation is what allows recipe modules to coexist even when they depend on
 
 For your own recipe library, the practical consequence is that you do not need to match your dependency versions to whatever else happens to be deployed in your marketplace. Your recipes run against the versions you published them with, in both the CLI and the Platform.
 
-## How declarative YAML recipes resolve
+## How standalone YAML recipes resolve
 
-The exception to this isolation is declarative YAML recipes.
+The exception to this isolation is a declarative YAML recipe that is installed on its own, rather than packaged inside a recipe artifact.
 
-A YAML recipe references the recipes it includes by name, not by artifact version. When the YAML is installed on its own, rather than packaged inside a recipe artifact, it carries no dependencies of its own to be isolated with. Its references are resolved when the recipe runs, against whatever versions your marketplace currently has installed.
+A YAML recipe references the recipes it includes by name, not by artifact version. YAML that is packaged inside a recipe JAR resolves those names against that JAR's classpath, so it stays isolated like any other recipe artifact. A standalone YAML recipe has no classpath of its own, so its references are resolved when the recipe runs, against whatever versions your marketplace currently has installed.
 
-You will run into this in two common places:
+You will run into this in two places:
 
 * **The [recipe builder](../../../moderne-platform/how-to-guides/new-recipe-builder.md)**: composing a new recipe, or customizing an existing one, produces a YAML recipe. Its sub-recipes are resolved against the versions deployed in your marketplace, which can be newer or older than the versions the original recipe was compiled against.
 * **YAML you copied from somewhere else**: a recipe pasted from a chat message, a docs page, or a colleague carries no version information either. Installing it with `mod config recipes yaml install` adds its recipes to your marketplace, where they resolve against the recipe modules you already have installed.
@@ -105,12 +105,12 @@ You will run into this in two common places:
 In both cases the recipe can pick up different – newer or older – versions of recipe modules than the ones it was originally written or compiled against.
 
 :::warning
-A YAML recipe is not pinned to the recipe module versions it was written against. Re-test YAML recipes after you update the recipe modules in your marketplace, since the sub-recipes they resolve to can change.
+A standalone YAML recipe is not pinned to the recipe module versions it was written against. Re-test these recipes after you update the recipe modules in your marketplace, since the sub-recipes they resolve to can change. Packaging the YAML into a recipe JAR instead gives it the same version isolation as any other recipe artifact.
 :::
 
 ## Keeping your marketplace up to date
 
-Because YAML recipes resolve against what is deployed, it is worth knowing how deployed versions change:
+Because standalone YAML recipes resolve against what is deployed, it is worth knowing how deployed versions change:
 
 * **Moderne CLI**: `mod config recipes upgrade` re-resolves and reinstalls each installed artifact that was requested at a dynamic version. See [curating the recipe marketplace](../../../moderne-cli/how-to-guides/curate-recipe-marketplace.md) for how to control which recipes your developers see and which versions they get.
 * **Moderne Platform**: an administrator re-deploys the recipe artifact, as described in [importing external recipes](../../../../administrator-documentation/moderne-platform/how-to-guides/importing-external-recipes.md). Deploying with a version of `RELEASE` re-resolves to the newest stable release, while `LATEST` re-resolves to the newest available build, including snapshots.

--- a/docs/user-documentation/recipes/authoring-recipes/set-up/recipe-module-versions.md
+++ b/docs/user-documentation/recipes/authoring-recipes/set-up/recipe-module-versions.md
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 
 # Aligning recipe module versions
 
-When you maintain your own recipe library, you depend on OpenRewrite and Moderne recipe modules – `rewrite-java`, `rewrite-static-analysis`, `rewrite-spring`, and so on. Those modules release on different schedules, so it is not obvious which combination of versions you should be building against. It is also not obvious which versions are used once your recipes run from the recipe marketplace in the Moderne CLI or the Moderne Platform.
+When you maintain your own recipe library, you depend on OpenRewrite and Moderne recipe modules – `rewrite-java`, `rewrite-static-analysis`, `rewrite-spring`, and so on. Each of these modules is individually versioned, and any of them may put out a new patch release in between Moderne's biweekly releases, so it is not obvious which combination of versions you should be building against. It is also not obvious which versions are used once your recipes run from the recipe marketplace in the Moderne CLI or the Moderne Platform.
 
 In this guide, we will walk you through using a bill of materials (BOM) to align the modules your recipe library depends on, how the marketplace isolates recipe modules from one another at run time, and the one case where that isolation does not apply.
 

--- a/docs/user-documentation/recipes/authoring-recipes/set-up/recipe-module-versions.md
+++ b/docs/user-documentation/recipes/authoring-recipes/set-up/recipe-module-versions.md
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 
 When you maintain your own recipe library, you depend on OpenRewrite and Moderne recipe modules – `rewrite-java`, `rewrite-static-analysis`, `rewrite-spring`, and so on. Each of these modules is individually versioned, and any of them may put out a new patch release in between Moderne's biweekly releases, so it is not obvious which combination of versions you should be building against. It is also not obvious which versions are used once your recipes run from the recipe marketplace in the Moderne CLI or the Moderne Platform.
 
-In this guide, we will walk you through using a bill of materials (BOM) to align the modules your recipe library depends on, how the marketplace isolates recipe modules from one another at run time, and the one case where that isolation does not apply.
+In this guide, we will walk you through using a bill of materials (BOM) to align the modules your recipe library depends on, how the marketplace isolates recipe modules from one another at run time, and where that isolation stops.
 
 ## Aligning your dependencies with a bill of materials
 
@@ -83,6 +83,14 @@ If your recipe library only depends on open source OpenRewrite modules, import `
 `moderne-recipe-bom` and the Moderne recipe modules it manages are distributed through the Code Genome Project, which requires authentication. See [configuring the Code Genome Project repository](../../lists/latest-versions-of-every-openrewrite-module.md#configure-the-code-genome-project-repository) for the repository and credential setup.
 :::
 
+### Matching versions across language ecosystems
+
+Some recipe modules have a counterpart published to another package ecosystem. Recipes that target languages such as JavaScript, TypeScript, C#, Go, and Python are split between a Maven module and an equivalent npm, NuGet, or PyPI package, and both halves need to be on the same version.
+
+The BOM manages only the Maven side, so install the counterpart at the version the BOM resolved for its matching module. For example, `io.moderne.recipe:rewrite-angular` pairs with the npm package `@openrewrite/recipes-angular`, and `org.openrewrite:rewrite-python` pairs with the PyPI package `openrewrite`.
+
+The [latest versions of every OpenRewrite module](../../lists/latest-versions-of-every-openrewrite-module.md#cli-installation) page publishes ready-made `mod config recipes npm install`, `pip install`, and `nuget install` commands, with each counterpart already pinned to the version of its matching Maven module.
+
 ## How recipe modules are isolated in the marketplace
 
 The recipe marketplace does not resolve every installed recipe module against one shared set of dependency versions. Each recipe artifact is loaded together with the dependencies it was published with, isolated from the other artifacts in the marketplace.
@@ -90,6 +98,12 @@ The recipe marketplace does not resolve every installed recipe module against on
 This isolation is what allows recipe modules to coexist even when they depend on different versions of other recipe modules. Moderne releases most recipe modules on a biweekly cadence, but not every module follows it. The Quarkus recipe modules, for example, release independently and are often behind the current biweekly release, so they may still be built against an older version of a shared module. Isolation means they run against the version they were built for, while the modules from the current release run against theirs.
 
 For your own recipe library, the practical consequence is that you do not need to match your dependency versions to whatever else happens to be deployed in your marketplace. Your recipes run against the versions you published them with, in both the CLI and the Platform.
+
+### What the CLI loads for itself
+
+Isolation is not total. The [`RecipeClassLoader`](https://github.com/openrewrite/rewrite/blob/main/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeClassLoader.java) gives each recipe artifact maximum isolation for its own implementation classes, but delegates the core OpenRewrite API types to its parent classloader so that the CLI and your recipe agree on them. `Recipe`, `ExecutionContext`, `SourceFile`, `Tree`, `JavaParser`, `MethodMatcher`, and the `org.openrewrite.rpc` types that back cross-language recipes are all loaded this way.
+
+Those classes come from the CLI itself rather than from your recipe artifact, which couples your recipe to the CLI release it runs on. To keep the two in step, run your recipes with a CLI version that was released together with the recipe modules in the BOM you built against. Each BOM manages the matching CLI release as `io.moderne:moderne-cli` for exactly this reason.
 
 ## How standalone YAML recipes resolve
 

--- a/docs/user-documentation/recipes/authoring-recipes/set-up/recipe-module-versions.md
+++ b/docs/user-documentation/recipes/authoring-recipes/set-up/recipe-module-versions.md
@@ -91,24 +91,33 @@ This isolation is what allows recipe modules to coexist even when they depend on
 
 For your own recipe library, the practical consequence is that you do not need to match your dependency versions to whatever else happens to be deployed in your marketplace. Your recipes run against the versions you published them with, in both the CLI and the Platform.
 
-## How the recipe builder resolves recipes
+## How declarative YAML recipes resolve
 
-The exception to this isolation is the [recipe builder](../../../moderne-platform/how-to-guides/new-recipe-builder.md).
+The exception to this isolation is declarative YAML recipes.
 
-Declarative YAML recipes reference the recipes they include by name, not by artifact version. When you compose a new recipe in the recipe builder, or customize an existing one, the result is a YAML recipe, and the recipes it references are resolved against the versions currently deployed in your marketplace.
+A YAML recipe references the recipes it includes by name, not by artifact version. When the YAML is installed on its own, rather than packaged inside a recipe artifact, it carries no dependencies of its own to be isolated with. Its references are resolved when the recipe runs, against whatever versions your marketplace currently has installed.
 
-That means a customized recipe can pick up different – newer or older – versions of recipe modules than the ones the original recipe was compiled against.
+You will run into this in two common places:
+
+* **The [recipe builder](../../../moderne-platform/how-to-guides/new-recipe-builder.md)**: composing a new recipe, or customizing an existing one, produces a YAML recipe. Its sub-recipes are resolved against the versions deployed in your marketplace, which can be newer or older than the versions the original recipe was compiled against.
+* **YAML you copied from somewhere else**: a recipe pasted from a chat message, a docs page, or a colleague carries no version information either. Installing it with `mod config recipes yaml install` adds its recipes to your marketplace, where they resolve against the recipe modules you already have installed.
+
+In both cases the recipe can pick up different – newer or older – versions of recipe modules than the ones it was originally written or compiled against.
 
 :::warning
-A recipe customized in the recipe builder is not pinned to the versions of the recipe it was derived from. Re-test customized recipes after you update the recipe modules in your marketplace, since the sub-recipes they resolve to can change.
+A YAML recipe is not pinned to the recipe module versions it was written against. Re-test YAML recipes after you update the recipe modules in your marketplace, since the sub-recipes they resolve to can change.
 :::
 
 ## Keeping your marketplace up to date
 
-Because the recipe builder resolves against what is deployed, it is worth knowing how deployed versions change:
+Because YAML recipes resolve against what is deployed, it is worth knowing how deployed versions change:
 
-* **Moderne CLI**: `mod config recipes upgrade` re-resolves either `LATEST` or `RELEASE` for each installed artifact and reinstalls it. See [curating the recipe marketplace](../../../moderne-cli/how-to-guides/curate-recipe-marketplace.md) for how to control which recipes your developers see and which versions they get.
+* **Moderne CLI**: `mod config recipes upgrade` re-resolves and reinstalls each installed artifact that was requested at a dynamic version. See [curating the recipe marketplace](../../../moderne-cli/how-to-guides/curate-recipe-marketplace.md) for how to control which recipes your developers see and which versions they get.
 * **Moderne Platform**: an administrator re-deploys the recipe artifact, as described in [importing external recipes](../../../../administrator-documentation/moderne-platform/how-to-guides/importing-external-recipes.md). Deploying with a version of `RELEASE` re-resolves to the newest stable release, while `LATEST` re-resolves to the newest available build, including snapshots.
+
+:::note
+Only artifacts requested at a dynamic version – `LATEST` or `RELEASE` – are re-resolved. An artifact installed at an exact version stays on that version until you reinstall it with `mod config recipes jar install`. That is what you want when you are deliberately holding a team on a validated release, but it also means `upgrade` alone will not move it.
+:::
 
 ## Next steps
 

--- a/docs/user-documentation/recipes/authoring-recipes/set-up/recipe-module-versions.md
+++ b/docs/user-documentation/recipes/authoring-recipes/set-up/recipe-module-versions.md
@@ -1,0 +1,117 @@
+---
+sidebar_label: Recipe module versions
+description: How to align the recipe module versions your recipe library depends on, and how those versions are resolved in the recipe marketplace.
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Aligning recipe module versions
+
+When you maintain your own recipe library, you depend on OpenRewrite and Moderne recipe modules – `rewrite-java`, `rewrite-static-analysis`, `rewrite-spring`, and so on. Those modules release on different schedules, so it is not obvious which combination of versions you should be building against. It is also not obvious which versions are used once your recipes run from the recipe marketplace in the Moderne CLI or the Moderne Platform.
+
+In this guide, we will walk you through using a bill of materials (BOM) to align the modules your recipe library depends on, how the marketplace isolates recipe modules from one another at run time, and the one case where that isolation does not apply.
+
+## Aligning your dependencies with a bill of materials
+
+A bill of materials (BOM) is a published artifact that manages the versions of a related set of modules. You import the BOM once, then declare dependencies on individual modules without specifying their versions.
+
+Moderne publishes [`io.moderne.recipe:moderne-recipe-bom`](https://artifacts.codegenomeproject.org/maven/io/moderne/recipe/moderne-recipe-bom/), which manages the versions of Moderne's recipe modules. It also imports [`org.openrewrite.recipe:rewrite-recipe-bom`](https://github.com/openrewrite/rewrite-recipe-bom), so a single import covers both the open source OpenRewrite modules and Moderne's proprietary ones.
+
+<Tabs groupId="projectType">
+<TabItem value="gradle" label="Gradle">
+
+```groovy title="build.gradle"
+dependencies {
+    // Import Moderne's bill of materials, which also imports rewrite-recipe-bom
+    implementation(platform("io.moderne.recipe:moderne-recipe-bom:latest.release"))
+
+    // Declare recipe modules without a version - the BOM manages them
+    implementation("org.openrewrite:rewrite-java")
+    implementation("org.openrewrite.recipe:rewrite-static-analysis")
+    implementation("io.moderne.recipe:rewrite-spring")
+}
+```
+
+</TabItem>
+
+<TabItem value="maven" label="Maven">
+
+```xml title="pom.xml"
+<dependencyManagement>
+  <dependencies>
+    <!-- Import Moderne's bill of materials, which also imports rewrite-recipe-bom -->
+    <dependency>
+      <groupId>io.moderne.recipe</groupId>
+      <artifactId>moderne-recipe-bom</artifactId>
+      <version>0.41.0</version>
+      <type>pom</type>
+      <scope>import</scope>
+    </dependency>
+  </dependencies>
+</dependencyManagement>
+
+<dependencies>
+  <!-- Declare recipe modules without a version - the BOM manages them -->
+  <dependency>
+    <groupId>org.openrewrite</groupId>
+    <artifactId>rewrite-java</artifactId>
+  </dependency>
+  <dependency>
+    <groupId>org.openrewrite.recipe</groupId>
+    <artifactId>rewrite-static-analysis</artifactId>
+  </dependency>
+  <dependency>
+    <groupId>io.moderne.recipe</groupId>
+    <artifactId>rewrite-spring</artifactId>
+  </dependency>
+</dependencies>
+```
+
+</TabItem>
+</Tabs>
+
+Check the [latest versions of every OpenRewrite module](../../lists/latest-versions-of-every-openrewrite-module.md) for the current `moderne-recipe-bom` version.
+
+### Why the BOM versions matter
+
+The versions the BOM manages are the versions Moderne tests together. They are also the versions that are loaded together when your recipe is deployed to the marketplace, and when your recipes are run directly. Building against the same set means what you tested locally is what runs at scale.
+
+If your recipe library only depends on open source OpenRewrite modules, import `rewrite-recipe-bom` instead. See [setting up your recipe development environment](./recipe-development-environment.md) for a fuller starter build configuration.
+
+:::info
+`moderne-recipe-bom` and the Moderne recipe modules it manages are distributed through the Code Genome Project, which requires authentication. See [configuring the Code Genome Project repository](../../lists/latest-versions-of-every-openrewrite-module.md#configure-the-code-genome-project-repository) for the repository and credential setup.
+:::
+
+## How recipe modules are isolated in the marketplace
+
+The recipe marketplace does not resolve every installed recipe module against one shared set of dependency versions. Each recipe artifact is loaded together with the dependencies it was published with, isolated from the other artifacts in the marketplace.
+
+This isolation is what allows recipe modules to coexist even when they depend on different versions of other recipe modules. Moderne releases most recipe modules on a biweekly cadence, but not every module follows it. The Quarkus recipe modules, for example, release independently and are often behind the current biweekly release, so they may still be built against an older version of a shared module. Isolation means they run against the version they were built for, while the modules from the current release run against theirs.
+
+For your own recipe library, the practical consequence is that you do not need to match your dependency versions to whatever else happens to be deployed in your marketplace. Your recipes run against the versions you published them with, in both the CLI and the Platform.
+
+## How the recipe builder resolves recipes
+
+The exception to this isolation is the [recipe builder](../../../moderne-platform/how-to-guides/new-recipe-builder.md).
+
+Declarative YAML recipes reference the recipes they include by name, not by artifact version. When you compose a new recipe in the recipe builder, or customize an existing one, the result is a YAML recipe, and the recipes it references are resolved against the versions currently deployed in your marketplace.
+
+That means a customized recipe can pick up different – newer or older – versions of recipe modules than the ones the original recipe was compiled against.
+
+:::warning
+A recipe customized in the recipe builder is not pinned to the versions of the recipe it was derived from. Re-test customized recipes after you update the recipe modules in your marketplace, since the sub-recipes they resolve to can change.
+:::
+
+## Keeping your marketplace up to date
+
+Because the recipe builder resolves against what is deployed, it is worth knowing how deployed versions change:
+
+* **Moderne CLI**: `mod config recipes upgrade` re-resolves `LATEST` for each installed artifact and reinstalls it. See [curating the recipe marketplace](../../../moderne-cli/how-to-guides/curate-recipe-marketplace.md) for how to control which recipes your developers see and which versions they get.
+* **Moderne Platform**: an administrator re-deploys the recipe artifact, as described in [importing external recipes](../../../../administrator-documentation/moderne-platform/how-to-guides/importing-external-recipes.md). Deploying with a version of `LATEST` re-resolves to the newest published version.
+
+## Next steps
+
+* [Setting up your recipe development environment](./recipe-development-environment.md): the full build configuration for a new recipe library.
+* [Writing and installing recipes](../../../moderne-platform/how-to-guides/writing-and-installing-recipes.md): publishing your recipe library and deploying it to the Moderne Platform.
+* [Using multiple versions of a library in a project](../advanced-authoring/multiple-versions.md): depending on several versions of the same library within one recipe library.

--- a/docs/user-documentation/recipes/authoring-recipes/set-up/recipe-module-versions.md
+++ b/docs/user-documentation/recipes/authoring-recipes/set-up/recipe-module-versions.md
@@ -107,8 +107,8 @@ A recipe customized in the recipe builder is not pinned to the versions of the r
 
 Because the recipe builder resolves against what is deployed, it is worth knowing how deployed versions change:
 
-* **Moderne CLI**: `mod config recipes upgrade` re-resolves `LATEST` for each installed artifact and reinstalls it. See [curating the recipe marketplace](../../../moderne-cli/how-to-guides/curate-recipe-marketplace.md) for how to control which recipes your developers see and which versions they get.
-* **Moderne Platform**: an administrator re-deploys the recipe artifact, as described in [importing external recipes](../../../../administrator-documentation/moderne-platform/how-to-guides/importing-external-recipes.md). Deploying with a version of `LATEST` re-resolves to the newest published version.
+* **Moderne CLI**: `mod config recipes upgrade` re-resolves either `LATEST` or `RELEASE` for each installed artifact and reinstalls it. See [curating the recipe marketplace](../../../moderne-cli/how-to-guides/curate-recipe-marketplace.md) for how to control which recipes your developers see and which versions they get.
+* **Moderne Platform**: an administrator re-deploys the recipe artifact, as described in [importing external recipes](../../../../administrator-documentation/moderne-platform/how-to-guides/importing-external-recipes.md). Deploying with a version of `RELEASE` re-resolves to the newest stable release, while `LATEST` re-resolves to the newest available build, including snapshots.
 
 ## Next steps
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -736,6 +736,7 @@ const recipes = {
           items: [
             'user-documentation/recipes/authoring-recipes/set-up/recipe-development-environment',
             'user-documentation/recipes/authoring-recipes/set-up/javascript-recipe-development-environment',
+            'user-documentation/recipes/authoring-recipes/set-up/recipe-module-versions',
           ],
         },
         {


### PR DESCRIPTION
Users regularly ask how the recipe marketplace in the CLI and Platform relates to the recipe module dependencies in their own recipe library, so this adds a new page under **Recipe development → Set up your environment** covering it.

The page explains how to align your recipe library with `moderne-recipe-bom` (which imports `rewrite-recipe-bom`, so one import covers both the OSS and proprietary modules), how the marketplace loads each recipe artifact with the dependencies it was published with — letting modules on different release cadences like Quarkus coexist — and why the recipe builder is the exception, since declarative YAML recipes reference sub-recipes by name and resolve against whatever versions are deployed.

It is cross-linked from the Platform writing-and-installing-recipes and recipe builder guides, the CLI curate-recipe-marketplace guide, and the recipe development environment setup page.

One thing worth a reviewer's eye: the Maven snippet hardcodes `moderne-recipe-bom` version `0.41.0`, because `src/plugins/latest-versions.js` is regenerated wholesale by `rewrite-recipe-markdown-generator` and has no `moderne-recipe-bom` key to use as a `{{VERSION_*}}` placeholder.

`yarn build` passes with no broken links. The build does emit pre-existing SSG warnings from `<figure>` markup on 211 unrelated pages; these are unchanged by this PR.
