### PR TITLE
Revert the blob:none checkout filter, which broke the deploy

### DIFF
--- a/.github/workflows/pages-sharded.yml
+++ b/.github/workflows/pages-sharded.yml
@@ -58,12 +58,13 @@ jobs:
       matrix:
         shard: [0, 1, 2, 3]
     steps:
-      # fetch-depth: 0 is required by showLastUpdateTime, whose `git log` reads
-      # only commits and trees — hence blob:none.
+      # fetch-depth: 0 is required by showLastUpdateTime. Do not add
+      # filter: blob:none — future.v4 makes Docusaurus read dates with
+      # `git log --name-status`, whose rename detection needs historical blobs,
+      # so the build lazily refetches them from the promisor remote mid-build.
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          filter: blob:none
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,7 +20,6 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          filter: blob:none
       - uses: actions/setup-node@v6
         with:
           node-version: 24


### PR DESCRIPTION
- The production deploy on main is failing. `filter: blob:none`, added in #946,
- is the cause and this removes it. Everything else from #946 — the node_modules
cache, the shared bundler cache and the even shard split — is unaffected and
stays.

## What happened

`docusaurus.config.ts:244` sets `future.v4`, which switches the last-update
lookup from the per-file `git log -- <basename>` of the `default-v1` preset to
the eager `git log --format=t:%ct,a:%an --name-status` pass. Rename detection in
that command needs historical file contents, so under a partial clone the build
lazily refetches blobs from the promisor remote while loading doc metadata:

```
Command failed with exit code 128: git --no-pager -c log.showSignature=false log --format=t:%ct,a:%an --name-status
fatal: unable to access 'https://github.com/moderneinc/moderne-docs/': server certificate verification failed
fatal: could not fetch 67507a9cfae674becdd4134acee8f4e49b498d66 from promisor remote
Error: Can't process doc metadata for doc at path docs/hands-on-learning.md
```

- The first deploy after #946 succeeded because those refetches went through — and
probably accounts for part of that run's slower compile. The second failed when
the runner could not verify GitHub's certificate, which only mattered because
the filter made the build depend on network access mid-build at all.

## Why the verification missed it

- #946 checked the per-file `git log -- <basename>` command over all 8,496
markdown files and found byte-identical timestamps under a filtered clone. That
conclusion was correct for the command tested and irrelevant, because this site
does not run that command. The `--name-status` incompatibility was even measured
- while writing #946 and written up as a reason not to enable
`DOCUSAURUS_VCS=git-eager` — without checking whether `future.v4` had already
enabled the equivalent path.

A comment now records why the filter must not be reintroduced.