### PR TITLE
Drop the yarn cache, which the node_modules cache already supersedes

### DIFF
--- a/.github/workflows/pages-sharded.yml
+++ b/.github/workflows/pages-sharded.yml
@@ -29,7 +29,6 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 24
-          cache: yarn
 
       # This job gates every other one, so it populates the cache they restore.
       - name: Cache node_modules

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,9 +23,18 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 24
-          cache: yarn
+
+      - name: Restore node_modules
+        id: node-modules
+        uses: actions/cache/restore@v6
+        with:
+          path: |
+            node_modules
+            !node_modules/.cache
+          key: node-modules-${{ runner.os }}-${{ runner.arch }}-node24-${{ hashFiles('yarn.lock') }}
 
       - name: Install dependencies
+        if: steps.node-modules.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
 
       - name: Cache build compilation artifacts

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -20,9 +20,21 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 24
-          cache: yarn
+
+      # Restore only: a cache saved on a pull request ref cannot be read by any
+      # other pull request, so writing here would just fill the quota. The entry
+      # this restores is published by the lint job of pages-sharded.yml on main.
+      - name: Restore node_modules
+        id: node-modules
+        uses: actions/cache/restore@v6
+        with:
+          path: |
+            node_modules
+            !node_modules/.cache
+          key: node-modules-${{ runner.os }}-${{ runner.arch }}-node24-${{ hashFiles('yarn.lock') }}
 
       - name: Install dependencies
+        if: steps.node-modules.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
 
       - name: Check file types
@@ -48,9 +60,18 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 24
-          cache: yarn
+
+      - name: Restore node_modules
+        id: node-modules
+        uses: actions/cache/restore@v6
+        with:
+          path: |
+            node_modules
+            !node_modules/.cache
+          key: node-modules-${{ runner.os }}-${{ runner.arch }}-node24-${{ hashFiles('yarn.lock') }}
 
       - name: Install dependencies
+        if: steps.node-modules.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
 
       # Separate namespace: this build sets SKIP_RECIPE_CATALOG.

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -116,9 +116,21 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 24
-          cache: yarn
-          cache-dependency-path: moderne-docs/yarn.lock
+
+      # Own key: this job checks the repository out under moderne-docs/, and a
+      # cache restores to the path it was saved from, so it cannot share the
+      # root-layout entry the other workflows use.
+      - name: Cache node_modules
+        id: node-modules
+        uses: actions/cache@v6
+        with:
+          path: |
+            moderne-docs/node_modules
+            !moderne-docs/node_modules/.cache
+          key: node-modules-updatedocs-${{ runner.os }}-${{ runner.arch }}-node24-${{ hashFiles('moderne-docs/yarn.lock') }}
+
       - name: Install dependencies
+        if: steps.node-modules.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
         working-directory: moderne-docs
       - name: Lint generated markdown

--- a/.github/workflows/update-graphql-docs.yml
+++ b/.github/workflows/update-graphql-docs.yml
@@ -20,9 +20,18 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 24
-          cache: yarn
 
-      - run: yarn install --frozen-lockfile
+      - name: Restore node_modules
+        id: node-modules
+        uses: actions/cache/restore@v6
+        with:
+          path: |
+            node_modules
+            !node_modules/.cache
+          key: node-modules-${{ runner.os }}-${{ runner.arch }}-node24-${{ hashFiles('yarn.lock') }}
+
+      - if: steps.node-modules.outputs.cache-hit != 'true'
+        run: yarn install --frozen-lockfile
 
       - name: Install Rover
         run: |


### PR DESCRIPTION
The 1621 MB yarn cache is the largest entry in the repository's cache budget and
cannot help in any case where the `node_modules` cache does not already help
more. This removes it.

## Why it is dead weight

`actions/setup-node` only passes a `[keyPrefix]` restore-key when
`isManagedByYarnBerry`. This repository is on Yarn 1.22.22, so it takes the
`else` branch — `restoreCache(cachePaths, primaryKey)`, an exact match on
`node-cache-<os>-<arch>-yarn-<hash(yarn.lock)>` with no fallback. So:

* **yarn.lock changed** — the key misses and yarn installs from the registry
  regardless. The 1.6 GB buys nothing in precisely the case it was kept for.
* **yarn.lock unchanged** — the key hits, but so does `node-modules-…-<same
  hash>`, so the install is skipped and the yarn cache is never read.

Both caches are keyed on the same hash and written on the same run, so there is
no third case.

Measured in the lint job of the last deploy:

```
21:47:58  setup-node starts
21:48:24  yarn cache restored — 1622 MB, 26.3s
21:48:31  node_modules restored — 222 MB, 7.4s
21:48:31  yarn lint:markdown        <- install skipped; the 1.6 GB was never touched
```

That 26.3s is on the critical path of every deploy, since `build-shard` has
`needs: lint`.

## What changed

Every job that installed unconditionally now restores `node_modules` and installs
only on a miss, and no workflow sets `cache: yarn` any more — one remaining usage
anywhere would republish the 1.6 GB entry on its next miss.

Two jobs needed care:

* **pr-validation restores without writing.** A cache saved on a `refs/pull/N/merge`
  ref cannot be read by any other pull request, so writing there would only fill
  the quota with entries nothing can use. It restores the entry published by
  `pages-sharded.yml`'s lint job on `main`, which every pull request can read.
* **update-docs keeps its own key.** It checks the repository out under
  `moderne-docs/`, and a cache restores to the path it was saved from, so sharing
  the root-layout key would extract to the wrong directory.

## Tradeoff

When `yarn.lock` changes the install runs cold from the registry — 78s measured
locally against 17s warm. That was 32 commits in the last 90 days, against 507
total, so roughly 6% of runs.

This is neutral rather than a regression: on those same runs the yarn cache
misses today too, for the same exact-match reason. The residual risk is
`node_modules` being evicted while the yarn cache survives, which is far less
likely now that usage sits at 3.25 GiB with headroom rather than over the 10 GB
limit, and degrades to a slower install rather than a failure.

## Expected effect

| | now | after |
|---|---|---|
| cache usage | 3.25 GiB | ~1.7 GiB |
| deploy critical path | — | −26s |
| pr-validation, per job | 26s restore + 17s install | ~7s restore |

- Unlike #946, the pull-request half of this change **is** exercised by this pull
request's own CI: both `pr-validation` jobs are modified, so their cache
restore and skipped install are visible in the checks below.