### PR TITLE
Install the jars C# recipes delegate into

### DIFF
--- a/src/components/RunRecipe/RunRecipe.test.tsx
+++ b/src/components/RunRecipe/RunRecipe.test.tsx
@@ -137,6 +137,67 @@ describe('RunRecipe', () => {
     expect(tabText('LATEST').match(/:LATEST/g)).toHaveLength(2);
   });
 
+  it('installs only the NuGet package when a C# recipe has no companion jar', () => {
+    renderRecipe({
+      recipeName: 'OpenRewrite.Recipes.CSharp.Migration.Dotnet.FindCsprojMarker',
+      displayName: 'Find csproj marker',
+      nugetPackage: 'OpenRewrite.Recipes.CSharp.Migration.Dotnet',
+    });
+
+    expect(text()).toContain('mod config recipes nuget install OpenRewrite.Recipes.CSharp.Migration.Dotnet');
+    expect(text()).not.toContain('jar install');
+    // Nothing here has a version, so there is no second tab to choose between.
+    expect(tabText('Pinned version')).toEqual('');
+  });
+
+  it('installs the jar a C# recipe delegates into alongside its NuGet package', () => {
+    renderRecipe({
+      recipeName: 'OpenRewrite.Recipes.CSharp.Migration.Dotnet.ChangeType',
+      displayName: 'Change type',
+      nugetPackage: 'OpenRewrite.Recipes.CSharp.Migration.Dotnet',
+      companionJars: [
+        { groupId: 'org.openrewrite', artifactId: 'rewrite-java', versionKey: 'VERSION_ORG_OPENREWRITE_REWRITE_JAVA' },
+      ],
+    });
+
+    // The wrapper delegates to org.openrewrite.java.ChangeType, and NuGet cannot pull a Maven artifact,
+    // so the CLI has nothing to resolve the delegate against unless the reader installs the jar too.
+    expect(text()).toContain('mod config recipes nuget install OpenRewrite.Recipes.CSharp.Migration.Dotnet');
+    expect(tabText('RELEASE')).toContain('mod config recipes jar install org.openrewrite:rewrite-java:RELEASE');
+    expect(tabText('LATEST')).toContain('mod config recipes jar install org.openrewrite:rewrite-java:LATEST');
+    expect(text()).toContain('mod run . --recipe OpenRewrite.Recipes.CSharp.Migration.Dotnet.ChangeType');
+  });
+
+  it('leaves the NuGet package unpinned in the pinned tab of a C# recipe', () => {
+    renderRecipe({
+      recipeName: 'OpenRewrite.Recipes.CSharp.Migration.Dotnet.ChangeType',
+      displayName: 'Change type',
+      nugetPackage: 'OpenRewrite.Recipes.CSharp.Migration.Dotnet',
+      companionJars: [
+        { groupId: 'org.openrewrite', artifactId: 'rewrite-java', versionKey: 'VERSION_ORG_OPENREWRITE_REWRITE_JAVA' },
+      ],
+    });
+
+    // C# usage props carry no version for the NuGet package itself, so only the jar can be pinned.
+    const pinned = tabText('Pinned version');
+    expect(pinned).toContain('mod config recipes nuget install OpenRewrite.Recipes.CSharp.Migration.Dotnet\n');
+    expect(pinned).toMatch(/jar install org\.openrewrite:rewrite-java:[\d.]+/);
+  });
+
+  it('drops an unresolvable companion jar from a C# recipe rather than pasting a placeholder', () => {
+    renderRecipe({
+      recipeName: 'OpenRewrite.Recipes.CSharp.Migration.Dotnet.ChangeType',
+      displayName: 'Change type',
+      nugetPackage: 'OpenRewrite.Recipes.CSharp.Migration.Dotnet',
+      companionJars: [
+        { groupId: 'org.openrewrite', artifactId: 'rewrite-nonexistent', versionKey: 'VERSION_NOT_A_REAL_KEY' },
+      ],
+    });
+
+    expect(text()).not.toContain('{{VERSION_');
+    expect(text()).not.toContain('rewrite-nonexistent');
+  });
+
   it('drops the pinned tab when a Go module has no resolvable version', () => {
     renderRecipe({
       recipeName: 'org.openrewrite.go.search.FindTypes',

--- a/src/components/RunRecipe/index.tsx
+++ b/src/components/RunRecipe/index.tsx
@@ -200,18 +200,36 @@ export default function RunRecipe({
     );
   }
 
-  // C# recipes
+  // C# recipes. A NuGet recipe package can delegate into a jar recipe, and NuGet has no way to express a
+  // Maven dependency, so — as with Python — every package the recipe reaches is listed. The NuGet install
+  // itself is never pinned: only the jars carry a version here, so the pinned tab pins those alone.
   if (nugetPackage) {
+    const resolvedCompanionJars = (companionJars ?? [])
+      .map((jar) => ({ ...jar, version: resolveVersion(jar.versionKey) }))
+      .filter((jar) => jar.version);
+    const installCommandsFor = (mode: VersionMode): string[] => [
+      `mod config recipes nuget install ${nugetPackage}`,
+      ...resolvedCompanionJars.map(
+        (jar) => `mod config recipes jar install ${jarSpec(jar.groupId, jar.artifactId, jar.version, mode)}`
+      ),
+    ];
+    const multiplePackages = resolvedCompanionJars.length > 0;
     return (
       <>
         <p>
           In order to run C# recipes, you will need to use the{' '}
           <a href="https://docs.moderne.io/user-documentation/moderne-cli/getting-started/cli-intro">Moderne CLI</a>.
         </p>
-        <p>Once the CLI is installed, you can install this C# recipe package by running the following command:</p>
-        <CodeBlock language="shell" title="Install the recipe package">
-          {`mod config recipes nuget install ${nugetPackage}`}
-        </CodeBlock>
+        <p>
+          {multiplePackages
+            ? 'This recipe calls into other OpenRewrite packages as it runs, and the CLI needs every one of them in its marketplace. Once the CLI is installed, install all of the following:'
+            : 'Once the CLI is installed, you can install this C# recipe package by running the following command:'}
+        </p>
+        <InstallCommands
+          title={multiplePackages ? 'Install the recipe packages' : 'Install the recipe package'}
+          commandsFor={installCommandsFor}
+          hasPinnedVersion={multiplePackages}
+        />
         <p>Then, you can run the recipe via:</p>
         <CodeBlock language="shell" title="Run the recipe">
           {`mod run . --recipe ${recipeName}`}


### PR DESCRIPTION
- Four recipes in `OpenRewrite.Recipes.CSharp.Migration.Dotnet` delegate into `org.openrewrite:rewrite-java`, but their catalog pages advertise only the NuGet install — NuGet cannot express a Maven dependency, and the CLI resolves delegates eagerly, so a marketplace without that jar fails the whole run rather than skipping the delegated step. The `companionJars` prop added for Python in #906 was already general and only the pip branch read it, so this gives `RunRecipe`'s nuget branch the same rendering, plus four tests covering the delegating and non-delegating cases. The NuGet install stays unpinned in every tab because C# usage props carry no version for the package itself, which leaves the jars as the only thing there is to pin.

This is inert until openrewrite/rewrite-recipe-markdown-generator emits `companionJars` for C# recipes (branch `tim/csharp-delegate-companion-jars`, PR pending), so it should land second. Verified against that branch's real generator output: the rendered page offers RELEASE / LATEST / 8.89.0 tabs, each installing both packages.

- Fixes #909