### PR TITLE
Add local cursor rules to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ docs/plans/
 storybook-static
 .env
 .env*.local
+
+.cursor/rules/*.local.mdc


### PR DESCRIPTION
This is a demo of a change campaign to add a gitignore entry ignoring local cursor rules so they are not accidently committed

Use this link to re-run the recipe: https://dev.moderne.io/recipes/org.openrewrite.AddToGitignore?organizationId=QUxML01vZGVybmU%3D#defaults=W3sibmFtZSI6ImVudHJpZXMiLCJ2YWx1ZSI6Ii5jdXJzb3IvcnVsZXMvKi5sb2NhbC5tZGMifSx7Im5hbWUiOiJmaWxlUGF0dGVybiIsInZhbHVlIjoiLmdpdGlnbm9yZSJ9XQ==