### PR TITLE
feat(trial): try-in-app first-time-user interstitial (moderne-docs)

### DIFF
--- a/src/__mocks__/docusaurus/Translate.tsx
+++ b/src/__mocks__/docusaurus/Translate.tsx
@@ -7,3 +7,5 @@ export function translate({ message }: { message: string; id?: string; descripti
 export function Translate({ children }: { children: React.ReactNode }): JSX.Element {
   return <>{children}</>;
 }
+
+export default Translate;

--- a/src/__mocks__/docusaurus/useBaseUrl.ts
+++ b/src/__mocks__/docusaurus/useBaseUrl.ts
@@ -4,3 +4,9 @@
 export default function useBaseUrl(url: string): string {
   return url;
 }
+
+export function useBaseUrlUtils() {
+  return {
+    withBaseUrl: (url: string): string => url,
+  };
+}

--- a/src/components/TryInPlatformModal/TryInPlatformModal.module.css
+++ b/src/components/TryInPlatformModal/TryInPlatformModal.module.css
@@ -15,7 +15,7 @@
   z-index: 501;
   width: 420px;
   max-width: calc(100vw - var(--mor-space-8));
-  padding: var(--mor-space-32px);
+  padding: var(--mor-space-6) var(--mor-space-32px) var(--mor-space-32px);
   background-color: var(--mor-panel);
   border: 1px solid var(--mor-line);
   border-radius: var(--mor-radius-card);

--- a/src/components/TryInPlatformModal/TryInPlatformModal.module.css
+++ b/src/components/TryInPlatformModal/TryInPlatformModal.module.css
@@ -15,7 +15,7 @@
   z-index: 501;
   width: 420px;
   max-width: calc(100vw - var(--mor-space-8));
-  padding: var(--mor-space-6) var(--mor-space-32px) var(--mor-space-32px);
+  padding: var(--mor-space-5) var(--mor-space-6) var(--mor-space-6);
   background-color: var(--mor-panel);
   border: 1px solid var(--mor-line);
   border-radius: var(--mor-radius-card);

--- a/src/components/TryInPlatformModal/TryInPlatformModal.module.css
+++ b/src/components/TryInPlatformModal/TryInPlatformModal.module.css
@@ -46,28 +46,3 @@
   justify-content: flex-end;
   gap: var(--mor-space-2);
 }
-
-.primaryButton,
-.secondaryButton {
-  padding: var(--mor-space-2) var(--mor-space-4);
-  border-radius: var(--mor-radius-full);
-  font-size: var(--mor-font-size-base);
-  font-weight: var(--mor-font-weight-semibold);
-  cursor: pointer;
-}
-
-.primaryButton {
-  color: white;
-  background-color: var(--mor-link-deep);
-  border: none;
-}
-
-.secondaryButton {
-  color: var(--mor-text);
-  background-color: transparent;
-  border: 1px solid var(--mor-line);
-}
-
-html[data-theme='dark'] .primaryButton {
-  background-color: var(--mor-link);
-}

--- a/src/components/TryInPlatformModal/TryInPlatformModal.module.css
+++ b/src/components/TryInPlatformModal/TryInPlatformModal.module.css
@@ -1,0 +1,73 @@
+/* src/components/TryInPlatformModal/TryInPlatformModal.module.css */
+
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 500;
+  background: rgba(0, 0, 0, 0.4);
+}
+
+.modal {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 501;
+  width: 420px;
+  max-width: calc(100vw - var(--mor-space-8));
+  padding: var(--mor-space-32px);
+  background-color: var(--mor-panel);
+  border: 1px solid var(--mor-line);
+  border-radius: var(--mor-radius-card);
+  box-shadow: var(--mor-shadow-dropdown);
+}
+
+.title {
+  font-size: var(--mor-font-size-doc-h1);
+  font-weight: var(--mor-font-weight-semibold);
+  color: var(--mor-text);
+  margin: 0 0 var(--mor-space-4) 0;
+}
+
+.steps {
+  margin: 0 0 var(--mor-space-6) 0;
+  padding-left: var(--mor-space-4);
+  color: var(--mor-text);
+  font-size: var(--mor-font-size-base);
+  line-height: 1.65;
+}
+
+.steps li {
+  margin-bottom: var(--mor-space-2);
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--mor-space-2);
+}
+
+.primaryButton,
+.secondaryButton {
+  padding: var(--mor-space-2) var(--mor-space-4);
+  border-radius: var(--mor-radius-full);
+  font-size: var(--mor-font-size-base);
+  font-weight: var(--mor-font-weight-semibold);
+  cursor: pointer;
+}
+
+.primaryButton {
+  color: white;
+  background-color: var(--mor-link-deep);
+  border: none;
+}
+
+.secondaryButton {
+  color: var(--mor-text);
+  background-color: transparent;
+  border: 1px solid var(--mor-line);
+}
+
+html[data-theme='dark'] .primaryButton {
+  background-color: var(--mor-link);
+}

