### PR TITLE
Strip the [bot] suffix when removing release note author mentions

### DIFF
--- a/.github/scripts/fetch-proprietary-release-notes.js
+++ b/.github/scripts/fetch-proprietary-release-notes.js
@@ -148,8 +148,8 @@ This changelog is automatically generated from GitHub releases and only contains
       escapedBody = escapedBody.replace(/^###? (.+)$/gm, '**$1**');
 
       // Remove references to private GitHub content:
-      // 1. Remove "by @username" mentions
-      escapedBody = escapedBody.replace(/\s+by @[\w-]+/g, '');
+      // 1. Remove "by @username" mentions, including the [bot] suffix on app accounts
+      escapedBody = escapedBody.replace(/\s+by @[\w-]+(?:\[bot\])?/g, '');
 
       // 2. Remove "in https://github.com/.../pull/..." references
       escapedBody = escapedBody.replace(/\s+in https:\/\/github\.com\/[^\s]+/g, '');


### PR DESCRIPTION
The `by @username` cleanup in `fetch-proprietary-release-notes.js` used `/\s+by @[\w-]+/`, which does not match the trailing `[bot]` on GitHub App accounts, leaving artifacts like `Bump jest from 30.3.0 to 30.4.2 in /recipes-angular[bot]` in the proprietary recipe changelog (30 occurrences today).

Making the `[bot]` suffix part of the match fixes it. The changelog itself is regenerated in full on every run, so the existing artifacts disappear the next time the scheduled workflow runs after this merges.