### PR TITLE
Speed up the sharded docs build with shared caches and an even shard split

### DIFF
--- a/.github/workflows/pages-sharded.yml
+++ b/.github/workflows/pages-sharded.yml
@@ -30,8 +30,21 @@ jobs:
         with:
           node-version: 24
           cache: yarn
+
+      # This job gates every other one, so it populates the cache they restore.
+      - name: Cache node_modules
+        id: node-modules
+        uses: actions/cache@v6
+        with:
+          path: |
+            node_modules
+            !node_modules/.cache
+          key: node-modules-${{ runner.os }}-${{ runner.arch }}-node24-${{ hashFiles('yarn.lock') }}
+
       - name: Install dependencies
+        if: steps.node-modules.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
+
       - name: Lint markdown
         run: yarn lint:markdown
 
@@ -45,25 +58,39 @@ jobs:
       matrix:
         shard: [0, 1, 2, 3]
     steps:
+      # fetch-depth: 0 is required by showLastUpdateTime, whose `git log` reads
+      # only commits and trees — hence blob:none.
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          filter: blob:none
+
       - uses: actions/setup-node@v6
         with:
           node-version: 24
-          cache: yarn
+
+      - name: Restore node_modules
+        id: node-modules
+        uses: actions/cache/restore@v6
+        with:
+          path: |
+            node_modules
+            !node_modules/.cache
+          key: node-modules-${{ runner.os }}-${{ runner.arch }}-node24-${{ hashFiles('yarn.lock') }}
 
       - name: Install dependencies
+        if: steps.node-modules.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
 
-      - name: Cache bundler artifacts (per shard)
-        uses: actions/cache@v6
+      # Shards diverge only at SSG time, so they compile identical bundles.
+      - name: Restore bundler artifacts
+        id: bundler-cache
+        uses: actions/cache/restore@v6
         with:
           path: node_modules/.cache
-          key: docusaurus-shard-${{ matrix.shard }}-${{ runner.os }}-${{ hashFiles('yarn.lock', 'docusaurus.config.ts', 'src/theme/**') }}
+          key: docusaurus-ssg-${{ runner.os }}-${{ hashFiles('yarn.lock', 'docusaurus.config.ts', 'src/theme/**') }}
           restore-keys: |
-            docusaurus-shard-${{ matrix.shard }}-${{ runner.os }}-
-            docusaurus-${{ runner.os }}-
+            docusaurus-ssg-${{ runner.os }}-
 
       - name: Debug — disk and memory before build
         run: |
@@ -92,6 +119,13 @@ jobs:
           echo "=== free -h ==="
           free -h
 
+      - name: Save bundler artifacts
+        if: matrix.shard == 0 && steps.bundler-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: node_modules/.cache
+          key: docusaurus-ssg-${{ runner.os }}-${{ hashFiles('yarn.lock', 'docusaurus.config.ts', 'src/theme/**') }}
+
       - name: Upload shard artifact
         uses: actions/upload-artifact@v7
         with:
@@ -110,7 +144,15 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 24
-          cache: yarn
+
+      - name: Restore node_modules
+        id: node-modules
+        uses: actions/cache/restore@v6
+        with:
+          path: |
+            node_modules
+            !node_modules/.cache
+          key: node-modules-${{ runner.os }}-${{ runner.arch }}-node24-${{ hashFiles('yarn.lock') }}
 
       - name: Download all shard artifacts
         uses: actions/download-artifact@v8
@@ -130,6 +172,7 @@ jobs:
           ls -la
 
       - name: Install dependencies (for broken-links aggregator)
+        if: steps.node-modules.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
 
       - name: Merge shards

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          filter: blob:none
       - uses: actions/setup-node@v6
         with:
           node-version: 24
@@ -32,9 +33,9 @@ jobs:
         uses: actions/cache@v6
         with:
           path: node_modules/.cache
-          key: docusaurus-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          key: docusaurus-ssg-${{ runner.os }}-${{ hashFiles('yarn.lock', 'docusaurus.config.ts', 'src/theme/**') }}
           restore-keys: |
-            docusaurus-${{ runner.os }}-
+            docusaurus-ssg-${{ runner.os }}-
 
       - name: Build website
         run: |

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -53,13 +53,14 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
+      # Separate namespace: this build sets SKIP_RECIPE_CATALOG.
       - name: Cache build compilation artifacts
         uses: actions/cache@v6
         with:
           path: node_modules/.cache
-          key: docusaurus-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          key: docusaurus-pr-${{ runner.os }}-${{ hashFiles('yarn.lock', 'docusaurus.config.ts', 'src/theme/**') }}
           restore-keys: |