--- a/src/components/TryInPlatformModal/TryInPlatformModal.stories.tsx
+++ b/src/components/TryInPlatformModal/TryInPlatformModal.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { TryInPlatformModal } from './TryInPlatformModal';
+
+const meta: Meta<typeof TryInPlatformModal> = {
+  title: 'Components/TryInPlatformModal',
+  component: TryInPlatformModal,
+};
+export default meta;
+
+type Story = StoryObj<typeof TryInPlatformModal>;
+
+export const Open: Story = {
+  render: () => {
+    const [isOpen, setIsOpen] = useState(true);
+    return (
+      <TryInPlatformModal
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        onConfirm={() => setIsOpen(false)}
+        recipeName="Upgrade to Java 21"
+      />
+    );
+  },
+};

--- a/src/components/TryInPlatformModal/TryInPlatformModal.tsx
+++ b/src/components/TryInPlatformModal/TryInPlatformModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback, type FunctionComponent } from 'react';
+import React, { useEffect, useCallback, useRef, type FunctionComponent } from 'react';
 import { ModButton } from '@site/src/components/ModButton';
 import styles from './TryInPlatformModal.module.css';
 
@@ -15,6 +15,9 @@ const TryInPlatformModal: FunctionComponent<TryInPlatformModalProps> = ({
   onConfirm,
   recipeName,
 }) => {
+  const modalRef = useRef<HTMLDivElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
   const handleEscapeKey = useCallback(
     (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
@@ -32,12 +35,23 @@ const TryInPlatformModal: FunctionComponent<TryInPlatformModalProps> = ({
     };
   }, [isOpen, handleEscapeKey]);
 
+  useEffect(() => {
+    if (!isOpen) return undefined;
+    previousFocusRef.current = document.activeElement as HTMLElement | null;
+    modalRef.current?.focus();
+    return () => {
+      previousFocusRef.current?.focus();
+    };
+  }, [isOpen]);
+
   if (!isOpen) return null;
 
   return (
     <>
       <div className={styles.overlay} onClick={onClose} />
       <div
+        ref={modalRef}
+        tabIndex={-1}
         className={styles.modal}
         role="dialog"
         aria-modal="true"

--- a/src/components/TryInPlatformModal/TryInPlatformModal.tsx
+++ b/src/components/TryInPlatformModal/TryInPlatformModal.tsx
@@ -1,0 +1,71 @@
+import React, { useEffect, useCallback, type FunctionComponent } from 'react';
+import styles from './TryInPlatformModal.module.css';
+
+export type TryInPlatformModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  recipeName: string;
+};
+
+const TryInPlatformModal: FunctionComponent<TryInPlatformModalProps> = ({
+  isOpen,
+  onClose,
+  onConfirm,
+  recipeName,
+}) => {
+  const handleEscapeKey = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    },
+    [onClose],
+  );
+
+  useEffect(() => {
+    if (!isOpen) return undefined;
+    document.addEventListener('keydown', handleEscapeKey);
+    return () => {
+      document.removeEventListener('keydown', handleEscapeKey);
+    };
+  }, [isOpen, handleEscapeKey]);
+
+  if (!isOpen) return null;
+
+  return (
+    <>
+      <div className={styles.overlay} onClick={onClose} />
+      <div
+        className={styles.modal}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="try-in-platform-title"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 id="try-in-platform-title" className={styles.title}>
+          Here&apos;s what happens next
+        </h2>
+        <ol className={styles.steps}>
+          <li>Sign in to Moderne (GitHub, Bitbucket, or GitLab)</li>
+          <li>
+            Run <strong>{recipeName}</strong> on a curated sample repository
+          </li>
+          <li>Explore the results with a quick guided tour</li>
+        </ol>
+        <div className={styles.actions}>
+          <button type="button" className={styles.secondaryButton} onClick={onClose}>
+            Not now
+          </button>
+          <button type="button" className={styles.primaryButton} onClick={onConfirm}>
+            Continue to sign in
+          </button>
+        </div>
+      </div>
+    </>
+  );
+};
+
+TryInPlatformModal.displayName = 'TryInPlatformModal';
+
+export { TryInPlatformModal };

