### PR TITLE
Remove references to the removed Maven recipe CSV goal

### DIFF
--- a/docs/administrator-documentation/moderne-platform/how-to-guides/categorize-recipes.md
+++ b/docs/administrator-documentation/moderne-platform/how-to-guides/categorize-recipes.md
@@ -3,9 +3,6 @@ sidebar_label: Managing recipe categories
 description: How to create your own recipe categories in the Moderne Platform.
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 # How to manage recipe categories
 
 When you publish recipes to the Moderne Platform, organizing them into meaningful categories helps users in your organization discover and run them. By default, recipes are categorized based on their package structure, but you can define a custom category hierarchy that better fits your organization's needs.
@@ -48,24 +45,11 @@ For a real-world example, see the [category.yml from rewrite-spring](https://git
 
 ### Generating and validating the `recipes.csv` file
 
-Once the `category.yml` file is ready, you will need to generate the CSV file using the build plugin for your build tool:
-
-<Tabs groupId="build-tool">
-<TabItem value="gradle" label="Gradle">
+Once the `category.yml` file is ready, you will need to generate the CSV file using the [rewrite-build-gradle-plugin](https://github.com/openrewrite/rewrite-build-gradle-plugin):
 
 ```bash
 ./gradlew recipeCsvGenerate
 ```
-
-</TabItem>
-<TabItem value="maven" label="Maven">
-
-```bash
-./mvnw rewrite:recipeCsvGenerate
-```
-
-</TabItem>
-</Tabs>
 
 This will scan your compiled recipe classes and resources and generate a `recipes.csv` file with `category1`, `category2`, ... `categoryN` columns derived from your `category.yml` file. Any manual adjustments you've made to the CSV file beforehand will be retained.
 
@@ -73,12 +57,18 @@ This will scan your compiled recipe classes and resources and generate a `recipe
 CSV generation only scans your own project — recipes from dependencies are not included.
 :::
 
-For Gradle projects, validation will run automatically as part of `./gradlew check`. It will verify that the CSV file is synchronized with the JAR content and that formatting conventions are followed (e.g., display names should begin with a capital letter and descriptions should end with a period).
+:::note
+CSV generation is only available for Gradle projects. The [rewrite-maven-plugin](https://github.com/openrewrite/rewrite-maven-plugin) does not offer an equivalent goal.
+
+Maven recipe modules do not need an embedded `recipes.csv` file. When a JAR does not contain one, the categories from your `category.yml` file are picked up by scanning the classpath instead — this is slower to parse, but the resulting category hierarchy is the same.
+:::
+
+Validation will run automatically as part of `./gradlew check`. It will verify that the CSV file is synchronized with the JAR content and that formatting conventions are followed (e.g., display names should begin with a capital letter and descriptions should end with a period).
 
 If any recipes appear in the CSV file but do not exist in the JAR ("phantom recipes"), the build will fail.
 
 :::info
-For more details, see the [recipes.csv reference](../../../user-documentation/moderne-cli/references/recipes-csv.md), which covers both [CSV generation](../../../user-documentation/moderne-cli/references/recipes-csv.md#generating-the-csv) and [automatic validation](../../../user-documentation/moderne-cli/references/recipes-csv.md#automatic-validation-gradle-only).
+For more details, see the [recipes.csv reference](../../../user-documentation/moderne-cli/references/recipes-csv.md), which covers both [CSV generation](../../../user-documentation/moderne-cli/references/recipes-csv.md#generating-the-csv) and [automatic validation](../../../user-documentation/moderne-cli/references/recipes-csv.md#automatic-validation).
 :::
 
 Once validation passes, you can [publish and deploy the artifact to the Moderne Platform](#deploying-recipe-artifacts-to-the-moderne-platform).
@@ -121,7 +111,7 @@ dependencies {
 ### Creating the `recipes.csv` file manually
 
 :::warning
-You **cannot** use `./gradlew recipeCsvGenerate` or `./mvnw rewrite:recipeCsvGenerate` for the wrapper artifact. These only scan the project's own classes, and since your wrapper does not define any recipes of its own, they would generate an empty CSV file.
+You **cannot** use `./gradlew recipeCsvGenerate` for the wrapper artifact. It only scans the project's own classes, and since your wrapper does not define any recipes of its own, it would generate an empty CSV file.
 
 In addition, the Gradle build validation (`./gradlew check`) would reject any entry for a recipe from a dependency as a "phantom recipe".
 :::

--- a/docs/user-documentation/moderne-cli/references/recipes-csv.md
+++ b/docs/user-documentation/moderne-cli/references/recipes-csv.md
@@ -3,9 +3,6 @@ sidebar_label: CSV recipe marketplace
 description: Learn how the CLI CSV recipe marketplace works.
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 # Defining the recipe marketplace with a CSV file
 
 Starting with CLI version `3.55.0`, the recipe marketplace in the Moderne CLI is defined via a CSV file rather than a binary Lucene index. This provides several benefits:
@@ -113,32 +110,23 @@ When duplicating rows, the recipe metadata (`options`, `dataTables`, `displayNam
 
 ## For recipe authors
 
-If you maintain a recipe library and want to include an embedded `recipes.csv` file in your JAR, both the [Gradle](https://github.com/openrewrite/rewrite-build-gradle-plugin) and [Maven](https://github.com/openrewrite/rewrite-maven-plugin) build plugins provide goals to generate the CSV.
+If you maintain a recipe library and want to include an embedded `recipes.csv` file in your JAR, the [rewrite-build-gradle-plugin](https://github.com/openrewrite/rewrite-build-gradle-plugin) provides tasks to generate and validate the CSV.
 
 ### Generating the CSV
 
 To create or update your `recipes.csv` file, run:
 
-<Tabs groupId="build-tool">
-<TabItem value="gradle" label="Gradle">
-
 ```bash
 ./gradlew recipeCsvGenerate
 ```
 
-</TabItem>
-<TabItem value="maven" label="Maven">
-
-```bash
-./mvnw rewrite:recipeCsvGenerate
-```
-
-</TabItem>
-</Tabs>
-
 This scans your compiled recipe classes and resources and generates the CSV, preserving any manual customizations you've made (such as custom category assignments).
 
-### Automatic validation (Gradle only)
+:::note
+There is no equivalent goal in the [rewrite-maven-plugin](https://github.com/openrewrite/rewrite-maven-plugin). Recipe JARs built with Maven work without an embedded CSV file — the CLI falls back to [classpath scanning](#how-it-works) to discover their recipes.
+:::
+
+### Automatic validation
 
 Once a `recipes.csv` file exists, validation runs automatically as part of the standard Gradle `check` task. This means every build will verify that:
 
@@ -148,10 +136,6 @@ Once a `recipes.csv` file exists, validation runs automatically as part of the s
 If validation fails, the build will fail with detailed error messages.
 
 For more details, see the [Recipe Marketplace CSV Gradle Tasks ADR](https://github.com/openrewrite/rewrite-build-gradle-plugin/blob/main/adr/0001-recipe-marketplace-csv-gradle-tasks.md).
-
-:::note
-Automatic CSV validation is currently only available in the Gradle plugin. Maven users should manually verify that the generated CSV matches their JAR contents.
-:::
 
 ## Additional resources
 

--- a/docs/user-documentation/moderne-platform-v1/how-to-guides/categorize-recipes.md
+++ b/docs/user-documentation/moderne-platform-v1/how-to-guides/categorize-recipes.md
@@ -5,8 +5,6 @@ description: How to create your own recipe categories in the Moderne Platform.
 noIndex: true
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import VersionBanner from '@site/src/components/VersionBanner';
 
 <VersionBanner version="v1" linkPath="/user-documentation/moderne-platform/how-to-guides/categorize-recipes" />
@@ -53,24 +51,11 @@ For a real-world example, see the [category.yml from rewrite-spring](https://git
 
 ### Generating and validating the `recipes.csv` file
 
-Once the `category.yml` file is ready, you will need to generate the CSV file using the build plugin for your build tool:
-
-<Tabs groupId="build-tool">
-<TabItem value="gradle" label="Gradle">
+Once the `category.yml` file is ready, you will need to generate the CSV file using the [rewrite-build-gradle-plugin](https://github.com/openrewrite/rewrite-build-gradle-plugin):
 
 ```bash
 ./gradlew recipeCsvGenerate
 ```
-
-</TabItem>
-<TabItem value="maven" label="Maven">
-
-```bash
-./mvnw rewrite:recipeCsvGenerate
-```
-
-</TabItem>
-</Tabs>
 
 This will scan your compiled recipe classes and resources and generate a `recipes.csv` file with `category1`, `category2`, ... `categoryN` columns derived from your `category.yml` file. Any manual adjustments you've made to the CSV file beforehand will be retained.
 
@@ -78,12 +63,18 @@ This will scan your compiled recipe classes and resources and generate a `recipe
 CSV generation only scans your own project — recipes from dependencies are not included.
 :::
 
-For Gradle projects, validation will run automatically as part of `./gradlew check`. It will verify that the CSV file is synchronized with the JAR content and that formatting conventions are followed (e.g., display names should begin with a capital letter and descriptions should end with a period).
+:::note
+CSV generation is only available for Gradle projects. The [rewrite-maven-plugin](https://github.com/openrewrite/rewrite-maven-plugin) does not offer an equivalent goal.
+
+Maven recipe modules do not need an embedded `recipes.csv` file. When a JAR does not contain one, the categories from your `category.yml` file are picked up by scanning the classpath instead — this is slower to parse, but the resulting category hierarchy is the same.
+:::
+
+Validation will run automatically as part of `./gradlew check`. It will verify that the CSV file is synchronized with the JAR content and that formatting conventions are followed (e.g., display names should begin with a capital letter and descriptions should end with a period).
 
 If any recipes appear in the CSV file but do not exist in the JAR ("phantom recipes"), the build will fail.
 
 :::info
-For more details, see the [recipes.csv reference](../../moderne-cli/references/recipes-csv.md), which covers both [CSV generation](../../moderne-cli/references/recipes-csv.md#generating-the-csv) and [automatic validation](../../moderne-cli/references/recipes-csv.md#automatic-validation-gradle-only).
+For more details, see the [recipes.csv reference](../../moderne-cli/references/recipes-csv.md), which covers both [CSV generation](../../moderne-cli/references/recipes-csv.md#generating-the-csv) and [automatic validation](../../moderne-cli/references/recipes-csv.md#automatic-validation).
 :::
 
 Once validation passes, you can [publish and deploy the artifact to the Moderne Platform](#deploying-recipe-artifacts-to-the-moderne-platform).
@@ -126,7 +117,7 @@ dependencies {
 ### Creating the `recipes.csv` file manually
 
 :::warning
-You **cannot** use `./gradlew recipeCsvGenerate` or `./mvnw rewrite:recipeCsvGenerate` for the wrapper artifact. These only scan the project's own classes, and since your wrapper does not define any recipes of its own, they would generate an empty CSV file.
+You **cannot** use `./gradlew recipeCsvGenerate` for the wrapper artifact. It only scans the project's own classes, and since your wrapper does not define any recipes of its own, it would generate an empty CSV file.
 
 In addition, the Gradle build validation (`./gradlew check`) would reject any entry for a recipe from a dependency as a "phantom recipe".
 :::


### PR DESCRIPTION
- The docs told Maven users to run `./mvnw rewrite:recipeCsvGenerate`, but no such goal exists: it was added to rewrite-maven-plugin in openrewrite/rewrite-maven-plugin#1113 and reverted in openrewrite/rewrite-maven-plugin#1185, so `recipeCsvGenerate` is a Gradle-only task.

This drops the Maven tabs (and the now single-item `<Tabs>` wrappers) from the two "Managing recipe categories" pages and the CSV recipe marketplace reference, and adds a note explaining that Maven recipe modules do not need an embedded `recipes.csv` — without one, categories from `category.yml` are still picked up by classpath scanning.

The "Automatic validation (Gradle only)" heading is now just "Automatic validation", since the Maven caveat is covered above it; the two inbound anchor links were updated to match. Verified with `yarn build`.