-            docusaurus-${{ runner.os }}-
+            docusaurus-pr-${{ runner.os }}-
 
       - name: Build site
         run: |

--- a/scripts/build-shard-patch.js
+++ b/scripts/build-shard-patch.js
@@ -25,9 +25,9 @@ const { flattenRoutes } = require('@docusaurus/utils');
 
 const originalExecuteSSG = ssgExecutor.executeSSG;
 
-// Routes matched here are pulled out of the normal modulo pool and rendered
-// exclusively by the last shard, giving them an isolated memory budget.
-// All auto-generated lists/ pages are large and prone to OOM in normal shards.
+// Routes matched here are pulled out of the normal modulo pool and pinned to
+// the last shard, so no more than one shard ever holds a memory spike from
+// them. All auto-generated lists/ pages are large and prone to OOM.
 const HEAVY_ROUTE_PATTERNS = [
   '/user-documentation/recipes/lists',
 ];
@@ -42,18 +42,17 @@ ssgExecutor.executeSSG = async function shardedExecuteSSG(opts) {
   const heavyPaths = allPaths.filter(isHeavy);
   const normalPaths = allPaths.filter((p) => !isHeavy(p));
 
-  let mine;
+  // Every shard takes an equal slice of the normal pool; the dedicated shard
+  // additionally renders the heavy routes, which cost seconds rather than
+  // minutes and so barely affect its share.
+  const mine = normalPaths.filter((_, i) => i % SHARD_TOTAL === SHARD_INDEX);
   if (SHARD_INDEX === DEDICATED_SHARD) {
-    // Last shard: only the heavy routes
-    mine = heavyPaths;
-  } else {
-    // All other shards: split normal routes across SHARD_TOTAL - 1 buckets
-    mine = normalPaths.filter((_, i) => i % (SHARD_TOTAL - 1) === SHARD_INDEX);
+    mine.push(...heavyPaths);
   }
 
   console.log(
     `[shard ${SHARD_INDEX}/${SHARD_TOTAL}] rendering ${mine.length} of ${allPaths.length} routes` +
-    (SHARD_INDEX === DEDICATED_SHARD ? ' (dedicated heavy shard)' : ''),
+    (SHARD_INDEX === DEDICATED_SHARD ? ` (incl. ${heavyPaths.length} heavy)` : ''),
   );
   opts.props.routesPaths = mine;
 


### PR DESCRIPTION
Every deploy ran four build shards that each fetched the full repository with all
history and blobs, downloaded a 1.6&nbsp;GB yarn cache, ran the same `yarn install`,
compiled an identical webpack bundle, and restored its own private copy of a
bundler cache holding the same contents as the other three. One of the four then
rendered 11 of 8550 routes and sat idle.

Four changes, each measured before and after.

## 1. Checkout skips historical blobs

`fetch-depth: 0` is load-bearing — `showLastUpdateTime` (`docusaurus.config.ts:114`)
resolves every page's date with `git log`, so shallow history would silently
produce wrong dates. But that command is pathspec-limited and reads only commit
and tree objects, never historical file contents, so `filter: blob:none` is safe:

| | fetch | checkout | total | `.git` |
|---|---|---|---|---|
| before | 42.1s | 1.8s | **43.9s** | 566 MB |
| after | 1.4s | 16.6s | **18.0s** | 204 MB |

Verified rather than assumed: running Docusaurus's exact `git log` invocation over
all 8,496 `.md`/`.mdx` files in both a full and a filtered clone produced
byte-identical timestamps, and `.git` did not grow, so nothing lazily re-fetched.

Limiting the fetch to a single branch, which is what the 46-branch listing in the
log suggests, saves nothing at all — measured 564 MB and 42.1s either way, since
the topic branches share `main`'s objects.

## 2. `node_modules` is cached instead of the yarn cache

The yarn cache is raw material: shards downloaded 1621 MB of package tarballs so
each could spend 17s rebuilding the same tree. The tree itself is 828 MB raw,
**155 MB** compressed. The `lint` job already gates every other job, so it
populates the cache and the rest restore it.

An exact hit skips the install entirely rather than leaving it as a no-op safety
net. With `node_modules` restored, `yarn install --frozen-lockfile` is a 0.19s
"Already up-to-date" — but only while the yarn cache folder is untouched;
pointing it elsewhere triggered a full 78s reinstall. Skipping on an exact key
match does not depend on that heuristic.

## 3. One shared bundler cache instead of four private ones

`scripts/build-shard-patch.js` hooks `executeSSG`, which runs *after* compilation,
so every shard compiles a byte-identical bundle and only the render step differs.
Confirmed empirically that one cache therefore serves all shards — a cache written
under `--out-dir shard-0` gave `--out-dir shard-1` the same speedup as reusing its
own:

| run | cache state | `--out-dir` | compile |
|---|---|---|---|
| 1 | cold | `shard-0` | **75s** |
| 2 | warm, written by shard-0 | `shard-1` | **15s** |
| 3 | warm | `shard-1` (repeat) | 12s |
| 4 | warm | `shard-0` | 13s |

The cache directory also stayed at 2.7 GB across all four runs, so shards add no
per-shard entries to it.

This fixes a live problem. Active cache usage was **10,956,166,924 bytes, over the
10 GB per-repo limit**, with four ~1.1 GB shard entries per generation. Entries
were already being evicted: the previous generation retained shards 0, 2 and 3,
but shard 1 was gone — so the caches were partly thrashing rather than helping.
Expected usage after this change is ~3.4 GB.

## 4. The dedicated heavy shard takes a normal share

The last shard rendered only the 11 heavy `lists/` routes: two seconds of work
after paying the same ~3.5 minutes of fixed cost as every other shard. The normal
pool was meanwhile divided across `SHARD_TOTAL - 1` shards instead of all of them.
This is consistent, not a one-off:

| run | shard 0 | shard 1 | shard 2 | shard 3 |
|---|---|---|---|---|
| 31481854425 | 5m08 | 4m54 | 5m08 | **1m40** |
| 31476971737 | 5m07 | 4m56 | 4m23 | **1m50** |
| 31476444428 | 7m12 | 7m20 | 6m04 | **4m03** |

Shards 0–2 track each other within ~15%, so the count-based split is sound and the
last shard is simply idle capacity. Route counts go from 2847/2846/2846/11 to
**2135/2135/2135/2146**.

Heavy routes stay pinned to one shard, so the memory spike that #724 and #726
isolated is still confined to a single job — that job just is not idle anymore:

| | routes | SSG | peak RSS |
|---|---|---|---|
| new shard 3, incl. 11 heavy | 2146 | 13s | **13.5 GB** |
| shard 0 today, runs safely in CI | 2847 | 38s | **13.7 GB** |
| shard 3 today | 11 | 2s | 12.5 GB |

The mixed shard peaks *below* the normal shard already running in CI. The telling
row is the third: today's shard 3 peaks at 12.5 GB to render 11 routes, so peak
memory is dominated by the webpack compile every shard performs regardless, and
SSG's marginal contribution is small with the 512 MB worker recycler in place.

## Expected effect

Per shard, prep drops from ~75s to ~15s and the SSG phase loses about a quarter of
its routes. The larger win is that the bundler cache should now survive between
runs instead of evicting itself.

## Validation

* Route partition checked at `SHARD_TOTAL` of 1, 2, 3, 4, 5 and 8: every route
  assigned exactly once, no gaps, no duplicates.
* All four shards built locally and merged: **8587 unique HTML files**, against the
  8586 CI produces today, with the aggregated broken-links report covering 8551
  routes and reporting zero broken paths or anchors.

Two things that look like problems but are not, both checked against CI logs and
`main`:

* `merge-shards.js` logs **108 `rendered by both` warnings**. CI logs exactly the
  same 108 files today. They are client-redirect stubs, emitted byte-identically by
  every shard because the patch deliberately restores the full route list for
  postBuild plugins. Not addressed here.
* `src/theme/DocSidebarItems/filterUtils.test.ts` fails with and without these
  changes.

**PR CI does not exercise the main path.** `pages-sharded.yml` only triggers on
push to `main` and via `workflow_dispatch`, so the green checks here come from
`pr-validation.yml`. A `workflow_dispatch` run on this branch would exercise the
real thing but also deploys to production Pages, so none was triggered. The first
run after merge will be cold on both new cache keys and no faster than today; the
second should show the difference.

## Deliberately not changed

`pr-validation.yml` keeps a full-blob checkout. Its `check-file-types.js` runs
`git diff --diff-filter=ACMR`, and rename detection needs blob content. Its bundler
cache also moves to its own namespace rather than being shared, because it builds
with `SKIP_RECIPE_CATALOG` and so is not interchangeable with the production one.

The same rename-detection constraint rules out `DOCUSAURUS_VCS=git-eager`, which
would otherwise replace 8,496 per-file `git log` calls with a single 1.9s pass: its
`git log --name-status` died with `fatal: could not fetch ... from promisor remote`
under `blob:none`.

The remaining prize is the ~8m21s of runner time spent compiling the same bundle
four times. Splitting compile from render would need Docusaurus to expose those as
separate phases, which it currently does not.