--- a/src/components/TryInPlatformModal/TryInPlatformModal.tsx
+++ b/src/components/TryInPlatformModal/TryInPlatformModal.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useCallback, type FunctionComponent } from 'react';
+import { ModButton } from '@site/src/components/ModButton';
 import styles from './TryInPlatformModal.module.css';
 
 export type TryInPlatformModalProps = {
@@ -54,12 +55,12 @@ const TryInPlatformModal: FunctionComponent<TryInPlatformModalProps> = ({
           <li>Explore the results with a quick guided tour</li>
         </ol>
         <div className={styles.actions}>
-          <button type="button" className={styles.secondaryButton} onClick={onClose}>
+          <ModButton variant="secondary" onClick={onClose}>
             Not now
-          </button>
-          <button type="button" className={styles.primaryButton} onClick={onConfirm}>
+          </ModButton>
+          <ModButton variant="primary" onClick={onConfirm}>
             Continue to sign in
-          </button>
+          </ModButton>
         </div>
       </div>
     </>

--- a/src/components/TryInPlatformModal/TryInPlatformModal.tsx
+++ b/src/components/TryInPlatformModal/TryInPlatformModal.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useCallback, useRef, type FunctionComponent } from 'react';
+import { createPortal } from 'react-dom';
 import { ModButton } from '@site/src/components/ModButton';
 import styles from './TryInPlatformModal.module.css';
 
@@ -46,7 +47,7 @@ const TryInPlatformModal: FunctionComponent<TryInPlatformModalProps> = ({
 
   if (!isOpen) return null;
 
-  return (
+  return createPortal(
     <>
       <div className={styles.overlay} onClick={onClose} />
       <div
@@ -77,7 +78,8 @@ const TryInPlatformModal: FunctionComponent<TryInPlatformModalProps> = ({
           </ModButton>
         </div>
       </div>
-    </>
+    </>,
+    document.body,
   );
 };
 

--- a/src/components/TryInPlatformModal/index.ts
+++ b/src/components/TryInPlatformModal/index.ts
@@ -1,0 +1,2 @@
+export { TryInPlatformModal } from './TryInPlatformModal';
+export type { TryInPlatformModalProps } from './TryInPlatformModal';

--- a/src/components/recipe/RecipeHeader/RecipeHeader.tsx
+++ b/src/components/recipe/RecipeHeader/RecipeHeader.tsx
@@ -1,7 +1,10 @@
-import React, { isValidElement, type FunctionComponent, type ReactElement, type ReactNode } from 'react';
+import React, { isValidElement, useState, type FunctionComponent, type ReactElement, type ReactNode } from 'react';
 import clsx from 'clsx';
 import { ArrowRight } from 'lucide-react';
 import { ModButton } from '@site/src/components/ModButton';
+import { TryInPlatformModal } from '@site/src/components/TryInPlatformModal';
+import { DEFAULT_ORG_ID_B64 } from '@site/src/constants';
+import { hasTrySeenCookie } from '@site/src/helpers/cookie.helper';
 import { CopyButton } from '../CopyButton';
 import { AccessInfoButton } from '../AccessInfoButton';
 import { renderWithCode } from '../shared/renderWithCode';
@@ -60,6 +63,23 @@ const RecipeHeaderRoot: FunctionComponent<RecipeHeaderProps> = ({
   const descriptionSlot = slotChildren(children, Description);
   const title = titleSlot ?? (displayName != null ? renderWithCode(displayName, styles.titleCode) : null);
   const summary = descriptionSlot ?? (description != null ? renderWithCode(description, styles.descCode) : null);
+
+  const [isTryModalOpen, setIsTryModalOpen] = useState(false);
+  const trialAppLink = `${appLink}?organizationId=${DEFAULT_ORG_ID_B64}&trial=1`;
+
+  const handleTryClick = (
+    event: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>
+  ): void => {
+    if (hasTrySeenCookie()) {
+      return;
+    }
+    event.preventDefault();
+    setIsTryModalOpen(true);
+  };
+
+  const handleConfirmTry = (): void => {
+    window.location.href = trialAppLink;
+  };
 
   return (
   <header className={styles.header}>
@@ -129,11 +149,10 @@ const RecipeHeaderRoot: FunctionComponent<RecipeHeaderProps> = ({
           <ModButton
             variant="primary"
             size="small"
-            href={appLink}
-            target="_blank"
-            rel="noopener noreferrer"
+            href={trialAppLink}
             icon={<ArrowRight size={14} />}
             iconPosition="right"
+            onClick={handleTryClick}
           >
             Try in Platform
           </ModButton>
@@ -142,6 +161,12 @@ const RecipeHeaderRoot: FunctionComponent<RecipeHeaderProps> = ({
             environment, with nothing to install or configure.
           </span>
         </span>
+        <TryInPlatformModal
+          isOpen={isTryModalOpen}
+          onClose={() => setIsTryModalOpen(false)}
+          onConfirm={handleConfirmTry}
+          recipeName={typeof title === 'string' ? title : fqName}
+        />
       </div>
     </div>
   </header>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,13 @@
+/**
+ * Base64-encoded id of the `Default` organization — the curated sample-repo
+ * org first-time trial runs target. Must stay in sync with moderne-ui's
+ * DEFAULT_ORG_ID (helpers/organizations.helper.ts); moderne-ui's
+ * useOrganizationFromUrl hook decodes this value with the same base64
+ * encoding this was produced with.
+ *
+ * NOTE: this is currently the DEV-tenant value (raw id 'ALL/Default',
+ * resolved against api.dev.moderne.io) — no production credential was
+ * available when this was set. It MUST be re-verified against
+ * api.app.moderne.io before this feature ships to production.
+ */
+export const DEFAULT_ORG_ID_B64 = 'QUxML0RlZmF1bHQ=';

--- a/src/helpers/cookie.helper.test.ts
+++ b/src/helpers/cookie.helper.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { hasTrySeenCookie } from './cookie.helper';
+
+const clearCookie = () => {
+  document.cookie = 'moderne_try_seen=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/';
+};
+
+describe('hasTrySeenCookie', () => {
+  afterEach(clearCookie);
+
+  it('returns false when the cookie is not set', () => {
+    expect(hasTrySeenCookie()).toBe(false);
+  });
+
+  it('returns true when the cookie is set', () => {
+    document.cookie = 'moderne_try_seen=1; path=/';
+    expect(hasTrySeenCookie()).toBe(true);
+  });
+
+  it('does not match a cookie whose name is a superstring of this one', () => {
+    document.cookie = 'moderne_try_seen_extra=1; path=/';
+    expect(hasTrySeenCookie()).toBe(false);
+  });
+});

--- a/src/helpers/cookie.helper.ts
+++ b/src/helpers/cookie.helper.ts
@@ -1,0 +1,16 @@
+const TRY_SEEN_COOKIE = 'moderne_try_seen';
+
+/**
+ * Whether this browser has already landed in-app via a trial link once
+ * before — set by moderne-ui as a Domain=.moderne.io cookie the first time a
+ * ?trial=1 landing succeeds, so it's readable here without any network call.
+ */
+export const hasTrySeenCookie = (): boolean => {
+  if (typeof document === 'undefined') {
+    return false;
+  }
+  return document.cookie
+    .split(';')
+    .map((entry) => entry.trim())
+    .some((entry) => entry.startsWith(`${TRY_SEEN_COOKIE}=`));
+};


### PR DESCRIPTION
## Summary
- Implements the moderne-docs half of the "try in app" first-time-user trial flow (design-system#610), pairing with moderne-ui PR #8817.
- Adds a `TryInPlatformModal` interstitial to the existing "Try in Platform" button on recipe pages, shown once per browser (`moderne_try_seen` cookie) before continuing to sign-in. Appends `?organizationId=<Default org>&trial=1` to the deep link so moderne-ui recognizes the trial landing and starts its guided tour.
- Behavior change worth flagging: the button now navigates in the same tab (dropped `target="_blank"`) since this is a continuous guided journey the user follows through, not a background tab.

## Known pre-merge item
`DEFAULT_ORG_ID_B64` (`src/constants.ts`) currently decodes to a **dev-tenant** org id (`ALL/Default`, resolved against `api.dev.moderne.io` — no production credential was available in this environment). This must be re-verified against `api.app.moderne.io` before this ships to production, alongside the matching constant in the moderne-ui PR. Flagged inline with a comment.

## Test plan
- [x] Scoped `tsc` checks clean on every touched file (a full-repo `tsc` run is separately known to be flaky/load-dependent on this machine, unrelated to this change — confirmed via repeated isolated runs)
- [x] `vitest run`: 407/415 passing; the 8 failures are all the same single pre-existing, unrelated test (`filterUtils.test.ts`) duplicated across other worktrees in this repo — confirmed untouched by any commit in this branch
- [x] Task-by-task review (4 tasks, 1 fix round) + final whole-branch review, both clean after fixes
- [x] Manual browser walkthrough (chrome-devtools MCP against a live dev server): cookie-absent click opens modal with correct recipe name, "Not now" closes without navigating, cookie-set click and "Continue to sign in" both navigate through with the trial query params intact
- [ ] Resolve/verify `DEFAULT_ORG_ID_B64` against production before this ships live